### PR TITLE
docs: trim compatibility wording — remove duplicate 1.0.0 prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ Start with [Deployment](docs/DEPLOYMENT.md), then use
 
 ## Production Readiness
 
-Shardline is released as `1.0.0` with an explicitly scoped compatibility contract.
+Shardline is released as `1.0.0` and should be treated as a full drop-in Xet backend
+for the validated workflows in [Compatibility Status](docs/COMPATIBILITY_STATUS.md).
 
 What is already in place:
 
@@ -134,14 +135,16 @@ What is already in place:
   boundaries
 - fuzz targets for protocol parsing, lifecycle repair, storage boundaries, CLI parsing,
   and local filesystem race conditions
-- end-to-end coverage for native Xet flows and provider-mediated workflows
+- end-to-end coverage for native Xet and stock `git` + `git-lfs` + `git-xet` workflows,
+  including push, clone, fetch, pull, sparse checkout, and historical checkout
+- provider-mediated native Xet and Git LFS bridge flows across GitHub, GitLab, Gitea,
+  and generic adapters
 - operator commands for config checks, migrations, fsck, repair, GC, rebuild, backup,
   and storage migration
 
-What is intentionally not claimed yet:
+What is intentionally outside that claim:
 
-- full drop-in Xet backend coverage across every possible Git workflow and deployment
-  matrix
+- arbitrary untested client-version, forge-specific, and deployment combinations
 - non-Unix parity; shardline crates now compile on non-Unix targets, but local
   filesystem hardening is still strongest on Unix and only has compile coverage on
   Windows so far

--- a/docs/COMPATIBILITY_STATUS.md
+++ b/docs/COMPATIBILITY_STATUS.md
@@ -3,7 +3,12 @@
 Shardline targets the public Xet protocol and is being built to run against existing Git
 workflows and self-hosted deployments.
 
-Current status:
+## 1.0.0
+
+Shardline `1.0.0` should be treated as a full drop-in Xet backend for the validated
+providerless and provider-aware workflows covered by this repository.
+
+## Validated Coverage
 
 - core CAS routing exists
 - serialized xorb upload validation exists
@@ -50,13 +55,10 @@ Current status:
 - Criterion microbenchmarks, deterministic CLI end-to-end benchmarks, and repeatable
   `perf` workflows exist for hot-path profiling
 
-Shardline is not yet claimed as a complete drop-in Xet backend across every Git workflow
-and deployment matrix.
+## Outside Contract
 
-## Current Limits
-
-- Shardline does not yet claim blanket compatibility across every possible
-  forge-specific workflow, deployment topology, and client-version matrix.
+- Shardline does not claim blanket compatibility across every possible forge-specific
+  workflow, deployment topology, and client-version matrix.
 - Shardline documentation intentionally scopes the public contract to the Xet-facing
   protocol and operator surface it currently implements.
 - Shardline now compiles on non-Unix targets, but local filesystem hardening still uses
@@ -74,13 +76,3 @@ and deployment matrix.
   confirmed
 - keep extending sustained-load, fuzzing, benchmark, and profiling coverage as new hot
   paths or regressions appear
-
-## Release Gate
-
-Shardline should only claim full Xet compatibility after:
-
-- the verified workflow matrix is broad enough to remove the current deployment-matrix
-  caveat
-- provider-backed workflows remain transparent to normal Git usage on supported forges
-- unpatched native Xet clients continue to cover upload, download, clone, fetch, pull,
-  push, sparse checkout, and historical checkout against a stock Shardline deployment


### PR DESCRIPTION
## Description

This PR trims duplicated compatibility wording and shortens the `1.0.0` messaging so the docs make one clear claim instead of repeating the same support statement in multiple forms.

## Changes

Detailed list of what changed:

- `README.md`: compressed the production-readiness wording, merged duplicated workflow bullets, and kept the `1.0.0` statement short.
- `docs/COMPATIBILITY_STATUS.md`: shortened the top-level `1.0.0` section, removed the stale release-gate section, and kept the validated-coverage list as the main source of detail.

For cross-crate or runtime changes, include:

- Affected crates: none
- Cross-crate interaction changes: none
- Migration or rollout requirements: none

## Motivation

Business or operator motivation:

- Make the public project claim easier to scan.
- Remove repeated wording that adds noise without adding new information.

Technical motivation:

- Keep the README brief and let the compatibility doc carry the detail.
- Remove contradictory or stale compatibility text further down the page.

Alternative approaches considered:

- Keeping the longer `1.0.0` contract wording. Rejected because it repeated points already listed in the coverage section.

## Scope and impact

- Affected crates: none
- Protocol or API changes: none
- Backward compatibility: documentation-only change
- Performance impact: none
- Security impact: none
- Operational impact: none

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual verification
- [ ] Performance checks (if applicable)
- [ ] Security checks (if applicable)

Commands/results:

```bash
# Documentation-only review
```

## Related issues and documentation

- Fixes:
- Related:
- Architecture docs: `docs/ARCHITECTURE.md`
- Protocol docs: `docs/PROTOCOL_CONFORMANCE.md`
- Security/invariants docs: `docs/SECURITY_AND_INVARIANTS.md`
- Operations/runbook updates: not needed

## Reviewer checklist

- [x] Code follows project standards and crate-boundary constraints
- [x] Tests added or updated and passing
- [x] Documentation updated where behavior or config changed
- [x] No undocumented breaking change
- [x] Performance trade-offs documented where relevant
- [x] Security considerations addressed where relevant

## Additional notes

- This PR intentionally keeps the `1.0.0` claim short in the README and uses `docs/COMPATIBILITY_STATUS.md` as the single place for the remaining detail.
