### PR TITLE
feat: add CAS protocol frontends and hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2946,7 +2946,6 @@ dependencies = [
  "sha2",
  "subtle",
  "thiserror 2.0.18",
- "xet-core-structures",
  "zeroize",
 ]
 
@@ -2961,6 +2960,7 @@ dependencies = [
  "bytes",
  "criterion",
  "futures-util",
+ "getrandom 0.3.4",
  "hex",
  "hmac",
  "libc",
@@ -2997,8 +2997,10 @@ dependencies = [
  "blake3",
  "bytes",
  "futures-util",
+ "hex",
  "libc",
  "object_store",
+ "sha2",
  "shardline-protocol",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ clap_complete = "4.5.59"
 clap_mangen = "0.2.31"
 criterion = { version = "0.5.1", default-features = false }
 futures-util = "0.3"
+getrandom = "0.3"
 hex = "0.4"
 hmac = "0.12"
 libc = "0.2.177"

--- a/README.md
+++ b/README.md
@@ -7,18 +7,19 @@
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-green)](#license)
 
 Shardline is an open, self-hostable content-addressed storage backend with
-Xet-compatible protocol support.
+pluggable protocol frontends.
 
 It accepts immutable object uploads, verifies protocol objects, plans
 reconstructions, and serves range-aware downloads. You can run it directly as a
-providerless Xet backend or pair it with GitHub, GitLab, Gitea, or a generic Git
+providerless CAS backend or pair it with GitHub, GitLab, Gitea, or a generic Git
 provider without baking provider-specific behavior into the CAS core.
 
-The default implemented frontend is the Xet protocol.
+Validated frontends in this repository today are Xet, Git LFS, Bazel HTTP remote
+cache, and OCI Distribution.
 `shardline serve` now accepts an explicit frontend set through `--frontend` or
 `SHARDLINE_SERVER_FRONTENDS`, with `xet` enabled by default.
-The core storage, indexing, and reconstruction boundaries stay separate from Xet-specific
-protocol handling so future frontends can be added without rewriting the engine.
+The core storage, indexing, and reconstruction boundaries stay separate from
+frontend-specific protocol handling.
 
 For small deployments, `shardline serve` runs the control plane and transfer plane in
 one process. Larger deployments can split the same binary into `api` and `transfer`
@@ -27,7 +28,7 @@ protocol surface.
 
 ## Why Shardline
 
-- self-hostable CAS backend with Xet-compatible protocol support
+- self-hostable CAS backend with explicit protocol frontends
 - production-oriented operator surface: health checks, migrations, fsck, repair, backup,
   storage migration, retention holds, and garbage collection
 - storage and metadata adapters kept behind explicit boundaries
@@ -47,7 +48,7 @@ Start here:
 - [CLI](docs/CLI.md)
 - [Database Migrations](docs/DATABASE_MIGRATIONS.md)
 
-For a direct, providerless Xet-compatible backend:
+For the current providerless Xet-compatible backend:
 
 - deploy the local SQLite + filesystem profile or Postgres + S3 profile
 - from a source checkout, run `shardline serve`; it bootstraps `.shardline/`
@@ -72,7 +73,7 @@ flowchart TD
     Client[Client]
     Provider[Optional Git provider]
     Router[Frontend router]
-    Frontends["<b>Frontend set</b><br/>Xet frontend<br/>Future frontends"]
+    Frontends["<b>Frontend set</b><br/>Xet<br/>Git LFS<br/>Bazel HTTP cache<br/>OCI Distribution"]
     Core["<b>Shared server core</b><br/>Auth and scope checks<br/>CAS coordinator<br/>Reconstruction planner<br/>GC and operator flows"]
     Adapters["<b>Adapters</b><br/>Index and record store<br/>Object store<br/>Reconstruction cache<br/>VCS and provider adapters"]
   end
@@ -139,7 +140,7 @@ flowchart TD
 All three profiles can run providerless.
 Provider integration is optional and only needed when a forge or bridge service must
 mint scoped CAS tokens on behalf of users.
-The exact validated local providerless steps are in
+The exact validated local providerless Xet steps are in
 [Providerless Direct Xet Backend](docs/DEPLOYMENT.md#providerless-direct-xet-backend).
 
 Start with [Deployment](docs/DEPLOYMENT.md), then use
@@ -147,8 +148,8 @@ Start with [Deployment](docs/DEPLOYMENT.md), then use
 
 ## Production Readiness
 
-Shardline is released as `1.0.0` for the validated Xet workflows and operator surface
-documented in this repo. Before a production rollout, read:
+Shardline is released as `1.0.0` for the protocol and operator surface documented in
+this repo. Before a production rollout, read:
 
 - [Deployment](docs/DEPLOYMENT.md)
 - [Operations](docs/OPERATIONS.md)
@@ -159,7 +160,7 @@ documented in this repo. Before a production rollout, read:
 
 | Crate | Purpose |
 | --- | --- |
-| `protocol` | Xet protocol types, hash parsing, byte-range handling, and token types |
+| `protocol` | Shared protocol-facing types, hash and byte-range parsing, scoped token types, and small security/time/text helpers |
 | `cache` | Reconstruction-cache traits and adapters |
 | `storage` | Immutable object-storage contracts and adapters |
 | `index` | Reconstruction and deduplication metadata contracts and adapters |
@@ -177,6 +178,7 @@ documented in this repo. Before a production rollout, read:
 - [Client Configuration](docs/CLIENT_CONFIGURATION.md)
 - [Contributing](CONTRIBUTING.md)
 - [CLI](docs/CLI.md)
+- [Protocol Frontends](docs/PROTOCOLS.md)
 - [Protocol Conformance](docs/PROTOCOL_CONFORMANCE.md)
 - [Compatibility Status](docs/COMPATIBILITY_STATUS.md)
 - [Performance](docs/PERFORMANCE.md)

--- a/crates/cas/tests/coordinator_contract.rs
+++ b/crates/cas/tests/coordinator_contract.rs
@@ -8,7 +8,7 @@ use shardline_cas::{CasCoordinator, CasLimits};
 use shardline_index::{
     DedupeShardMapping, FileId, FileReconstruction, IndexStore, LocalIndexStore,
     ProviderRepositoryState, QuarantineCandidate, ReconstructionTerm, RetentionHold,
-    StoredObjectId, WebhookDelivery,
+    StoredObjectId, WebhookDelivery, xet_hash_hex_string,
 };
 use shardline_protocol::{ByteRange, ChunkRange, RepositoryProvider, ShardlineHash};
 use shardline_storage::{
@@ -167,9 +167,7 @@ impl IndexStore for MemoryIndexStore {
             .copied()
             .collect::<Vec<_>>();
         file_ids.sort_by(|left, right| {
-            left.hash()
-                .api_hex_string()
-                .cmp(&right.hash().api_hex_string())
+            xet_hash_hex_string(left.hash()).cmp(&xet_hash_hex_string(right.hash()))
         });
         Ok(file_ids)
     }
@@ -197,9 +195,7 @@ impl IndexStore for MemoryIndexStore {
             .cloned()
             .collect::<Vec<_>>();
         mappings.sort_by(|left, right| {
-            left.chunk_hash()
-                .api_hex_string()
-                .cmp(&right.chunk_hash().api_hex_string())
+            xet_hash_hex_string(left.chunk_hash()).cmp(&xet_hash_hex_string(right.chunk_hash()))
         });
         Ok(mappings)
     }

--- a/crates/cli/src/command.rs
+++ b/crates/cli/src/command.rs
@@ -456,8 +456,8 @@ pub enum BenchMode {
 #[derive(Debug, Parser)]
 #[command(
     name = "shardline",
-    about = "Native Xet-compatible asset coordinator and operations CLI.",
-    long_about = "Shardline serves native Xet traffic, provider integration, storage maintenance, and operational workflows from one CLI.\n\nUse `shardline help <command>` to inspect a command in detail.",
+    about = "Content-addressed storage server and operations CLI.",
+    long_about = "Shardline serves CAS protocol frontends, provider integration, storage maintenance, and operational workflows from one CLI.\n\nThe current frontend set in this repository is Xet, Git LFS, Bazel HTTP remote cache, and OCI Distribution.\n\nUse `shardline help <command>` to inspect a command in detail.",
     after_help = CLI_AFTER_LONG_HELP,
     arg_required_else_help = true,
     next_line_help = true
@@ -1028,8 +1028,15 @@ enum CliServerRole {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 enum CliServerFrontend {
-    /// Serve the Xet-compatible CAS frontend.
+    /// Serve the validated Xet-compatible CAS frontend.
     Xet,
+    /// Serve the Git LFS batch and object-transfer frontend.
+    Lfs,
+    /// Serve the Bazel-compatible HTTP remote-cache frontend.
+    #[value(name = "bazel-http")]
+    BazelHttp,
+    /// Serve the OCI Distribution frontend.
+    Oci,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -1335,6 +1342,9 @@ impl From<CliServerFrontend> for ServerFrontend {
     fn from(value: CliServerFrontend) -> Self {
         match value {
             CliServerFrontend::Xet => Self::Xet,
+            CliServerFrontend::Lfs => Self::Lfs,
+            CliServerFrontend::BazelHttp => Self::BazelHttp,
+            CliServerFrontend::Oci => Self::Oci,
         }
     }
 }
@@ -1546,6 +1556,28 @@ mod tests {
             Ok(CliCommand::Serve {
                 role: None,
                 frontends: Some(vec![ServerFrontend::Xet]),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_serve_with_multiple_frontends() {
+        let args = vec![
+            "shardline".to_owned(),
+            "serve".to_owned(),
+            "--frontend".to_owned(),
+            "lfs,bazel-http,oci".to_owned(),
+        ];
+
+        assert_eq!(
+            CliCommand::parse(args),
+            Ok(CliCommand::Serve {
+                role: None,
+                frontends: Some(vec![
+                    ServerFrontend::Lfs,
+                    ServerFrontend::BazelHttp,
+                    ServerFrontend::Oci,
+                ]),
             })
         );
     }

--- a/crates/fuzz/Cargo.toml
+++ b/crates/fuzz/Cargo.toml
@@ -91,5 +91,29 @@ path = "fuzz_targets/shardline/local_filesystem_races.rs"
 test = false
 doc = false
 
+[[bin]]
+name = "shardline_protocol_frontends"
+path = "fuzz_targets/shardline/protocol_frontends.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "shardline_protocol_lfs"
+path = "fuzz_targets/shardline/protocol_lfs.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "shardline_protocol_bazel_http"
+path = "fuzz_targets/shardline/protocol_bazel_http.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "shardline_protocol_oci"
+path = "fuzz_targets/shardline/protocol_oci.rs"
+test = false
+doc = false
+
 [lints]
 workspace = true

--- a/crates/fuzz/fuzz_targets/shardline/local_filesystem_races.rs
+++ b/crates/fuzz/fuzz_targets/shardline/local_filesystem_races.rs
@@ -13,6 +13,7 @@ use std::{
 
 use libfuzzer_sys::fuzz_target;
 use shardline::write_output_bytes;
+use shardline_index::xet_hash_hex_string;
 use shardline_protocol::ShardlineHash;
 use shardline_storage::{LocalObjectStore, ObjectBody, ObjectIntegrity, ObjectKey, ObjectStore};
 
@@ -71,7 +72,7 @@ fn exercise_local_object_write(body: &[u8]) {
         return;
     };
     let hash = ShardlineHash::from_bytes(*blake3::hash(body).as_bytes());
-    let key_text = format!("aa/{}", hash.api_hex_string());
+    let key_text = format!("aa/{}", xet_hash_hex_string(hash));
     let key = ObjectKey::parse(&key_text);
     assert!(key.is_ok());
     let Ok(key) = key else {
@@ -88,7 +89,7 @@ fn exercise_local_object_write(body: &[u8]) {
     stop.store(true, Ordering::SeqCst);
     let _joined = mutator.join();
 
-    assert_no_escape(outside.path(), hash.api_hex_string().as_str());
+    assert_no_escape(outside.path(), xet_hash_hex_string(hash).as_str());
     if put_result.is_ok() {
         assert_file_is_either_absent_or_expected(store.path_for_key(&key).as_path(), body);
     }

--- a/crates/fuzz/fuzz_targets/shardline/protocol_bazel_http.rs
+++ b/crates/fuzz/fuzz_targets/shardline/protocol_bazel_http.rs
@@ -1,0 +1,23 @@
+#![no_main]
+
+use std::str::from_utf8;
+
+use libfuzzer_sys::fuzz_target;
+use shardline_server::fuzz_bazel_http_frontend_summary;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(hash_hex) = from_utf8(data) else {
+        return;
+    };
+
+    let Ok(summary) = fuzz_bazel_http_frontend_summary(hash_hex) else {
+        return;
+    };
+
+    if summary.ac_accepts || summary.cas_accepts {
+        assert!(summary.ac_accepts);
+        assert!(summary.cas_accepts);
+        assert_eq!(hash_hex.len(), 64);
+        assert!(hash_hex.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    }
+});

--- a/crates/fuzz/fuzz_targets/shardline/protocol_frontends.rs
+++ b/crates/fuzz/fuzz_targets/shardline/protocol_frontends.rs
@@ -1,0 +1,38 @@
+#![no_main]
+
+use std::str::from_utf8;
+
+use libfuzzer_sys::fuzz_target;
+use shardline_server::fuzz_protocol_frontend_summary;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(raw) = from_utf8(data) else {
+        return;
+    };
+
+    let mut parts = raw.split('\0');
+    let frontend = parts.next().unwrap_or_default();
+    let oid = parts.next().unwrap_or_default();
+    let digest = parts.next().unwrap_or_default();
+    let repository = parts.next().unwrap_or_default();
+    let reference = parts.next().unwrap_or_default();
+
+    let summary = fuzz_protocol_frontend_summary(frontend, oid, digest, repository, reference);
+    let Ok(summary) = summary else {
+        return;
+    };
+
+    if summary.oci_blob_accepts || summary.oci_manifest_accepts {
+        assert!(summary.digest_accepts);
+        assert!(summary.oci_repository_accepts);
+    }
+
+    if summary.lfs_accepts || summary.bazel_accepts {
+        assert_eq!(oid.len(), 64);
+        assert!(oid.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    }
+
+    if summary.frontend_accepts {
+        assert!(matches!(frontend, "xet" | "lfs" | "bazel-http" | "oci"));
+    }
+});

--- a/crates/fuzz/fuzz_targets/shardline/protocol_hash.rs
+++ b/crates/fuzz/fuzz_targets/shardline/protocol_hash.rs
@@ -8,14 +8,13 @@ use shardline_protocol::ShardlineHash;
 fuzz_target!(|data: &[u8]| {
     if let Ok(bytes) = <[u8; 32]>::try_from(data) {
         let hash = ShardlineHash::from_bytes(bytes);
-        let api_hex = hash.api_hex_string();
-        assert_eq!(api_hex.len(), 64);
+        let hex = hash.hex_string();
+        assert_eq!(hex.len(), 64);
         assert!(
-            api_hex
-                .bytes()
+            hex.bytes()
                 .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
         );
-        assert_eq!(ShardlineHash::parse_api_hex(&api_hex), Ok(hash));
+        assert_eq!(ShardlineHash::parse_hex(&hex), Ok(hash));
     }
 
     let Ok(raw) = from_utf8(data) else {
@@ -23,14 +22,14 @@ fuzz_target!(|data: &[u8]| {
     };
 
     // INVARIANT 1: Hash parsing is deterministic.
-    let first = ShardlineHash::parse_api_hex(raw);
-    let second = ShardlineHash::parse_api_hex(raw);
+    let first = ShardlineHash::parse_hex(raw);
+    let second = ShardlineHash::parse_hex(raw);
     assert_eq!(first, second);
 
-    // INVARIANT 2: Any accepted API hash emits canonical lowercase API hex.
+    // INVARIANT 2: Any accepted hash emits canonical lowercase hex.
     if let Ok(hash) = first {
-        let api_hex = hash.api_hex_string();
-        assert_eq!(api_hex, raw);
-        assert_eq!(ShardlineHash::parse_api_hex(&api_hex), Ok(hash));
+        let hex = hash.hex_string();
+        assert_eq!(hex, raw);
+        assert_eq!(ShardlineHash::parse_hex(&hex), Ok(hash));
     }
 });

--- a/crates/fuzz/fuzz_targets/shardline/protocol_lfs.rs
+++ b/crates/fuzz/fuzz_targets/shardline/protocol_lfs.rs
@@ -1,0 +1,22 @@
+#![no_main]
+
+use std::str::from_utf8;
+
+use libfuzzer_sys::fuzz_target;
+use shardline_server::fuzz_lfs_frontend_summary;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(oid) = from_utf8(data) else {
+        return;
+    };
+
+    let Ok(summary) = fuzz_lfs_frontend_summary(oid) else {
+        return;
+    };
+
+    if summary.oid_accepts {
+        assert!(summary.key_is_stable);
+        assert_eq!(oid.len(), 64);
+        assert!(oid.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    }
+});

--- a/crates/fuzz/fuzz_targets/shardline/protocol_oci.rs
+++ b/crates/fuzz/fuzz_targets/shardline/protocol_oci.rs
@@ -1,0 +1,40 @@
+#![no_main]
+
+use std::str::from_utf8;
+
+use libfuzzer_sys::fuzz_target;
+use shardline_server::fuzz_oci_frontend_summary;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(raw) = from_utf8(data) else {
+        return;
+    };
+
+    let mut parts = raw.split('\0');
+    let repository = parts.next().unwrap_or_default();
+    let reference = parts.next().unwrap_or_default();
+    let digest = parts.next().unwrap_or_default();
+    let session_id = parts.next().unwrap_or_default();
+    let content_range = parts.next().unwrap_or_default();
+    let path = parts.next().unwrap_or_default();
+
+    let Ok(summary) = fuzz_oci_frontend_summary(
+        repository,
+        reference,
+        digest,
+        session_id,
+        content_range,
+        path,
+    ) else {
+        return;
+    };
+
+    if summary.blob_accepts || summary.manifest_accepts {
+        assert!(summary.repository_accepts);
+        assert!(summary.digest_accepts);
+    }
+
+    if summary.path_accepts && path.contains("/blobs/sha256:") {
+        assert!(summary.digest_accepts || path.contains("sha256:"));
+    }
+});

--- a/crates/fuzz/fuzz_targets/shardline/protocol_xorb.rs
+++ b/crates/fuzz/fuzz_targets/shardline/protocol_xorb.rs
@@ -3,8 +3,9 @@
 use std::io::Cursor;
 
 use libfuzzer_sys::fuzz_target;
-use shardline_protocol::{ShardlineHash, decode_serialized_xorb_chunks, validate_serialized_xorb};
+use shardline_protocol::ShardlineHash;
 use shardline_server::fuzz_normalize_and_validate_xorb;
+use shardline_server::{decode_serialized_xorb_chunks, validate_serialized_xorb};
 
 fuzz_target!(|data: (Vec<u8>, [u8; 32])| {
     let (serialized, expected_hash_bytes) = data;

--- a/crates/fuzz/fuzz_targets/shardline/reconstruction_plan.rs
+++ b/crates/fuzz/fuzz_targets/shardline/reconstruction_plan.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use shardline_index::{FileChunkRecord, FileRecord};
+use shardline_index::{FileChunkRecord, FileRecord, parse_xet_hash_hex, xet_hash_hex_string};
 use shardline_protocol::{ByteRange, ChunkRange, ShardlineHash};
 use shardline_server::fuzz_reconstruction_response_summary;
 
@@ -17,7 +17,7 @@ fuzz_target!(|data: (u64, Vec<RawChunk>)| {
         .map(
             |(hash_bytes, offset, length, range_start, range_end, packed_start, packed_end)| {
                 FileChunkRecord {
-                    hash: ShardlineHash::from_bytes(hash_bytes).api_hex_string(),
+                    hash: xet_hash_hex_string(ShardlineHash::from_bytes(hash_bytes)),
                     offset,
                     length,
                     range_start,
@@ -57,7 +57,7 @@ fuzz_target!(|data: (u64, Vec<RawChunk>)| {
         assert!(chunk.length > 0);
         assert!(chunk.range_end > chunk.range_start);
         assert!(chunk.packed_end > chunk.packed_start);
-        assert!(ShardlineHash::parse_api_hex(&chunk.hash).is_ok());
+        assert!(parse_xet_hash_hex(&chunk.hash).is_ok());
         assert!(ChunkRange::new(chunk.range_start, chunk.range_end).is_ok());
         let next_expected_offset = expected_offset.checked_add(chunk.length);
         assert!(next_expected_offset.is_some());

--- a/crates/index/src/lib.rs
+++ b/crates/index/src/lib.rs
@@ -40,6 +40,7 @@ mod record_key;
 mod store;
 #[cfg(test)]
 mod test_invariant_error;
+mod xet_hash;
 
 pub use dedupe::DedupeShardMapping;
 pub use ids::{FileId, StoredObjectId, XorbId};
@@ -63,3 +64,4 @@ pub use record::{
     RecordStoreFuture, RepositoryRecordScope, StoredRecord,
 };
 pub use store::{AsyncIndexStore, IndexStore, IndexStoreFuture};
+pub use xet_hash::{parse_xet_hash_hex, xet_hash_hex_string};

--- a/crates/index/src/local.rs
+++ b/crates/index/src/local.rs
@@ -25,7 +25,7 @@ use crate::{
     AsyncIndexStore, DedupeShardMapping, FileId, FileReconstruction, IndexStore, IndexStoreFuture,
     ProviderRepositoryState, QuarantineCandidate, QuarantineCandidateError, ReconstructionTerm,
     RetentionHold, RetentionHoldError, StoredObjectId, WebhookDelivery, WebhookDeliveryError,
-    XorbId,
+    XorbId, parse_xet_hash_hex, xet_hash_hex_string,
     provider::parse_repository_provider,
 };
 const MAX_CONTROL_PLANE_METADATA_BYTES: u64 = 1_048_576;
@@ -102,7 +102,7 @@ impl LocalIndexStore {
             &self.root,
             &self.xorb_path(object_id),
             &StoredObjectPresenceRecord {
-                hash: object_id.hash().api_hex_string(),
+                hash: xet_hash_hex_string(object_id.hash()),
             },
         )
     }
@@ -129,7 +129,7 @@ impl LocalIndexStore {
             &self.root,
             &self.dedupe_shard_path(mapping.chunk_hash()),
             &DedupeShardRecord {
-                chunk_hash: mapping.chunk_hash().api_hex_string(),
+                chunk_hash: xet_hash_hex_string(mapping.chunk_hash()),
                 shard_object_key: mapping.shard_object_key().as_str().to_owned(),
             },
         )
@@ -165,16 +165,16 @@ impl LocalIndexStore {
 
     fn reconstruction_path(&self, file_id: &FileId) -> PathBuf {
         self.reconstructions_dir()
-            .join(format!("{}.json", file_id.hash().api_hex_string()))
+            .join(format!("{}.json", xet_hash_hex_string(file_id.hash())))
     }
 
     fn xorb_path(&self, object_id: &StoredObjectId) -> PathBuf {
         self.xorbs_dir()
-            .join(format!("{}.json", object_id.hash().api_hex_string()))
+            .join(format!("{}.json", xet_hash_hex_string(object_id.hash())))
     }
 
     fn dedupe_shard_path(&self, chunk_hash: ShardlineHash) -> PathBuf {
-        let hash = chunk_hash.api_hex_string();
+        let hash = xet_hash_hex_string(&chunk_hash);
         let prefix = hash.get(..2).unwrap_or_default();
         self.dedupe_shards_dir()
             .join(prefix)
@@ -248,15 +248,11 @@ impl IndexStore for LocalIndexStore {
                     HashParseError::InvalidLength,
                 ));
             };
-            let hash = ShardlineHash::parse_api_hex(stem)?;
+            let hash = parse_xet_hash_hex(stem)?;
             file_ids.push(FileId::new(hash));
         }
 
-        file_ids.sort_by(|left, right| {
-            left.hash()
-                .api_hex_string()
-                .cmp(&right.hash().api_hex_string())
-        });
+        file_ids.sort_by(|left, right| xet_hash_hex_string(left.hash()).cmp(&xet_hash_hex_string(right.hash())));
         Ok(file_ids)
     }
 
@@ -303,9 +299,7 @@ impl IndexStore for LocalIndexStore {
         };
         visit_dedupe_shard_mappings_recursive(&self.dedupe_shards_dir(), &mut visitor)?;
         collected.sort_by(|left, right| {
-            left.chunk_hash()
-                .api_hex_string()
-                .cmp(&right.chunk_hash().api_hex_string())
+            xet_hash_hex_string(left.chunk_hash()).cmp(&xet_hash_hex_string(right.chunk_hash()))
         });
         Ok(collected)
     }
@@ -854,7 +848,7 @@ struct ReconstructionTermRecord {
 impl ReconstructionTermRecord {
     fn from_domain(term: &ReconstructionTerm) -> Self {
         Self {
-            object_hash: term.object_id().hash().api_hex_string(),
+            object_hash: xet_hash_hex_string(term.object_id().hash()),
             chunk_start: term.chunk_range().start(),
             chunk_end_exclusive: term.chunk_range().end_exclusive(),
             unpacked_length: term.unpacked_length(),
@@ -862,7 +856,7 @@ impl ReconstructionTermRecord {
     }
 
     fn into_domain(self) -> Result<ReconstructionTerm, LocalIndexStoreError> {
-        let hash = ShardlineHash::parse_api_hex(&self.object_hash)?;
+        let hash = parse_xet_hash_hex(&self.object_hash)?;
         let range = ChunkRange::new(self.chunk_start, self.chunk_end_exclusive)?;
         Ok(ReconstructionTerm::new(
             StoredObjectId::new(hash),
@@ -1041,7 +1035,7 @@ struct DedupeShardRecord {
 
 impl DedupeShardRecord {
     fn into_domain(self) -> Result<DedupeShardMapping, LocalIndexStoreError> {
-        let chunk_hash = ShardlineHash::parse_api_hex(&self.chunk_hash)?;
+        let chunk_hash = parse_xet_hash_hex(&self.chunk_hash)?;
         let shard_object_key = ObjectKey::parse(&self.shard_object_key)?;
         Ok(DedupeShardMapping::new(chunk_hash, shard_object_key))
     }
@@ -1730,7 +1724,7 @@ mod tests {
         let path = store
             .root
             .join("reconstructions")
-            .join(format!("{}.json", hash.api_hex_string()));
+            .join(format!("{}.json", xet_hash_hex_string(&hash)));
         let Some(parent) = path.parent() else {
             return;
         };
@@ -1815,7 +1809,7 @@ mod tests {
         );
         let escaped = outside
             .path()
-            .join(format!("{}.json", hash.api_hex_string()));
+            .join(format!("{}.json", xet_hash_hex_string(&hash)));
         assert!(
             !escaped.exists(),
             "local index write escaped into a symlink target outside the index root"
@@ -1865,13 +1859,13 @@ mod tests {
         assert!(
             !outside
                 .path()
-                .join(format!("{}.json", hash.api_hex_string()))
+                .join(format!("{}.json", xet_hash_hex_string(&hash)))
                 .exists(),
             "local index write escaped into an attacker-controlled symlink target"
         );
         assert!(
             !moved_parent
-                .join(format!("{}.json", hash.api_hex_string()))
+                .join(format!("{}.json", xet_hash_hex_string(&hash)))
                 .exists(),
             "local index write left a committed file behind in the detached original directory"
         );
@@ -1965,7 +1959,7 @@ mod tests {
         };
 
         let hash = ShardlineHash::from_bytes([8; 32]);
-        let hash_hex = hash.api_hex_string();
+        let hash_hex = xet_hash_hex_string(&hash);
         let path = storage
             .path()
             .join("dedupe-shards")
@@ -2153,7 +2147,7 @@ mod tests {
         let path = store
             .root
             .join("reconstructions")
-            .join(format!("{}.json", hash.api_hex_string()));
+            .join(format!("{}.json", xet_hash_hex_string(&hash)));
         let file = fs::File::create(&path);
         assert!(file.is_ok());
         let Ok(file) = file else {
@@ -2190,7 +2184,7 @@ mod tests {
         let path = store
             .root
             .join("reconstructions")
-            .join(format!("{}.json", hash.api_hex_string()));
+            .join(format!("{}.json", xet_hash_hex_string(&hash)));
         let written = fs::write(&path, br#"{"terms":[]}"#);
         assert!(written.is_ok());
 

--- a/crates/index/src/local_sqlite.rs
+++ b/crates/index/src/local_sqlite.rs
@@ -34,12 +34,14 @@ use crate::{
     IndexStoreFuture, ProviderRepositoryState, QuarantineCandidate, QuarantineCandidateError,
     ReconstructionTerm, RecordStore, RecordStoreFuture, RepositoryRecordScope, RetentionHold,
     RetentionHoldError, StoredObjectId, WebhookDelivery, WebhookDeliveryError, XorbId,
+    parse_xet_hash_hex,
     provider::parse_repository_provider,
     record_key::record_key as shared_record_key,
     record_key::{
         repository_record_scope_key as shared_repository_record_scope_key,
         repository_scope_key as shared_repository_scope_key,
     },
+    xet_hash_hex_string,
 };
 
 const LOCAL_METADATA_DATABASE_FILE_NAME: &str = "metadata.sqlite3";
@@ -199,7 +201,7 @@ impl LocalIndexStore {
              VALUES (?1, ?2)
              ON CONFLICT (object_hash) DO NOTHING",
             params![
-                object_id.hash().api_hex_string(),
+                xet_hash_hex_string(object_id.hash()),
                 u64_to_i64(unix_now_seconds_lossy())?
             ],
         )?;
@@ -240,7 +242,7 @@ impl IndexStore for LocalIndexStore {
                 "SELECT terms
                  FROM shardline_file_reconstructions
                  WHERE file_id = ?1",
-                params![file_id.hash().api_hex_string()],
+                params![xet_hash_hex_string(file_id.hash())],
                 |row| row.get::<_, String>(0),
             )
             .optional()?
@@ -258,7 +260,7 @@ impl IndexStore for LocalIndexStore {
         let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
         let mut file_ids = Vec::new();
         for row in rows {
-            let hash = ShardlineHash::parse_api_hex(&row?)?;
+            let hash = parse_xet_hash_hex(&row?)?;
             file_ids.push(FileId::new(hash));
         }
         Ok(file_ids)
@@ -268,7 +270,7 @@ impl IndexStore for LocalIndexStore {
         let connection = self.open_connection()?;
         let changed = connection.execute(
             "DELETE FROM shardline_file_reconstructions WHERE file_id = ?1",
-            params![file_id.hash().api_hex_string()],
+            params![xet_hash_hex_string(file_id.hash())],
         )?;
         Ok(changed > 0)
     }
@@ -279,7 +281,7 @@ impl IndexStore for LocalIndexStore {
             "SELECT EXISTS(
                 SELECT 1 FROM shardline_stored_objects WHERE object_hash = ?1
             )",
-            params![object_id.hash().api_hex_string()],
+            params![xet_hash_hex_string(object_id.hash())],
             |row| row.get::<_, i64>(0),
         )?;
         Ok(exists != 0)
@@ -295,7 +297,7 @@ impl IndexStore for LocalIndexStore {
                 "SELECT chunk_hash, shard_object_key
                  FROM shardline_dedupe_shards
                  WHERE chunk_hash = ?1",
-                params![chunk_hash.api_hex_string()],
+                params![xet_hash_hex_string(chunk_hash)],
                 dedupe_shard_mapping_from_row,
             )
             .optional()
@@ -331,7 +333,7 @@ impl IndexStore for LocalIndexStore {
         let connection = self.open_connection()?;
         let changed = connection.execute(
             "DELETE FROM shardline_dedupe_shards WHERE chunk_hash = ?1",
-            params![chunk_hash.api_hex_string()],
+            params![xet_hash_hex_string(chunk_hash)],
         )?;
         Ok(changed > 0)
     }
@@ -1385,7 +1387,7 @@ struct ReconstructionTermRecord {
 impl ReconstructionTermRecord {
     fn from_domain(term: &ReconstructionTerm) -> Self {
         Self {
-            object_hash: term.object_id().hash().api_hex_string(),
+            object_hash: xet_hash_hex_string(term.object_id().hash()),
             chunk_start: term.chunk_range().start(),
             chunk_end_exclusive: term.chunk_range().end_exclusive(),
             unpacked_length: term.unpacked_length(),
@@ -1393,7 +1395,7 @@ impl ReconstructionTermRecord {
     }
 
     fn into_domain(self) -> Result<ReconstructionTerm, LocalIndexStoreError> {
-        let hash = ShardlineHash::parse_api_hex(&self.object_hash)?;
+        let hash = parse_xet_hash_hex(&self.object_hash)?;
         let range = ChunkRange::new(self.chunk_start, self.chunk_end_exclusive)?;
         Ok(ReconstructionTerm::new(
             StoredObjectId::new(hash),
@@ -1424,7 +1426,7 @@ struct DedupeShardRecord {
 
 impl DedupeShardRecord {
     fn into_domain(self) -> Result<DedupeShardMapping, LocalIndexStoreError> {
-        let chunk_hash = ShardlineHash::parse_api_hex(&self.chunk_hash)?;
+        let chunk_hash = parse_xet_hash_hex(&self.chunk_hash)?;
         let shard_object_key = ObjectKey::parse(&self.shard_object_key)?;
         Ok(DedupeShardMapping::new(chunk_hash, shard_object_key))
     }
@@ -1670,7 +1672,7 @@ fn import_legacy_reconstructions(
             .file_stem()
             .and_then(OsStr::to_str)
             .ok_or_else(invalid_metadata_path_error)?;
-        let file_id = FileId::new(ShardlineHash::parse_api_hex(path_hash)?);
+        let file_id = FileId::new(parse_xet_hash_hex(path_hash)?);
         let reconstruction = parse_reconstruction_json_bytes(&bytes)?;
         upsert_reconstruction_row(
             transaction,
@@ -1955,7 +1957,7 @@ fn upsert_reconstruction_row(
             terms = excluded.terms,
             updated_at_unix_seconds = excluded.updated_at_unix_seconds",
         params![
-            file_id.hash().api_hex_string(),
+            xet_hash_hex_string(file_id.hash()),
             json,
             u64_to_i64(updated_at_unix_seconds)?,
         ],
@@ -1980,7 +1982,7 @@ fn upsert_dedupe_mapping_row(
             shard_object_key = excluded.shard_object_key,
             updated_at_unix_seconds = excluded.updated_at_unix_seconds",
         params![
-            mapping.chunk_hash().api_hex_string(),
+            xet_hash_hex_string(mapping.chunk_hash()),
             mapping.shard_object_key().as_str(),
             u64_to_i64(updated_at_unix_seconds)?,
         ],
@@ -2156,8 +2158,8 @@ fn provider_repository_state_from_row(
 }
 
 fn dedupe_shard_mapping_from_row(row: &Row<'_>) -> Result<DedupeShardMapping, SqliteError> {
-    let chunk_hash = ShardlineHash::parse_api_hex(&row.get::<_, String>("chunk_hash")?)
-        .map_err(from_sql_error)?;
+    let chunk_hash =
+        parse_xet_hash_hex(&row.get::<_, String>("chunk_hash")?).map_err(from_sql_error)?;
     let object_key =
         ObjectKey::parse(&row.get::<_, String>("shard_object_key")?).map_err(from_sql_error)?;
     Ok(DedupeShardMapping::new(chunk_hash, object_key))
@@ -2623,7 +2625,7 @@ mod tests {
         DedupeShardMapping, FileChunkRecord, FileId, FileReconstruction, FileRecord, IndexStore,
         MemoryIndexStore, MemoryRecordStore, ProviderRepositoryState, QuarantineCandidate,
         ReconstructionTerm, RecordStore, RetentionHold, WebhookDelivery, XorbId,
-        test_invariant_error::LocalSqliteInvariantError,
+        parse_xet_hash_hex, test_invariant_error::LocalSqliteInvariantError, xet_hash_hex_string,
     };
 
     fn sample_repository_scope() -> Result<RepositoryScope, Box<dyn Error>> {
@@ -3245,11 +3247,11 @@ mod tests {
                 .path()
                 .join("gc")
                 .join("reconstructions")
-                .join(format!("{}.json", file_id.hash().api_hex_string())),
+                .join(format!("{}.json", xet_hash_hex_string(file_id.hash()))),
             &FileReconstructionRecord::from_domain(&reconstruction),
         )?;
 
-        let xorb_hash = ShardlineHash::from_bytes([4; 32]).api_hex_string();
+        let xorb_hash = xet_hash_hex_string(ShardlineHash::from_bytes([4; 32]));
         write_json(
             &storage
                 .path()
@@ -3261,9 +3263,9 @@ mod tests {
             },
         )?;
 
-        let dedupe_chunk_hash = ShardlineHash::from_bytes([5; 32]).api_hex_string();
+        let dedupe_chunk_hash = xet_hash_hex_string(ShardlineHash::from_bytes([5; 32]));
         let dedupe_mapping = DedupeShardMapping::new(
-            ShardlineHash::parse_api_hex(&dedupe_chunk_hash)?,
+            parse_xet_hash_hex(&dedupe_chunk_hash)?,
             ObjectKey::parse("shards/aa/native.shard")?,
         );
         write_json(
@@ -3278,7 +3280,7 @@ mod tests {
             },
         )?;
 
-        let quarantine_hash = ShardlineHash::from_bytes([6; 32]).api_hex_string();
+        let quarantine_hash = xet_hash_hex_string(ShardlineHash::from_bytes([6; 32]));
         let quarantine_candidate = QuarantineCandidate::new(
             ObjectKey::parse(&format!("{}/{}", &quarantine_hash[..2], quarantine_hash))?,
             9,
@@ -3399,16 +3401,12 @@ mod tests {
                 LocalSqliteInvariantError::new("reconstruction row was not imported").into(),
             );
         }
-        if !IndexStore::contains_xorb(
-            &index_store,
-            &XorbId::new(ShardlineHash::parse_api_hex(&xorb_hash)?),
-        )? {
+        if !IndexStore::contains_xorb(&index_store, &XorbId::new(parse_xet_hash_hex(&xorb_hash)?))?
+        {
             return Err(LocalSqliteInvariantError::new("xorb marker was not imported").into());
         }
-        if IndexStore::dedupe_shard_mapping(
-            &index_store,
-            &ShardlineHash::parse_api_hex(&dedupe_chunk_hash)?,
-        )? != Some(dedupe_mapping)
+        if IndexStore::dedupe_shard_mapping(&index_store, &parse_xet_hash_hex(&dedupe_chunk_hash)?)?
+            != Some(dedupe_mapping)
         {
             return Err(LocalSqliteInvariantError::new("dedupe mapping was not imported").into());
         }
@@ -3475,12 +3473,12 @@ mod tests {
         Ok(vec![
             FileRecord {
                 file_id: "alpha.bin".to_owned(),
-                content_hash: ShardlineHash::from_bytes([11; 32]).api_hex_string(),
+                content_hash: xet_hash_hex_string(ShardlineHash::from_bytes([11; 32])),
                 total_bytes: 4,
                 chunk_size: 4,
                 repository_scope: None,
                 chunks: vec![FileChunkRecord {
-                    hash: ShardlineHash::from_bytes([21; 32]).api_hex_string(),
+                    hash: xet_hash_hex_string(ShardlineHash::from_bytes([21; 32])),
                     offset: 0,
                     length: 4,
                     range_start: 0,
@@ -3491,13 +3489,13 @@ mod tests {
             },
             FileRecord {
                 file_id: "beta.bin".to_owned(),
-                content_hash: ShardlineHash::from_bytes([12; 32]).api_hex_string(),
+                content_hash: xet_hash_hex_string(ShardlineHash::from_bytes([12; 32])),
                 total_bytes: 8,
                 chunk_size: 4,
                 repository_scope: Some(scope_a),
                 chunks: vec![
                     FileChunkRecord {
-                        hash: ShardlineHash::from_bytes([22; 32]).api_hex_string(),
+                        hash: xet_hash_hex_string(ShardlineHash::from_bytes([22; 32])),
                         offset: 0,
                         length: 4,
                         range_start: 0,
@@ -3506,7 +3504,7 @@ mod tests {
                         packed_end: 4,
                     },
                     FileChunkRecord {
-                        hash: ShardlineHash::from_bytes([23; 32]).api_hex_string(),
+                        hash: xet_hash_hex_string(ShardlineHash::from_bytes([23; 32])),
                         offset: 4,
                         length: 4,
                         range_start: 1,
@@ -3518,12 +3516,12 @@ mod tests {
             },
             FileRecord {
                 file_id: "gamma.bin".to_owned(),
-                content_hash: ShardlineHash::from_bytes([13; 32]).api_hex_string(),
+                content_hash: xet_hash_hex_string(ShardlineHash::from_bytes([13; 32])),
                 total_bytes: 6,
                 chunk_size: 6,
                 repository_scope: Some(scope_b),
                 chunks: vec![FileChunkRecord {
-                    hash: ShardlineHash::from_bytes([24; 32]).api_hex_string(),
+                    hash: xet_hash_hex_string(ShardlineHash::from_bytes([24; 32])),
                     offset: 0,
                     length: 6,
                     range_start: 0,
@@ -3946,7 +3944,7 @@ mod tests {
             .into_iter()
             .map(|mapping| {
                 (
-                    mapping.chunk_hash().api_hex_string(),
+                    xet_hash_hex_string(mapping.chunk_hash()),
                     mapping.shard_object_key().as_str().to_owned(),
                 )
             })

--- a/crates/index/src/memory.rs
+++ b/crates/index/src/memory.rs
@@ -13,6 +13,7 @@ use crate::{
     AsyncIndexStore, DedupeShardMapping, FileId, FileReconstruction, FileRecord, IndexStore,
     IndexStoreFuture, ProviderRepositoryState, QuarantineCandidate, RecordStore, RecordStoreFuture,
     RepositoryRecordScope, RetentionHold, StoredObjectId, StoredRecord, WebhookDelivery, XorbId,
+    xet_hash_hex_string,
 };
 
 /// In-memory implementation of [`IndexStore`].
@@ -133,9 +134,7 @@ impl IndexStore for MemoryIndexStore {
             .copied()
             .collect::<Vec<_>>();
         file_ids.sort_by(|left, right| {
-            left.hash()
-                .api_hex_string()
-                .cmp(&right.hash().api_hex_string())
+            xet_hash_hex_string(left.hash()).cmp(&xet_hash_hex_string(right.hash()))
         });
         Ok(file_ids)
     }
@@ -163,9 +162,7 @@ impl IndexStore for MemoryIndexStore {
             .cloned()
             .collect::<Vec<_>>();
         mappings.sort_by(|left, right| {
-            left.chunk_hash()
-                .api_hex_string()
-                .cmp(&right.chunk_hash().api_hex_string())
+            xet_hash_hex_string(left.chunk_hash()).cmp(&xet_hash_hex_string(right.chunk_hash()))
         });
         Ok(mappings)
     }

--- a/crates/index/src/postgres.rs
+++ b/crates/index/src/postgres.rs
@@ -17,13 +17,14 @@ use crate::{
     AsyncIndexStore, DedupeShardMapping, FileId, FileReconstruction, FileRecord, IndexStoreFuture,
     ProviderRepositoryState, QuarantineCandidate, QuarantineCandidateError, ReconstructionTerm,
     RecordStore, RecordStoreFuture, RepositoryRecordScope, RetentionHold, RetentionHoldError,
-    StoredObjectId, StoredRecord, WebhookDelivery, WebhookDeliveryError,
+    StoredObjectId, StoredRecord, WebhookDelivery, WebhookDeliveryError, parse_xet_hash_hex,
     provider::parse_repository_provider,
     record_key::record_key as shared_record_key,
     record_key::{
         repository_record_scope_key as shared_repository_record_scope_key,
         repository_scope_key as shared_repository_scope_key,
     },
+    xet_hash_hex_string,
 };
 
 /// Postgres-compatible implementation of the asynchronous index-store contract.
@@ -55,7 +56,7 @@ impl AsyncIndexStore for PostgresIndexStore {
     ) -> IndexStoreFuture<'operation, Option<FileReconstruction>, Self::Error> {
         Box::pin(async move {
             let row = query("SELECT terms FROM shardline_file_reconstructions WHERE file_id = $1")
-                .bind(file_id.hash().api_hex_string())
+                .bind(xet_hash_hex_string(file_id.hash()))
                 .fetch_optional(&self.pool)
                 .await?;
 
@@ -80,7 +81,7 @@ impl AsyncIndexStore for PostgresIndexStore {
                  ON CONFLICT (file_id)
                  DO UPDATE SET terms = EXCLUDED.terms, updated_at = now()",
             )
-            .bind(file_id.hash().api_hex_string())
+            .bind(xet_hash_hex_string(file_id.hash()))
             .bind(Json(record))
             .execute(&self.pool)
             .await?;
@@ -97,7 +98,7 @@ impl AsyncIndexStore for PostgresIndexStore {
             rows.iter()
                 .map(|row| {
                     let file_id = row.try_get::<String, _>("file_id")?;
-                    let hash = ShardlineHash::parse_api_hex(&file_id)?;
+                    let hash = parse_xet_hash_hex(&file_id)?;
                     Ok(FileId::new(hash))
                 })
                 .collect::<Result<Vec<_>, PostgresMetadataStoreError>>()
@@ -110,7 +111,7 @@ impl AsyncIndexStore for PostgresIndexStore {
     ) -> IndexStoreFuture<'operation, bool, Self::Error> {
         Box::pin(async move {
             let result = query("DELETE FROM shardline_file_reconstructions WHERE file_id = $1")
-                .bind(file_id.hash().api_hex_string())
+                .bind(xet_hash_hex_string(file_id.hash()))
                 .execute(&self.pool)
                 .await?;
             Ok(result.rows_affected() > 0)
@@ -127,7 +128,7 @@ impl AsyncIndexStore for PostgresIndexStore {
                     SELECT 1 FROM shardline_stored_objects WHERE object_hash = $1
                  )",
             )
-            .bind(object_id.hash().api_hex_string())
+            .bind(xet_hash_hex_string(object_id.hash()))
             .fetch_one(&self.pool)
             .await?;
             Ok(exists)
@@ -144,7 +145,7 @@ impl AsyncIndexStore for PostgresIndexStore {
                  FROM shardline_dedupe_shards
                  WHERE chunk_hash = $1",
             )
-            .bind(chunk_hash.api_hex_string())
+            .bind(xet_hash_hex_string(chunk_hash))
             .fetch_optional(&self.pool)
             .await?;
 
@@ -211,7 +212,7 @@ impl AsyncIndexStore for PostgresIndexStore {
                  VALUES ($1)
                  ON CONFLICT (object_hash) DO NOTHING",
             )
-            .bind(object_id.hash().api_hex_string())
+            .bind(xet_hash_hex_string(object_id.hash()))
             .execute(&self.pool)
             .await?;
             Ok(())
@@ -231,7 +232,7 @@ impl AsyncIndexStore for PostgresIndexStore {
                     shard_object_key = EXCLUDED.shard_object_key,
                     updated_at = now()",
             )
-            .bind(mapping.chunk_hash().api_hex_string())
+            .bind(xet_hash_hex_string(mapping.chunk_hash()))
             .bind(mapping.shard_object_key().as_str())
             .execute(&self.pool)
             .await?;
@@ -245,7 +246,7 @@ impl AsyncIndexStore for PostgresIndexStore {
     ) -> IndexStoreFuture<'operation, bool, Self::Error> {
         Box::pin(async move {
             let result = query("DELETE FROM shardline_dedupe_shards WHERE chunk_hash = $1")
-                .bind(chunk_hash.api_hex_string())
+                .bind(xet_hash_hex_string(chunk_hash))
                 .execute(&self.pool)
                 .await?;
             Ok(result.rows_affected() > 0)
@@ -910,7 +911,7 @@ async fn upsert_dedupe_shard_mapping_in_transaction(
             shard_object_key = EXCLUDED.shard_object_key,
             updated_at = now()",
     )
-    .bind(mapping.chunk_hash().api_hex_string())
+    .bind(xet_hash_hex_string(mapping.chunk_hash()))
     .bind(mapping.shard_object_key().as_str())
     .execute(&mut **transaction)
     .await?;
@@ -1403,7 +1404,7 @@ struct PostgresReconstructionTermRecord {
 impl PostgresReconstructionTermRecord {
     fn from_domain(term: &ReconstructionTerm) -> Self {
         Self {
-            object_hash: term.object_id().hash().api_hex_string(),
+            object_hash: xet_hash_hex_string(term.object_id().hash()),
             chunk_start: term.chunk_range().start(),
             chunk_end_exclusive: term.chunk_range().end_exclusive(),
             unpacked_length: term.unpacked_length(),
@@ -1411,7 +1412,7 @@ impl PostgresReconstructionTermRecord {
     }
 
     fn into_domain(self) -> Result<ReconstructionTerm, PostgresMetadataStoreError> {
-        let hash = ShardlineHash::parse_api_hex(&self.object_hash)?;
+        let hash = parse_xet_hash_hex(&self.object_hash)?;
         let range = ChunkRange::new(self.chunk_start, self.chunk_end_exclusive)?;
         Ok(ReconstructionTerm::new(
             StoredObjectId::new(hash),
@@ -1458,8 +1459,7 @@ fn quarantine_candidate_from_row(
 fn dedupe_shard_mapping_from_row(
     row: &PgRow,
 ) -> Result<DedupeShardMapping, PostgresMetadataStoreError> {
-    let chunk_hash =
-        ShardlineHash::parse_api_hex(row.try_get::<String, _>("chunk_hash")?.as_str())?;
+    let chunk_hash = parse_xet_hash_hex(row.try_get::<String, _>("chunk_hash")?.as_str())?;
     let shard_object_key =
         ObjectKey::parse(row.try_get::<String, _>("shard_object_key")?.as_str())?;
     Ok(DedupeShardMapping::new(chunk_hash, shard_object_key))
@@ -1606,6 +1606,7 @@ mod tests {
             repository_record_scope_key as shared_repository_record_scope_key,
             repository_scope_key as shared_repository_scope_key,
         },
+        xet_hash_hex_string,
     };
 
     #[test]
@@ -1712,7 +1713,7 @@ mod tests {
 
     fn file_record(scope: RepositoryScope, content_seed: &str) -> FileRecord {
         let hash = ShardlineHash::from_bytes([12; 32]);
-        let file_id = FileId::new(hash).hash().api_hex_string();
+        let file_id = xet_hash_hex_string(FileId::new(hash).hash());
         FileRecord {
             file_id,
             content_hash: content_seed.repeat(64),

--- a/crates/index/src/record.rs
+++ b/crates/index/src/record.rs
@@ -1,8 +1,10 @@
 use std::{future::Future, pin::Pin, time::Duration};
 
 use serde::{Deserialize, Serialize};
-use shardline_protocol::{HashParseError, RepositoryProvider, RepositoryScope, ShardlineHash};
+use shardline_protocol::{HashParseError, RepositoryProvider, RepositoryScope};
 use thiserror::Error;
+
+use crate::parse_xet_hash_hex;
 
 /// Boxed asynchronous record-store operation.
 pub type RecordStoreFuture<'operation, T, E> =
@@ -144,7 +146,7 @@ impl FileRecord {
     pub fn validate_reconstruction_plan(&self) -> Result<(), FileRecordInvariantError> {
         let mut expected_offset = 0_u64;
         for chunk in &self.chunks {
-            ShardlineHash::parse_api_hex(&chunk.hash)?;
+            parse_xet_hash_hex(&chunk.hash)?;
             if chunk.length == 0 {
                 return Err(FileRecordInvariantError::EmptyChunk);
             }

--- a/crates/index/src/xet_hash.rs
+++ b/crates/index/src/xet_hash.rs
@@ -1,0 +1,126 @@
+use std::borrow::Borrow;
+
+use shardline_protocol::{HashParseError, ShardlineHash};
+
+const HASH_HEX_LENGTH: usize = 64;
+const XET_HASH_GROUP_BYTES: usize = 8;
+
+/// Parses the reordered lowercase hash text used by Xet API paths and persisted Xet metadata.
+///
+/// # Errors
+///
+/// Returns [`HashParseError`] when the string has the wrong length, contains
+/// non-lowercase hexadecimal characters, or cannot be decoded into 32 bytes.
+pub fn parse_xet_hash_hex(value: &str) -> Result<ShardlineHash, HashParseError> {
+    if value.len() != HASH_HEX_LENGTH {
+        return Err(HashParseError::InvalidLength);
+    }
+
+    if !value
+        .bytes()
+        .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(HashParseError::InvalidCharacter);
+    }
+
+    let decoded = hex::decode(value).map_err(|_error| HashParseError::InvalidCharacter)?;
+    let reordered = decoded
+        .chunks_exact(XET_HASH_GROUP_BYTES)
+        .flat_map(|chunk| chunk.iter().rev().copied())
+        .collect::<Vec<u8>>();
+    let bytes = <[u8; 32]>::try_from(reordered).map_err(|_error| HashParseError::InvalidLength)?;
+
+    Ok(ShardlineHash::from_bytes(bytes))
+}
+
+/// Returns the reordered lowercase hash text used by Xet API paths and persisted Xet metadata.
+#[must_use]
+pub fn xet_hash_hex_string(hash: impl Borrow<ShardlineHash>) -> String {
+    let hash = hash.borrow();
+    let mut encoded = Vec::with_capacity(HASH_HEX_LENGTH);
+    for chunk in hash.as_bytes().chunks_exact(XET_HASH_GROUP_BYTES) {
+        for byte in chunk.iter().rev() {
+            append_lower_hex_byte(&mut encoded, *byte);
+        }
+    }
+
+    String::from_utf8(encoded).unwrap_or_default()
+}
+
+fn append_lower_hex_byte(output: &mut Vec<u8>, byte: u8) {
+    output.push(lower_hex_digit(byte >> 4));
+    output.push(lower_hex_digit(byte & 0x0f));
+}
+
+const fn lower_hex_digit(nibble: u8) -> u8 {
+    match nibble {
+        0 => b'0',
+        1 => b'1',
+        2 => b'2',
+        3 => b'3',
+        4 => b'4',
+        5 => b'5',
+        6 => b'6',
+        7 => b'7',
+        8 => b'8',
+        9 => b'9',
+        10 => b'a',
+        11 => b'b',
+        12 => b'c',
+        13 => b'd',
+        14 => b'e',
+        _ => b'f',
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use shardline_protocol::ShardlineHash;
+
+    use super::{parse_xet_hash_hex, xet_hash_hex_string};
+
+    #[test]
+    fn xet_hash_hex_uses_xet_byte_group_ordering() {
+        let hash = ShardlineHash::from_bytes([
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ]);
+
+        let xet_hex = xet_hash_hex_string(hash);
+
+        assert_eq!(
+            xet_hex,
+            "07060504030201000f0e0d0c0b0a090817161514131211101f1e1d1c1b1a1918"
+        );
+        assert_eq!(parse_xet_hash_hex(&xet_hex), Ok(hash));
+    }
+
+    #[test]
+    fn xet_hash_vectors_round_trip_each_xet_byte_group_independently() {
+        let cases = [
+            (
+                [
+                    0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc,
+                    0xdd, 0xee, 0xff, 0x10, 0x32, 0x54, 0x76, 0x98, 0xba, 0xdc, 0xfe, 0x01, 0x23,
+                    0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
+                ],
+                "7766554433221100ffeeddccbbaa9988fedcba9876543210efcdab8967452301",
+            ),
+            (
+                [
+                    0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33,
+                    0x22, 0x11, 0x00, 0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01, 0xfe, 0xdc,
+                    0xba, 0x98, 0x76, 0x54, 0x32, 0x10,
+                ],
+                "8899aabbccddeeff00112233445566770123456789abcdef1032547698badcfe",
+            ),
+        ];
+
+        for (bytes, xet_hex) in cases {
+            let hash = ShardlineHash::from_bytes(bytes);
+
+            assert_eq!(xet_hash_hex_string(hash), xet_hex);
+            assert_eq!(parse_xet_hash_hex(xet_hex), Ok(hash));
+        }
+    }
+}

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -21,7 +21,6 @@ serde_json.workspace = true
 sha2.workspace = true
 subtle.workspace = true
 thiserror.workspace = true
-xet-core-structures.workspace = true
 zeroize = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/protocol/benches/protocol_core.rs
+++ b/crates/protocol/benches/protocol_core.rs
@@ -6,11 +6,11 @@ use shardline_protocol::{
     TokenScope, TokenSigner,
 };
 
-const HASH_HEX: &str = "07060504030201000f0e0d0c0b0a090817161514131211101f1e1d1c1b1a1918";
+const HASH_HEX: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
 
 fn protocol_benchmarks(criterion: &mut Criterion) {
     let hash = must(
-        ShardlineHash::parse_api_hex(HASH_HEX),
+        ShardlineHash::parse_hex(HASH_HEX),
         "benchmark hash fixture should parse",
     );
     let repository = must(
@@ -42,16 +42,16 @@ fn protocol_benchmarks(criterion: &mut Criterion) {
     );
 
     let mut group = criterion.benchmark_group("shardline_protocol");
-    group.bench_function("hash_parse_api_hex", |bench| {
+    group.bench_function("hash_parse_hex", |bench| {
         bench.iter(|| {
             must(
-                ShardlineHash::parse_api_hex(black_box(HASH_HEX)),
+                ShardlineHash::parse_hex(black_box(HASH_HEX)),
                 "hash parse failed",
             )
         });
     });
-    group.bench_function("hash_api_hex_string", |bench| {
-        bench.iter(|| black_box(hash).api_hex_string());
+    group.bench_function("hash_hex_string", |bench| {
+        bench.iter(|| black_box(hash).hex_string());
     });
     group.bench_function("byte_range_new_and_len", |bench| {
         bench.iter(|| {

--- a/crates/protocol/src/hash.rs
+++ b/crates/protocol/src/hash.rs
@@ -2,8 +2,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 const HASH_BYTE_LENGTH: usize = 32;
-const HASH_API_HEX_LENGTH: usize = 64;
-const HASH_API_GROUP_BYTES: usize = 8;
+const HASH_HEX_LENGTH: usize = 64;
 
 /// A 32-byte protocol hash.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -24,14 +23,14 @@ impl ShardlineHash {
         &self.bytes
     }
 
-    /// Parses a hash from the hexadecimal representation used by Xet CAS API paths.
+    /// Parses a hash from canonical lowercase hexadecimal text.
     ///
     /// # Errors
     ///
     /// Returns [`HashParseError`] when the string has the wrong length, contains
     /// non-lowercase hexadecimal characters, or cannot be decoded into 32 bytes.
-    pub fn parse_api_hex(value: &str) -> Result<Self, HashParseError> {
-        if value.len() != HASH_API_HEX_LENGTH {
+    pub fn parse_hex(value: &str) -> Result<Self, HashParseError> {
+        if value.len() != HASH_HEX_LENGTH {
             return Err(HashParseError::InvalidLength);
         }
 
@@ -43,24 +42,18 @@ impl ShardlineHash {
         }
 
         let decoded = hex::decode(value).map_err(|_error| HashParseError::InvalidCharacter)?;
-        let reordered = decoded
-            .chunks_exact(HASH_API_GROUP_BYTES)
-            .flat_map(|chunk| chunk.iter().rev().copied())
-            .collect::<Vec<u8>>();
-        let bytes = <[u8; HASH_BYTE_LENGTH]>::try_from(reordered)
+        let bytes = <[u8; HASH_BYTE_LENGTH]>::try_from(decoded)
             .map_err(|_error| HashParseError::InvalidLength)?;
 
         Ok(Self { bytes })
     }
 
-    /// Returns the hexadecimal representation used by Xet CAS API paths.
+    /// Returns canonical lowercase hexadecimal text.
     #[must_use]
-    pub fn api_hex_string(&self) -> String {
-        let mut encoded = Vec::with_capacity(HASH_API_HEX_LENGTH);
-        for chunk in self.bytes.chunks_exact(HASH_API_GROUP_BYTES) {
-            for byte in chunk.iter().rev() {
-                append_lower_hex_byte(&mut encoded, *byte);
-            }
+    pub fn hex_string(&self) -> String {
+        let mut encoded = Vec::with_capacity(HASH_HEX_LENGTH);
+        for byte in self.bytes {
+            append_lower_hex_byte(&mut encoded, byte);
         }
 
         String::from_utf8(encoded).unwrap_or_default()
@@ -109,23 +102,23 @@ mod tests {
     use super::{HashParseError, ShardlineHash};
 
     #[test]
-    fn api_hash_hex_uses_xet_byte_group_ordering() {
+    fn canonical_hash_hex_round_trips_raw_bytes() {
         let hash = ShardlineHash::from_bytes([
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
             24, 25, 26, 27, 28, 29, 30, 31,
         ]);
 
-        let api_hex = hash.api_hex_string();
+        let hex = hash.hex_string();
 
         assert_eq!(
-            api_hex,
-            "07060504030201000f0e0d0c0b0a090817161514131211101f1e1d1c1b1a1918"
+            hex,
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
         );
-        assert_eq!(ShardlineHash::parse_api_hex(&api_hex), Ok(hash));
+        assert_eq!(ShardlineHash::parse_hex(&hex), Ok(hash));
     }
 
     #[test]
-    fn api_hash_vectors_round_trip_each_xet_byte_group_independently() {
+    fn canonical_hash_vectors_round_trip() {
         let cases = [
             (
                 [
@@ -133,7 +126,7 @@ mod tests {
                     0xdd, 0xee, 0xff, 0x10, 0x32, 0x54, 0x76, 0x98, 0xba, 0xdc, 0xfe, 0x01, 0x23,
                     0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
                 ],
-                "7766554433221100ffeeddccbbaa9988fedcba9876543210efcdab8967452301",
+                "00112233445566778899aabbccddeeff1032547698badcfe0123456789abcdef",
             ),
             (
                 [
@@ -141,37 +134,37 @@ mod tests {
                     0x22, 0x11, 0x00, 0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01, 0xfe, 0xdc,
                     0xba, 0x98, 0x76, 0x54, 0x32, 0x10,
                 ],
-                "8899aabbccddeeff00112233445566770123456789abcdef1032547698badcfe",
+                "ffeeddccbbaa99887766554433221100efcdab8967452301fedcba9876543210",
             ),
         ];
 
-        for (bytes, api_hex) in cases {
+        for (bytes, hex) in cases {
             let hash = ShardlineHash::from_bytes(bytes);
 
-            assert_eq!(hash.api_hex_string(), api_hex);
-            assert_eq!(ShardlineHash::parse_api_hex(api_hex), Ok(hash));
+            assert_eq!(hash.hex_string(), hex);
+            assert_eq!(ShardlineHash::parse_hex(hex), Ok(hash));
         }
     }
 
     #[test]
-    fn api_hash_rejects_uppercase_hex() {
+    fn canonical_hash_rejects_uppercase_hex() {
         let hash = ShardlineHash::from_bytes([31; 32]);
-        let invalid = hash.api_hex_string().replacen('f', "F", 1);
-        let result = ShardlineHash::parse_api_hex(&invalid);
+        let invalid = hash.hex_string().replacen('f', "F", 1);
+        let result = ShardlineHash::parse_hex(&invalid);
 
         assert_eq!(result, Err(HashParseError::InvalidCharacter));
     }
 
     #[test]
-    fn api_hash_rejects_short_hex() {
-        let result = ShardlineHash::parse_api_hex("abc");
+    fn canonical_hash_rejects_short_hex() {
+        let result = ShardlineHash::parse_hex("abc");
 
         assert_eq!(result, Err(HashParseError::InvalidLength));
     }
 
     #[test]
-    fn api_hash_rejects_long_hex() {
-        let result = ShardlineHash::parse_api_hex(
+    fn canonical_hash_rejects_long_hex() {
+        let result = ShardlineHash::parse_hex(
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         );
 
@@ -179,8 +172,8 @@ mod tests {
     }
 
     #[test]
-    fn api_hash_rejects_non_hex_character() {
-        let result = ShardlineHash::parse_api_hex(
+    fn canonical_hash_rejects_non_hex_character() {
+        let result = ShardlineHash::parse_hex(
             "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
         );
 

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -1,11 +1,12 @@
 #![deny(unsafe_code)]
 
-//! Xet protocol-facing types shared by Shardline clients, storage adapters, and the
+//! Shared protocol-facing types used by Shardline clients, storage adapters, and the
 //! HTTP server.
 //!
 //! This crate keeps the wire-level contracts small and explicit:
 //!
-//! - [`ShardlineHash`] encodes the Xet CAS hash byte ordering used in API paths.
+//! - [`ShardlineHash`] stores validated 32-byte hashes and canonical lowercase
+//!   hexadecimal text.
 //! - [`ByteRange`] and [`ChunkRange`] validate range boundaries before they reach
 //!   storage code.
 //! - [`TokenSigner`] signs and verifies scoped bearer tokens without exposing
@@ -46,8 +47,6 @@ mod security;
 mod text;
 mod time;
 mod token;
-mod xorb;
-
 pub use hash::{HashParseError, ShardlineHash};
 pub use ranges::{ByteRange, ChunkRange, HttpRangeParseError, RangeError, parse_http_byte_range};
 pub use security::{SecretBytes, SecretString};
@@ -56,8 +55,4 @@ pub use time::unix_now_seconds_lossy;
 pub use token::{
     RepositoryProvider, RepositoryScope, TokenClaims, TokenClaimsError, TokenCodecError,
     TokenScope, TokenSigner,
-};
-pub use xorb::{
-    DecodedXorbChunk, ValidatedXorb, ValidatedXorbChunk, XorbParseError, XorbVisitError,
-    decode_serialized_xorb_chunks, try_for_each_serialized_xorb_chunk, validate_serialized_xorb,
 };

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -19,6 +19,7 @@ base64.workspace = true
 blake3.workspace = true
 bytes.workspace = true
 futures-util.workspace = true
+getrandom.workspace = true
 hex.workspace = true
 libc.workspace = true
 serde = { workspace = true, features = ["derive"] }
@@ -60,4 +61,16 @@ workspace = true
 
 [[bench]]
 name = "local_backend"
+harness = false
+
+[[bench]]
+name = "oci_tags"
+harness = false
+
+[[bench]]
+name = "oci_tags_fixed"
+harness = false
+
+[[bench]]
+name = "oci_finalize_fixed"
 harness = false

--- a/crates/server/benches/oci_finalize_fixed.rs
+++ b/crates/server/benches/oci_finalize_fixed.rs
@@ -1,0 +1,187 @@
+use std::{
+    fs,
+    io::Read,
+    path::{Path, PathBuf},
+    process::ExitCode,
+    time::Instant,
+};
+
+use blake3::Hasher as Blake3Hasher;
+use sha2::{Digest, Sha256};
+use shardline_protocol::ShardlineHash;
+use shardline_storage::{LocalObjectStore, ObjectBody, ObjectIntegrity, ObjectKey, ObjectStore};
+use tempfile::TempDir;
+
+const FILE_BYTES: usize = 32 * 1024 * 1024;
+const DEFAULT_ITERATIONS: usize = 8;
+
+struct Fixture {
+    _root: TempDir,
+    source_file: PathBuf,
+    stage_dir: PathBuf,
+    object_store: LocalObjectStore,
+}
+
+impl Fixture {
+    fn new() -> Result<Self, Box<dyn std::error::Error>> {
+        let root = tempfile::tempdir()?;
+        let source_file = root.path().join("source.bin");
+        let stage_dir = root.path().join("oci-uploads");
+        let store_root = root.path().join("chunks");
+        fs::create_dir_all(&stage_dir)?;
+        let payload = vec![0x5a; FILE_BYTES];
+        fs::write(&source_file, payload)?;
+        let object_store = LocalObjectStore::new(store_root)?;
+        Ok(Self {
+            _root: root,
+            source_file,
+            stage_dir,
+            object_store,
+        })
+    }
+
+    fn stage_path(&self, iteration: usize) -> PathBuf {
+        self.stage_dir.join(format!("upload-{iteration}.bin"))
+    }
+
+    fn object_key(&self, iteration: usize) -> Result<ObjectKey, Box<dyn std::error::Error>> {
+        Ok(ObjectKey::parse(&format!(
+            "protocols/oci/global/repos/bench/blobs/{iteration:08x}"
+        ))?)
+    }
+
+    fn reset_stage_file(&self, iteration: usize) -> Result<PathBuf, Box<dyn std::error::Error>> {
+        let stage = self.stage_path(iteration);
+        let _ignored = fs::remove_file(&stage);
+        fs::copy(&self.source_file, &stage)?;
+        Ok(stage)
+    }
+}
+
+fn main() -> ExitCode {
+    let mut mode = "new";
+    let mut iterations = DEFAULT_ITERATIONS;
+    let mut args = std::env::args().skip(1);
+    while let Some(argument) = args.next() {
+        match argument.as_str() {
+            "old" | "new" => mode = Box::leak(argument.into_boxed_str()),
+            "--bench" => {}
+            "--iterations" => {
+                let Some(value) = args.next() else {
+                    eprintln!("missing value for --iterations");
+                    return ExitCode::FAILURE;
+                };
+                match value.parse::<usize>() {
+                    Ok(parsed) if parsed > 0 => iterations = parsed,
+                    _ => {
+                        eprintln!("invalid --iterations value: {value}");
+                        return ExitCode::FAILURE;
+                    }
+                }
+            }
+            _ => {
+                eprintln!(
+                    "usage: cargo bench --bench oci_finalize_fixed -- [old|new] [--iterations N]"
+                );
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+
+    let fixture = match Fixture::new() {
+        Ok(fixture) => fixture,
+        Err(error) => {
+            eprintln!("fixture setup failed: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let start = Instant::now();
+    for iteration in 0..iterations {
+        let stage = match fixture.reset_stage_file(iteration) {
+            Ok(stage) => stage,
+            Err(error) => {
+                eprintln!("stage reset failed: {error}");
+                return ExitCode::FAILURE;
+            }
+        };
+        let key = match fixture.object_key(iteration) {
+            Ok(key) => key,
+            Err(error) => {
+                eprintln!("object key failed: {error}");
+                return ExitCode::FAILURE;
+            }
+        };
+        let result = match mode {
+            "old" => old_finalize(&fixture.object_store, &stage, &key),
+            "new" => new_finalize(&fixture.object_store, &stage, &key),
+            invalid => {
+                eprintln!("unsupported mode: {invalid}");
+                return ExitCode::FAILURE;
+            }
+        };
+        if let Err(error) = result {
+            eprintln!("{mode} finalize failed: {error}");
+            return ExitCode::FAILURE;
+        }
+    }
+    let elapsed = start.elapsed();
+    let elapsed_ms = elapsed.as_millis();
+    let elapsed_micros_remainder = elapsed.subsec_micros() % 1000;
+    println!(
+        "mode={mode} iterations={iterations} file_bytes={FILE_BYTES} elapsed_ms={elapsed_ms}.{elapsed_micros_remainder:03}"
+    );
+    ExitCode::SUCCESS
+}
+
+fn old_finalize(
+    store: &LocalObjectStore,
+    stage: &Path,
+    key: &ObjectKey,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let bytes = fs::read(stage)?;
+    let _sha256 = hex::encode(Sha256::digest(&bytes));
+    let integrity = ObjectIntegrity::new(
+        ShardlineHash::from_bytes(*blake3::hash(&bytes).as_bytes()),
+        u64::try_from(bytes.len())?,
+    );
+    let _stored = store.put_if_absent(key, ObjectBody::from_vec(bytes), &integrity)?;
+    Ok(())
+}
+
+fn new_finalize(
+    store: &LocalObjectStore,
+    stage: &Path,
+    key: &ObjectKey,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_sha256, integrity) = stream_file_integrity(stage)?;
+    let _stored = store.put_temporary_file_if_absent(key, stage, &integrity)?;
+    Ok(())
+}
+
+fn stream_file_integrity(
+    path: &Path,
+) -> Result<(String, ObjectIntegrity), Box<dyn std::error::Error>> {
+    let mut file = fs::File::open(path)?;
+    let mut sha256 = Sha256::new();
+    let mut blake3 = Blake3Hasher::new();
+    let mut buffer = [0_u8; 256 * 1024];
+    let mut total_length = 0_u64;
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        let slice = buffer
+            .get(..read)
+            .ok_or("integrity buffer read exceeded allocated capacity")?;
+        sha256.update(slice);
+        blake3.update(slice);
+        total_length = total_length
+            .checked_add(u64::try_from(read)?)
+            .ok_or("overflow while summing file bytes")?;
+    }
+    let sha256_hex = hex::encode(sha256.finalize());
+    let blake3_hash = ShardlineHash::from_bytes(*blake3.finalize().as_bytes());
+    Ok((sha256_hex, ObjectIntegrity::new(blake3_hash, total_length)))
+}

--- a/crates/server/benches/oci_tags.rs
+++ b/crates/server/benches/oci_tags.rs
@@ -1,0 +1,173 @@
+use std::{hint::black_box, process::abort};
+
+use blake3::hash as blake3_hash;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use shardline_protocol::ShardlineHash;
+use shardline_storage::{
+    LocalObjectStore, ObjectBody, ObjectIntegrity, ObjectKey, ObjectMetadata, ObjectPrefix,
+    ObjectStore,
+};
+use tempfile::TempDir;
+
+const OCI_TAG_COUNT: usize = 50_000;
+const OCI_TAG_PAGE_SIZE: usize = 128;
+const OCI_TAG_DEEP_OFFSET: usize = 49_000;
+
+struct OciTagFixture {
+    _storage: TempDir,
+    prefix: ObjectPrefix,
+    store: LocalObjectStore,
+    tags: Vec<String>,
+}
+
+impl OciTagFixture {
+    fn new(tag_count: usize) -> Result<Self, Box<dyn std::error::Error>> {
+        let storage = tempfile::tempdir()?;
+        let store = LocalObjectStore::new(storage.path().to_path_buf())?;
+        let prefix = ObjectPrefix::parse("protocols/oci/global/repos/fixture/tags/")?;
+        let digest = b"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let integrity = ObjectIntegrity::new(
+            ShardlineHash::from_bytes(*blake3_hash(digest).as_bytes()),
+            u64::try_from(digest.len())?,
+        );
+        let mut tags = Vec::with_capacity(tag_count);
+        for index in 0..tag_count {
+            let tag = format!("tag-{index:06}");
+            let key = ObjectKey::parse(&format!("{}{}", prefix.as_str(), tag))?;
+            let _stored = store.put_if_absent(&key, ObjectBody::from_slice(digest), &integrity)?;
+            tags.push(tag);
+        }
+        Ok(Self {
+            _storage: storage,
+            prefix,
+            store,
+            tags,
+        })
+    }
+}
+
+fn oci_tag_benchmarks(criterion: &mut Criterion) {
+    let fixture = must(
+        OciTagFixture::new(OCI_TAG_COUNT),
+        "oci tag benchmark fixture should initialize",
+    );
+    let deep_last = fixture.tags.get(OCI_TAG_DEEP_OFFSET).cloned();
+    let first_last = fixture.tags.get(OCI_TAG_PAGE_SIZE).cloned();
+
+    let mut group = criterion.benchmark_group("shardline_server_oci_tags");
+    group.sample_size(20);
+
+    for (name, last) in [
+        ("first_page", None),
+        ("mid_page", first_last.as_deref()),
+        ("deep_page", deep_last.as_deref()),
+    ] {
+        group.bench_with_input(
+            BenchmarkId::new("old_full_scan", name),
+            &last,
+            |bench, last| {
+                bench.iter(|| {
+                    black_box(old_full_scan_page(
+                        &fixture.store,
+                        &fixture.prefix,
+                        OCI_TAG_PAGE_SIZE,
+                        *last,
+                    ))
+                });
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("new_flat_namespace", name),
+            &last,
+            |bench, last| {
+                bench.iter(|| {
+                    black_box(new_flat_namespace_page(
+                        &fixture.store,
+                        &fixture.prefix,
+                        OCI_TAG_PAGE_SIZE,
+                        *last,
+                    ))
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn old_full_scan_page(
+    store: &LocalObjectStore,
+    prefix: &ObjectPrefix,
+    page_size: usize,
+    last: Option<&str>,
+) -> Vec<String> {
+    let mut tags = std::collections::BTreeSet::new();
+    let mut has_more = false;
+    if let Err(error) = store.visit_prefix(prefix, |object: ObjectMetadata| {
+        let Some(tag) = object.key().as_str().rsplit('/').next() else {
+            return Ok::<(), shardline_storage::LocalObjectStoreError>(());
+        };
+        if last.is_some_and(|last| tag <= last) {
+            return Ok(());
+        }
+        let _inserted = tags.insert(tag.to_owned());
+        if tags.len() > page_size {
+            let _removed = tags.pop_last();
+            has_more = true;
+        }
+        Ok(())
+    }) {
+        abort_with_error("old full-scan tag page benchmark failed", &error);
+    }
+    let tags = tags.into_iter().collect::<Vec<_>>();
+    black_box(has_more);
+    tags
+}
+
+fn new_flat_namespace_page(
+    store: &LocalObjectStore,
+    prefix: &ObjectPrefix,
+    page_size: usize,
+    last: Option<&str>,
+) -> Vec<String> {
+    let start_after = last.map(|last| {
+        must(
+            ObjectKey::parse(&format!("{}{}", prefix.as_str(), last)),
+            "benchmark start-after key should parse",
+        )
+    });
+    let page = must(
+        store.list_flat_namespace_page(prefix, start_after.as_ref(), page_size.saturating_add(1)),
+        "new flat-namespace tag page benchmark failed",
+    );
+    let mut tags = page
+        .into_iter()
+        .filter_map(|object| {
+            object
+                .key()
+                .as_str()
+                .rsplit('/')
+                .next()
+                .map(ToOwned::to_owned)
+        })
+        .collect::<Vec<_>>();
+    let has_more = tags.len() > page_size;
+    tags.truncate(page_size);
+    black_box(has_more);
+    tags
+}
+
+fn must<T, E: std::fmt::Display>(result: Result<T, E>, context: &str) -> T {
+    match result {
+        Ok(value) => value,
+        Err(error) => abort_with_error(context, &error),
+    }
+}
+
+fn abort_with_error(context: &str, error: &dyn std::fmt::Display) -> ! {
+    eprintln!("{context}: {error}");
+    abort();
+}
+
+criterion_group!(benches, oci_tag_benchmarks);
+criterion_main!(benches);

--- a/crates/server/benches/oci_tags_fixed.rs
+++ b/crates/server/benches/oci_tags_fixed.rs
@@ -1,0 +1,178 @@
+use std::{hint::black_box, process::ExitCode, time::Instant};
+
+use blake3::hash as blake3_hash;
+use shardline_protocol::ShardlineHash;
+use shardline_storage::{
+    LocalObjectStore, ObjectBody, ObjectIntegrity, ObjectKey, ObjectMetadata, ObjectPrefix,
+    ObjectStore,
+};
+use tempfile::TempDir;
+
+const OCI_TAG_COUNT: usize = 50_000;
+const OCI_TAG_PAGE_SIZE: usize = 128;
+const OCI_TAG_DEEP_OFFSET: usize = 49_000;
+const DEFAULT_ITERATIONS: usize = 200;
+
+struct OciTagFixture {
+    _storage: TempDir,
+    prefix: ObjectPrefix,
+    store: LocalObjectStore,
+    deep_last: Option<String>,
+}
+
+impl OciTagFixture {
+    fn new(tag_count: usize) -> Result<Self, Box<dyn std::error::Error>> {
+        let storage = tempfile::tempdir()?;
+        let store = LocalObjectStore::new(storage.path().to_path_buf())?;
+        let prefix = ObjectPrefix::parse("protocols/oci/global/repos/fixture/tags/")?;
+        let digest = b"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let integrity = ObjectIntegrity::new(
+            ShardlineHash::from_bytes(*blake3_hash(digest).as_bytes()),
+            u64::try_from(digest.len())?,
+        );
+        let mut deep_last = None;
+        for index in 0..tag_count {
+            let tag = format!("tag-{index:06}");
+            let key = ObjectKey::parse(&format!("{}{}", prefix.as_str(), tag))?;
+            let _stored = store.put_if_absent(&key, ObjectBody::from_slice(digest), &integrity)?;
+            if index == OCI_TAG_DEEP_OFFSET {
+                deep_last = Some(tag);
+            }
+        }
+        Ok(Self {
+            _storage: storage,
+            prefix,
+            store,
+            deep_last,
+        })
+    }
+}
+
+fn main() -> ExitCode {
+    let mut mode = "new";
+    let mut iterations = DEFAULT_ITERATIONS;
+    let mut args = std::env::args().skip(1);
+    while let Some(argument) = args.next() {
+        match argument.as_str() {
+            "old" | "new" => mode = Box::leak(argument.into_boxed_str()),
+            "--bench" => {}
+            "--iterations" => {
+                let Some(value) = args.next() else {
+                    eprintln!("missing value for --iterations");
+                    return ExitCode::FAILURE;
+                };
+                match value.parse::<usize>() {
+                    Ok(parsed) if parsed > 0 => iterations = parsed,
+                    Ok(_) | Err(_) => {
+                        eprintln!("invalid --iterations value: {value}");
+                        return ExitCode::FAILURE;
+                    }
+                }
+            }
+            _ => {
+                eprintln!(
+                    "usage: cargo bench --bench oci_tags_fixed -- [old|new] [--iterations N]"
+                );
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+
+    let fixture = match OciTagFixture::new(OCI_TAG_COUNT) {
+        Ok(fixture) => fixture,
+        Err(error) => {
+            eprintln!("fixture setup failed: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let Some(last) = fixture.deep_last.as_deref() else {
+        eprintln!("missing deep-page marker");
+        return ExitCode::FAILURE;
+    };
+
+    let start = Instant::now();
+    for _ in 0..iterations {
+        let page = match mode {
+            "old" => old_full_scan_page(&fixture.store, &fixture.prefix, OCI_TAG_PAGE_SIZE, last),
+            "new" => {
+                new_flat_namespace_page(&fixture.store, &fixture.prefix, OCI_TAG_PAGE_SIZE, last)
+            }
+            invalid => {
+                eprintln!("unsupported mode: {invalid}");
+                return ExitCode::FAILURE;
+            }
+        };
+        black_box(page);
+    }
+    let elapsed = start.elapsed();
+    let elapsed_ms = elapsed.as_millis();
+    let elapsed_micros_remainder = elapsed.subsec_micros() % 1000;
+    println!(
+        "mode={mode} iterations={iterations} elapsed_ms={elapsed_ms}.{elapsed_micros_remainder:03}"
+    );
+    ExitCode::SUCCESS
+}
+
+fn old_full_scan_page(
+    store: &LocalObjectStore,
+    prefix: &ObjectPrefix,
+    page_size: usize,
+    last: &str,
+) -> Vec<String> {
+    let mut tags = std::collections::BTreeSet::new();
+    let mut has_more = false;
+    if let Err(error) = store.visit_prefix(prefix, |object: ObjectMetadata| {
+        let Some(tag) = object.key().as_str().rsplit('/').next() else {
+            return Ok::<(), shardline_storage::LocalObjectStoreError>(());
+        };
+        if tag <= last {
+            return Ok(());
+        }
+        let _inserted = tags.insert(tag.to_owned());
+        if tags.len() > page_size {
+            let _removed = tags.pop_last();
+            has_more = true;
+        }
+        Ok(())
+    }) {
+        eprintln!("old_full_scan_page failed: {error}");
+        std::process::abort();
+    }
+    let tags = tags.into_iter().collect::<Vec<_>>();
+    black_box(has_more);
+    tags
+}
+
+fn new_flat_namespace_page(
+    store: &LocalObjectStore,
+    prefix: &ObjectPrefix,
+    page_size: usize,
+    last: &str,
+) -> Vec<String> {
+    let start_after =
+        ObjectKey::parse(&format!("{}{}", prefix.as_str(), last)).unwrap_or_else(|error| {
+            eprintln!("start-after key parse failed: {error}");
+            std::process::abort();
+        });
+    let page = store
+        .list_flat_namespace_page(prefix, Some(&start_after), page_size.saturating_add(1))
+        .unwrap_or_else(|error| {
+            eprintln!("new_flat_namespace_page failed: {error}");
+            std::process::abort();
+        });
+    let mut tags = page
+        .into_iter()
+        .filter_map(|object| {
+            object
+                .key()
+                .as_str()
+                .rsplit('/')
+                .next()
+                .map(ToOwned::to_owned)
+        })
+        .collect::<Vec<_>>();
+    let has_more = tags.len() > page_size;
+    tags.truncate(page_size);
+    black_box(has_more);
+    tags
+}

--- a/crates/server/src/app.rs
+++ b/crates/server/src/app.rs
@@ -1,10 +1,17 @@
 mod operational;
+mod protocol_routes;
 mod provider;
 mod provider_routes;
 mod reconstruction_helpers;
 mod reconstruction_routes;
 
-use std::{num::NonZeroUsize, sync::Arc};
+use std::{
+    num::NonZeroUsize,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 
 use axum::{
     Router,
@@ -17,6 +24,7 @@ use shardline_protocol::{RepositoryScope, TokenScope};
 use tokio::net::TcpListener;
 #[cfg(test)]
 use tokio::sync::OwnedSemaphorePermit;
+use tokio::sync::Semaphore;
 
 use crate::{
     ServerConfig, ServerError,
@@ -33,6 +41,12 @@ use operational::{
     head_xorb, health, metrics, read_chunk, read_xorb_transfer, ready, stats, upload_shard,
     upload_xorb,
 };
+use protocol_routes::{
+    bazel_get_ac, bazel_get_cas, bazel_put_ac, bazel_put_cas, lfs_batch, lfs_get_object,
+    lfs_head_object, lfs_put_object, oci_api_dispatch, oci_dispatch, oci_registry_token,
+    oci_transfer_dispatch, oci_v2_root,
+};
+pub(crate) use protocol_routes::{parse_oci_path, parse_upload_content_range};
 #[cfg(test)]
 use provider::{
     extract_provider_subject, latest_lifecycle_signal_at, reconciled_provider_repository_state,
@@ -48,13 +62,17 @@ use reconstruction_routes::{batch_reconstruction, reconstruction, reconstruction
 
 const MAX_BATCH_RECONSTRUCTION_FILE_IDS: usize = 1024;
 const MAX_BATCH_RECONSTRUCTION_QUERY_BYTES: usize = 131_072;
+const MAX_LFS_BATCH_OBJECTS: usize = 1024;
+const MAX_OCI_MANIFEST_TAGS: usize = 128;
+const MAX_OCI_TAG_LIST_PAGE_SIZE: usize = 256;
+const MAX_PROTOCOL_QUERY_BYTES: usize = 16_384;
 const MAX_PROVIDER_TOKEN_REQUEST_BODY_BYTES: usize = 16_384;
 const MAX_PROVIDER_WEBHOOK_BODY_BYTES: usize = 1_048_576;
 const MAX_PROVIDER_NAME_BYTES: usize = 64;
 const MAX_PROVIDER_SUBJECT_BYTES: usize = 512;
 const MAX_PROVIDER_BASIC_AUTH_HEADER_BYTES: usize = 4096;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct AppState {
     config: ServerConfig,
     role: ServerRole,
@@ -63,6 +81,49 @@ struct AppState {
     provider_tokens: Option<ProviderTokenService>,
     reconstruction_cache: ReconstructionCacheService,
     transfer_limiter: TransferLimiter,
+    oci_registry_token_limiter: Arc<Semaphore>,
+    protocol_metrics: ProtocolMetrics,
+}
+
+#[derive(Debug, Default)]
+struct ProtocolMetrics {
+    oci_registry_token_requests_total: AtomicU64,
+    oci_registry_token_rate_limited_total: AtomicU64,
+    oci_registry_token_active_requests: AtomicU64,
+}
+
+impl ProtocolMetrics {
+    fn increment_oci_registry_token_requests(&self) {
+        let _previous = self
+            .oci_registry_token_requests_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn increment_oci_registry_token_rate_limited(&self) {
+        let _previous = self
+            .oci_registry_token_rate_limited_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn begin_oci_registry_token_request(&self) -> ActiveProtocolRequestGuard<'_> {
+        let _previous = self
+            .oci_registry_token_active_requests
+            .fetch_add(1, Ordering::Relaxed);
+        ActiveProtocolRequestGuard {
+            gauge: &self.oci_registry_token_active_requests,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ActiveProtocolRequestGuard<'metric> {
+    gauge: &'metric AtomicU64,
+}
+
+impl Drop for ActiveProtocolRequestGuard<'_> {
+    fn drop(&mut self) {
+        let _previous = self.gauge.fetch_sub(1, Ordering::Relaxed);
+    }
 }
 
 /// Builds the Shardline HTTP router.
@@ -118,6 +179,9 @@ pub async fn router(config: ServerConfig) -> Result<Router, ServerError> {
     };
     let transfer_limiter =
         TransferLimiter::new(config.chunk_size(), config.transfer_max_in_flight_chunks());
+    let oci_registry_token_limiter = Arc::new(Semaphore::new(
+        config.oci_registry_token_max_in_flight_requests().get(),
+    ));
     let state = Arc::new(AppState {
         config,
         role,
@@ -126,6 +190,8 @@ pub async fn router(config: ServerConfig) -> Result<Router, ServerError> {
         provider_tokens,
         reconstruction_cache,
         transfer_limiter,
+        oci_registry_token_limiter,
+        protocol_metrics: ProtocolMetrics::default(),
     });
 
     let mut app = Router::new()
@@ -191,6 +257,9 @@ fn register_frontend_routes(
 ) -> Router<Arc<AppState>> {
     match frontend {
         ServerFrontend::Xet => register_xet_routes(app, role),
+        ServerFrontend::Lfs => register_lfs_routes(app, role),
+        ServerFrontend::BazelHttp => register_bazel_routes(app, role),
+        ServerFrontend::Oci => register_oci_routes(app, role),
     }
 }
 
@@ -215,6 +284,60 @@ fn register_xet_routes(mut app: Router<Arc<AppState>>, role: ServerRole) -> Rout
                 head(head_xorb).post(upload_xorb),
             )
             .route(XORB_TRANSFER_ROUTE, get(read_xorb_transfer));
+    }
+    app
+}
+
+fn register_lfs_routes(mut app: Router<Arc<AppState>>, role: ServerRole) -> Router<Arc<AppState>> {
+    if role.serves_api() {
+        app = app.route("/v1/lfs/objects/batch", post(lfs_batch));
+    }
+    if role.serves_transfer() {
+        app = app.route(
+            "/v1/lfs/objects/{oid}",
+            get(lfs_get_object)
+                .head(lfs_head_object)
+                .put(lfs_put_object),
+        );
+    }
+    app
+}
+
+fn register_bazel_routes(
+    mut app: Router<Arc<AppState>>,
+    role: ServerRole,
+) -> Router<Arc<AppState>> {
+    if role.serves_transfer() {
+        app = app
+            .route(
+                "/v1/bazel/cache/ac/{hash}",
+                get(bazel_get_ac).put(bazel_put_ac),
+            )
+            .route(
+                "/v1/bazel/cache/cas/{hash}",
+                get(bazel_get_cas).put(bazel_put_cas),
+            );
+    }
+    app
+}
+
+fn register_oci_routes(mut app: Router<Arc<AppState>>, role: ServerRole) -> Router<Arc<AppState>> {
+    match role {
+        ServerRole::All => {
+            app = app
+                .route("/v2/token", get(oci_registry_token))
+                .route("/v2/", get(oci_v2_root))
+                .route("/v2/{*path}", axum::routing::any(oci_dispatch));
+        }
+        ServerRole::Api => {
+            app = app
+                .route("/v2/token", get(oci_registry_token))
+                .route("/v2/", get(oci_v2_root))
+                .route("/v2/{*path}", axum::routing::any(oci_api_dispatch));
+        }
+        ServerRole::Transfer => {
+            app = app.route("/v2/{*path}", axum::routing::any(oci_transfer_dispatch));
+        }
     }
     app
 }

--- a/crates/server/src/app/operational.rs
+++ b/crates/server/src/app/operational.rs
@@ -190,6 +190,18 @@ pub(super) async fn metrics(
     let auth_enabled = state.auth.is_some();
     let provider_tokens_enabled = state.provider_tokens.is_some();
     let metrics_auth_enabled = state.config.metrics_token().is_some();
+    let oci_registry_token_requests_total = state
+        .protocol_metrics
+        .oci_registry_token_requests_total
+        .load(std::sync::atomic::Ordering::Relaxed);
+    let oci_registry_token_rate_limited_total = state
+        .protocol_metrics
+        .oci_registry_token_rate_limited_total
+        .load(std::sync::atomic::Ordering::Relaxed);
+    let oci_registry_token_active_requests = state
+        .protocol_metrics
+        .oci_registry_token_active_requests
+        .load(std::sync::atomic::Ordering::Relaxed);
     let frontend_labels = state
         .config
         .server_frontends()
@@ -225,7 +237,22 @@ pub(super) async fn metrics(
             "shardline_upload_max_in_flight_chunks {}\n",
             "# HELP shardline_transfer_max_in_flight_chunks Configured transfer chunk parallelism.\n",
             "# TYPE shardline_transfer_max_in_flight_chunks gauge\n",
-            "shardline_transfer_max_in_flight_chunks {}\n"
+            "shardline_transfer_max_in_flight_chunks {}\n",
+            "# HELP shardline_oci_registry_token_ttl_seconds Configured OCI registry token TTL in seconds.\n",
+            "# TYPE shardline_oci_registry_token_ttl_seconds gauge\n",
+            "shardline_oci_registry_token_ttl_seconds {}\n",
+            "# HELP shardline_oci_registry_token_max_in_flight_requests Configured OCI registry token concurrency limit.\n",
+            "# TYPE shardline_oci_registry_token_max_in_flight_requests gauge\n",
+            "shardline_oci_registry_token_max_in_flight_requests {}\n",
+            "# HELP shardline_oci_registry_token_requests_total Total OCI registry token requests.\n",
+            "# TYPE shardline_oci_registry_token_requests_total counter\n",
+            "shardline_oci_registry_token_requests_total {}\n",
+            "# HELP shardline_oci_registry_token_rate_limited_total Total OCI registry token requests rejected by the in-flight limit.\n",
+            "# TYPE shardline_oci_registry_token_rate_limited_total counter\n",
+            "shardline_oci_registry_token_rate_limited_total {}\n",
+            "# HELP shardline_oci_registry_token_active_requests Current in-flight OCI registry token requests.\n",
+            "# TYPE shardline_oci_registry_token_active_requests gauge\n",
+            "shardline_oci_registry_token_active_requests {}\n"
         ),
         state.role.as_str(),
         frontend_labels,
@@ -239,6 +266,14 @@ pub(super) async fn metrics(
         state.config.max_request_body_bytes().get(),
         state.config.upload_max_in_flight_chunks().get(),
         state.config.transfer_max_in_flight_chunks().get(),
+        state.config.oci_registry_token_ttl_seconds().get(),
+        state
+            .config
+            .oci_registry_token_max_in_flight_requests()
+            .get(),
+        oci_registry_token_requests_total,
+        oci_registry_token_rate_limited_total,
+        oci_registry_token_active_requests,
     );
 
     Ok((

--- a/crates/server/src/app/protocol_routes.rs
+++ b/crates/server/src/app/protocol_routes.rs
@@ -1,0 +1,1846 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Write,
+    sync::Arc,
+};
+
+use axum::{
+    Json,
+    body::Body,
+    extract::{Path, State},
+    http::{
+        HeaderMap, HeaderValue, Method, StatusCode, Uri,
+        header::{
+            ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, LINK, LOCATION,
+            RANGE,
+        },
+    },
+    response::{IntoResponse, Response},
+};
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use shardline_protocol::{ByteRange, TokenClaims, TokenScope, TokenSigner, parse_http_byte_range};
+use shardline_storage::DeleteOutcome;
+
+use crate::{
+    ServerError,
+    bazel_http_adapter::{BazelCacheKind, bazel_cache_object_key},
+    lfs_adapter::{
+        LFS_CONTENT_TYPE, LfsBatchRequest, LfsBatchResponse, LfsObjectError, LfsObjectResponse,
+        lfs_object_key,
+    },
+    oci_adapter::{
+        OciReference, append_upload_bytes, create_upload_session, delete_upload_session,
+        lock_upload_sessions, oci_blob_key, oci_blob_location, oci_manifest_key,
+        oci_manifest_location, oci_manifest_media_type_key, oci_tag_key, oci_tag_prefix,
+        oci_tag_target_key, oci_tag_target_prefix, parse_reference, read_upload_session,
+        touch_upload_session, upload_body_integrity, upload_body_path_for_session, upload_length,
+        upload_session_location, validate_repository,
+    },
+    protocol_support::{parse_sha256_digest, scope_namespace, validate_oci_repository_scope},
+    upload_ingest::{RequestBodyReader, read_body_to_bytes},
+};
+
+use super::{
+    AppState, MAX_LFS_BATCH_OBJECTS, MAX_OCI_MANIFEST_TAGS, MAX_OCI_TAG_LIST_PAGE_SIZE,
+    MAX_PROTOCOL_QUERY_BYTES, authorize,
+    reconstruction_helpers::{byte_range_stream_response, full_byte_stream_response},
+    scope_from_auth,
+};
+
+const OCI_IMAGE_MANIFEST_MEDIA_TYPE: &str = "application/vnd.oci.image.manifest.v1+json";
+const OCI_IMAGE_INDEX_MEDIA_TYPE: &str = "application/vnd.oci.image.index.v1+json";
+const DOCKER_SCHEMA2_MANIFEST_MEDIA_TYPE: &str =
+    "application/vnd.docker.distribution.manifest.v2+json";
+const DOCKER_SCHEMA2_MANIFEST_LIST_MEDIA_TYPE: &str =
+    "application/vnd.docker.distribution.manifest.list.v2+json";
+const OCI_REGISTRY_SERVICE: &str = "shardline";
+const MAX_OCI_TOKEN_BASIC_AUTH_BYTES: usize = 8192;
+const MAX_OCI_TOKEN_QUERY_SERVICE_BYTES: usize = 128;
+const MAX_OCI_TOKEN_QUERY_SCOPE_BYTES: usize = 1024;
+const MAX_OCI_TOKEN_QUERY_ACCOUNT_BYTES: usize = 512;
+const MAX_OCI_TOKEN_QUERY_SCOPES: usize = 16;
+
+pub(super) async fn bazel_get_ac(
+    State(state): State<Arc<AppState>>,
+    Path(hash): Path<String>,
+    headers: HeaderMap,
+) -> Result<Response, ServerError> {
+    let auth = authorize(&state, &headers, TokenScope::Read)?;
+    let object_key = bazel_cache_object_key(
+        BazelCacheKind::Ac,
+        &hash,
+        auth.as_ref().map(scope_from_auth),
+    )?;
+    direct_object_response(
+        &state,
+        &headers,
+        &object_key,
+        "application/octet-stream",
+        None,
+    )
+    .await
+}
+
+pub(super) async fn bazel_put_ac(
+    State(state): State<Arc<AppState>>,
+    Path(hash): Path<String>,
+    headers: HeaderMap,
+    body: Body,
+) -> Result<impl IntoResponse, ServerError> {
+    let auth = authorize(&state, &headers, TokenScope::Write)?;
+    let object_key = bazel_cache_object_key(
+        BazelCacheKind::Ac,
+        &hash,
+        auth.as_ref().map(scope_from_auth),
+    )?;
+    let mut body = RequestBodyReader::from_body(body, state.config.max_request_body_bytes())?;
+    let bytes = read_body_to_bytes(&mut body).await?;
+    let _stored = state
+        .backend
+        .put_object_bytes_if_absent(&object_key, bytes)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub(super) async fn bazel_get_cas(
+    State(state): State<Arc<AppState>>,
+    Path(hash): Path<String>,
+    headers: HeaderMap,
+) -> Result<Response, ServerError> {
+    let auth = authorize(&state, &headers, TokenScope::Read)?;
+    let object_key = bazel_cache_object_key(
+        BazelCacheKind::Cas,
+        &hash,
+        auth.as_ref().map(scope_from_auth),
+    )?;
+    direct_object_response(
+        &state,
+        &headers,
+        &object_key,
+        "application/octet-stream",
+        None,
+    )
+    .await
+}
+
+pub(super) async fn bazel_put_cas(
+    State(state): State<Arc<AppState>>,
+    Path(hash): Path<String>,
+    headers: HeaderMap,
+    body: Body,
+) -> Result<impl IntoResponse, ServerError> {
+    let auth = authorize(&state, &headers, TokenScope::Write)?;
+    let object_key = bazel_cache_object_key(
+        BazelCacheKind::Cas,
+        &hash,
+        auth.as_ref().map(scope_from_auth),
+    )?;
+    let mut body = RequestBodyReader::from_body(body, state.config.max_request_body_bytes())?;
+    let bytes = read_body_to_bytes(&mut body).await?;
+    let observed = hex::encode(Sha256::digest(&bytes));
+    if observed != hash {
+        return Err(ServerError::ExpectedBodyHashMismatch);
+    }
+    let _stored = state
+        .backend
+        .put_object_bytes_if_absent(&object_key, bytes)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub(super) async fn lfs_batch(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(request): Json<LfsBatchRequest>,
+) -> Result<Response, ServerError> {
+    let requested_scope = match request.operation.as_str() {
+        "download" => TokenScope::Read,
+        "upload" => TokenScope::Write,
+        _ => return Err(ServerError::InvalidManifestReference),
+    };
+    let auth = authorize(&state, &headers, requested_scope)?;
+    if request.objects.len() > MAX_LFS_BATCH_OBJECTS {
+        return Ok((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            [(CONTENT_TYPE, LFS_CONTENT_TYPE)],
+            Json(json!({ "message": "too many objects in batch request" })),
+        )
+            .into_response());
+    }
+    if let Some(hash_algo) = request.hash_algo.as_deref()
+        && hash_algo != "sha256"
+    {
+        return Ok((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            [(CONTENT_TYPE, LFS_CONTENT_TYPE)],
+            Json(json!({ "message": "unsupported hash algorithm" })),
+        )
+            .into_response());
+    }
+
+    let scope = auth.as_ref().map(scope_from_auth);
+    let transfer = if request.transfers.is_empty()
+        || request.transfers.iter().any(|transfer| transfer == "basic")
+    {
+        "basic".to_owned()
+    } else {
+        return Ok((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            [(CONTENT_TYPE, LFS_CONTENT_TYPE)],
+            Json(json!({ "message": "unsupported transfer adapter" })),
+        )
+            .into_response());
+    };
+    let mut objects = Vec::with_capacity(request.objects.len());
+    for object in request.objects {
+        let object_key = lfs_object_key(&object.oid, scope)?;
+        let object_length = state.backend.object_length(&object_key).await;
+        match request.operation.as_str() {
+            "download" => match object_length {
+                Ok(length) => {
+                    let actions = json!({
+                        "download": {
+                            "href": format!(
+                                "{}/v1/lfs/objects/{}",
+                                state.config.public_base_url().trim_end_matches('/'),
+                                object.oid
+                            )
+                        }
+                    });
+                    objects.push(LfsObjectResponse {
+                        oid: object.oid,
+                        size: length,
+                        authenticated: Some(auth.is_some()),
+                        actions: Some(actions),
+                        error: None,
+                    });
+                }
+                Err(ServerError::NotFound) => objects.push(LfsObjectResponse {
+                    oid: object.oid,
+                    size: object.size,
+                    authenticated: None,
+                    actions: None,
+                    error: Some(LfsObjectError {
+                        code: 404,
+                        message: "Object does not exist".to_owned(),
+                    }),
+                }),
+                Err(error) => return Err(error),
+            },
+            "upload" => {
+                let (size, actions) = match object_length {
+                    Ok(length) => (length, None),
+                    Err(ServerError::NotFound) => (
+                        object.size,
+                        Some(json!({
+                            "upload": {
+                                "href": format!(
+                                    "{}/v1/lfs/objects/{}",
+                                    state.config.public_base_url().trim_end_matches('/'),
+                                    object.oid
+                                )
+                            }
+                        })),
+                    ),
+                    Err(error) => return Err(error),
+                };
+                objects.push(LfsObjectResponse {
+                    oid: object.oid,
+                    size,
+                    authenticated: Some(auth.is_some()),
+                    actions,
+                    error: None,
+                });
+            }
+            _ => return Err(ServerError::InvalidManifestReference),
+        }
+    }
+
+    Ok((
+        StatusCode::OK,
+        [(CONTENT_TYPE, LFS_CONTENT_TYPE)],
+        Json(LfsBatchResponse {
+            transfer,
+            objects,
+            hash_algo: "sha256",
+        }),
+    )
+        .into_response())
+}
+
+pub(super) async fn lfs_get_object(
+    State(state): State<Arc<AppState>>,
+    Path(oid): Path<String>,
+    headers: HeaderMap,
+) -> Result<Response, ServerError> {
+    let auth = authorize(&state, &headers, TokenScope::Read)?;
+    let object_key = lfs_object_key(&oid, auth.as_ref().map(scope_from_auth))?;
+    direct_object_response(
+        &state,
+        &headers,
+        &object_key,
+        "application/octet-stream",
+        Some(format!("sha256:{oid}")),
+    )
+    .await
+}
+
+pub(super) async fn lfs_head_object(
+    State(state): State<Arc<AppState>>,
+    Path(oid): Path<String>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, ServerError> {
+    let auth = authorize(&state, &headers, TokenScope::Read)?;
+    let object_key = lfs_object_key(&oid, auth.as_ref().map(scope_from_auth))?;
+    let total_length = state.backend.object_length(&object_key).await?;
+    Ok((StatusCode::OK, [(CONTENT_LENGTH, total_length.to_string())]))
+}
+
+pub(super) async fn lfs_put_object(
+    State(state): State<Arc<AppState>>,
+    Path(oid): Path<String>,
+    headers: HeaderMap,
+    body: Body,
+) -> Result<impl IntoResponse, ServerError> {
+    let auth = authorize(&state, &headers, TokenScope::Write)?;
+    let object_key = lfs_object_key(&oid, auth.as_ref().map(scope_from_auth))?;
+    let mut body = RequestBodyReader::from_body(body, state.config.max_request_body_bytes())?;
+    let bytes = read_body_to_bytes(&mut body).await?;
+    let observed = hex::encode(Sha256::digest(&bytes));
+    if observed != oid {
+        return Err(ServerError::ExpectedBodyHashMismatch);
+    }
+    let _stored = state
+        .backend
+        .put_object_bytes_if_absent(&object_key, bytes)?;
+    Ok(StatusCode::OK)
+}
+
+pub(super) async fn oci_registry_token(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    uri: Uri,
+) -> Result<Json<crate::model::OciRegistryTokenResponse>, ServerError> {
+    state
+        .protocol_metrics
+        .increment_oci_registry_token_requests();
+    let _permit = state
+        .oci_registry_token_limiter
+        .clone()
+        .try_acquire_owned()
+        .map_err(|_error| {
+            state
+                .protocol_metrics
+                .increment_oci_registry_token_rate_limited();
+            ServerError::TooManyRegistryTokenRequests
+        })?;
+    let _active_request = state.protocol_metrics.begin_oci_registry_token_request();
+    let signer = TokenSigner::new(
+        state
+            .config
+            .token_signing_key()
+            .ok_or(ServerError::MissingAuthorization)?,
+    )?;
+    let query = parse_oci_registry_token_query(&uri)?;
+    if let Some(service) = query.service.as_deref()
+        && service != OCI_REGISTRY_SERVICE
+    {
+        return Err(ServerError::InvalidManifestReference);
+    }
+
+    let bootstrap_claims =
+        verify_oci_registry_bootstrap_credentials(&headers, &signer).map_err(|error| {
+            if matches!(
+                error,
+                ServerError::MissingAuthorization
+                    | ServerError::InvalidAuthorizationHeader
+                    | ServerError::InvalidToken(_)
+            ) {
+                ServerError::UnauthorizedChallenge(oci_bearer_challenge(
+                    state.config.public_base_url(),
+                    None,
+                    TokenScope::Read,
+                ))
+            } else {
+                error
+            }
+        })?;
+    let (requested_scope, requested_repository) = parse_oci_registry_token_scopes(&query.scopes)?;
+    if let Some(repository) = requested_repository.as_deref() {
+        validate_oci_repository_scope(repository, Some(bootstrap_claims.repository()))?;
+    }
+    if !scope_allows_oci_exchange(bootstrap_claims.scope(), requested_scope) {
+        return Err(ServerError::InsufficientScope);
+    }
+
+    let now = crate::clock::unix_now_seconds_checked()?;
+    let expires_at_unix_seconds = bootstrap_claims
+        .expires_at_unix_seconds()
+        .min(now.saturating_add(state.config.oci_registry_token_ttl_seconds().get()));
+    let issued_claims = TokenClaims::new(
+        bootstrap_claims.issuer(),
+        bootstrap_claims.subject(),
+        requested_scope.unwrap_or_else(|| bootstrap_claims.scope()),
+        bootstrap_claims.repository().clone(),
+        expires_at_unix_seconds,
+    )
+    .map_err(|_error| ServerError::InvalidProviderTokenRequest)?;
+    let token = signer.sign(&issued_claims)?;
+    Ok(Json(crate::model::OciRegistryTokenResponse {
+        access_token: token.clone(),
+        token,
+        expires_in: issued_claims
+            .expires_at_unix_seconds()
+            .saturating_sub(now)
+            .min(i32::MAX as u64),
+    }))
+}
+
+pub(super) async fn oci_v2_root(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, ServerError> {
+    let _auth = oci_authorize(&state, &headers, None, TokenScope::Read)?;
+    Ok((
+        StatusCode::OK,
+        [("Docker-Distribution-API-Version", "registry/2.0")],
+    ))
+}
+
+pub(super) async fn oci_dispatch(
+    method: Method,
+    State(state): State<Arc<AppState>>,
+    Path(path): Path<String>,
+    headers: HeaderMap,
+    uri: Uri,
+    body: Body,
+) -> Result<Response, ServerError> {
+    let parsed = parse_oci_path(&path)?;
+    oci_dispatch_parsed(&state, method, headers, uri, body, parsed).await
+}
+
+pub(super) async fn oci_api_dispatch(
+    method: Method,
+    State(state): State<Arc<AppState>>,
+    Path(path): Path<String>,
+    headers: HeaderMap,
+    uri: Uri,
+    body: Body,
+) -> Result<Response, ServerError> {
+    let parsed = parse_oci_path(&path)?;
+    if !oci_route_served_by_api(&method, &parsed) {
+        return Err(ServerError::NotFound);
+    }
+    oci_dispatch_parsed(&state, method, headers, uri, body, parsed).await
+}
+
+pub(super) async fn oci_transfer_dispatch(
+    method: Method,
+    State(state): State<Arc<AppState>>,
+    Path(path): Path<String>,
+    headers: HeaderMap,
+    uri: Uri,
+    body: Body,
+) -> Result<Response, ServerError> {
+    let parsed = parse_oci_path(&path)?;
+    if !oci_route_served_by_transfer(&method, &parsed) {
+        return Err(ServerError::NotFound);
+    }
+    oci_dispatch_parsed(&state, method, headers, uri, body, parsed).await
+}
+
+async fn oci_dispatch_parsed(
+    state: &Arc<AppState>,
+    method: Method,
+    headers: HeaderMap,
+    uri: Uri,
+    body: Body,
+    parsed: OciPath,
+) -> Result<Response, ServerError> {
+    match (method, parsed) {
+        (
+            Method::GET,
+            OciPath::Blob {
+                repository,
+                digest_hex,
+            },
+        ) => {
+            let auth = oci_authorize(state, &headers, Some(&repository), TokenScope::Read)?;
+            let object_key =
+                oci_blob_key(&repository, &digest_hex, auth.as_ref().map(scope_from_auth))?;
+            direct_object_response(
+                state,
+                &headers,
+                &object_key,
+                "application/octet-stream",
+                Some(format!("sha256:{digest_hex}")),
+            )
+            .await
+        }
+        (
+            Method::HEAD,
+            OciPath::Blob {
+                repository,
+                digest_hex,
+            },
+        ) => {
+            let auth = oci_authorize(state, &headers, Some(&repository), TokenScope::Read)?;
+            let object_key =
+                oci_blob_key(&repository, &digest_hex, auth.as_ref().map(scope_from_auth))?;
+            let total_length = state.backend.object_length(&object_key).await?;
+            Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header(CONTENT_LENGTH, total_length.to_string())
+                .header("Docker-Content-Digest", format!("sha256:{digest_hex}"))
+                .body(Body::empty())
+                .map_err(|_error| ServerError::Overflow)?)
+        }
+        (
+            Method::GET,
+            OciPath::Manifest {
+                repository,
+                reference,
+            },
+        ) => oci_get_manifest(state, &headers, &repository, &reference, false).await,
+        (
+            Method::HEAD,
+            OciPath::Manifest {
+                repository,
+                reference,
+            },
+        ) => oci_get_manifest(state, &headers, &repository, &reference, true).await,
+        (Method::GET, OciPath::TagsList { repository }) => {
+            oci_tags_list(state, &headers, &uri, &repository).await
+        }
+        (Method::POST, OciPath::BlobUploads { repository }) => {
+            oci_post_blob_upload(state, &headers, &uri, &repository, body).await
+        }
+        (
+            Method::PATCH,
+            OciPath::BlobUploadSession {
+                repository,
+                session_id,
+            },
+        ) => oci_patch_blob_upload(state, &headers, &headers, &repository, &session_id, body).await,
+        (
+            Method::PUT,
+            OciPath::BlobUploadSession {
+                repository,
+                session_id,
+            },
+        ) => oci_put_blob_upload(state, &headers, &uri, &repository, &session_id, body).await,
+        (
+            Method::GET,
+            OciPath::BlobUploadSession {
+                repository,
+                session_id,
+            },
+        ) => oci_get_blob_upload(state, &headers, &repository, &session_id).await,
+        (
+            Method::DELETE,
+            OciPath::BlobUploadSession {
+                repository,
+                session_id,
+            },
+        ) => oci_delete_blob_upload(state, &headers, &repository, &session_id).await,
+        (
+            Method::PUT,
+            OciPath::Manifest {
+                repository,
+                reference,
+            },
+        ) => oci_put_manifest(state, &headers, &uri, &repository, &reference, body).await,
+        (
+            Method::DELETE,
+            OciPath::Manifest {
+                repository,
+                reference,
+            },
+        ) => oci_delete_manifest(state, &headers, &repository, &reference).await,
+        _ => Err(ServerError::NotFound),
+    }
+}
+
+#[allow(clippy::missing_const_for_fn)]
+fn oci_route_served_by_api(method: &Method, path: &OciPath) -> bool {
+    matches!(
+        (method, path),
+        (
+            &Method::GET,
+            OciPath::Manifest { .. } | OciPath::TagsList { .. }
+        ) | (&Method::HEAD, OciPath::Manifest { .. })
+            | (&Method::PUT, OciPath::Manifest { .. })
+            | (&Method::DELETE, OciPath::Manifest { .. })
+    )
+}
+
+#[allow(clippy::missing_const_for_fn)]
+fn oci_route_served_by_transfer(method: &Method, path: &OciPath) -> bool {
+    matches!(
+        (method, path),
+        (
+            &Method::GET,
+            OciPath::Blob { .. } | OciPath::BlobUploadSession { .. }
+        ) | (&Method::HEAD, OciPath::Blob { .. })
+            | (&Method::POST, OciPath::BlobUploads { .. })
+            | (&Method::PATCH, OciPath::BlobUploadSession { .. })
+            | (&Method::PUT, OciPath::BlobUploadSession { .. })
+            | (&Method::DELETE, OciPath::BlobUploadSession { .. })
+    )
+}
+
+async fn oci_get_manifest(
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    repository: &str,
+    reference: &str,
+    head_only: bool,
+) -> Result<Response, ServerError> {
+    let auth = oci_authorize(state, headers, Some(repository), TokenScope::Read)?;
+    let scope = auth.as_ref().map(scope_from_auth);
+    let digest_hex = resolve_manifest_digest(state, repository, reference, scope).await?;
+    let manifest_key = oci_manifest_key(repository, &digest_hex, scope)?;
+    let media_type_key = oci_manifest_media_type_key(repository, &digest_hex, scope)?;
+    let total_length = state.backend.object_length(&manifest_key).await?;
+    let media_type = String::from_utf8(state.backend.read_object(&media_type_key).await?)
+        .map_err(|_error| ServerError::InvalidManifestReference)?;
+    ensure_manifest_representation_is_acceptable(headers, &media_type)?;
+    if head_only {
+        return Response::builder()
+            .status(StatusCode::OK)
+            .header(CONTENT_LENGTH, total_length.to_string())
+            .header(CONTENT_TYPE, media_type)
+            .header("Docker-Content-Digest", format!("sha256:{digest_hex}"))
+            .body(Body::empty())
+            .map_err(|_error| ServerError::Overflow);
+    }
+
+    direct_object_response(
+        state,
+        headers,
+        &manifest_key,
+        &media_type,
+        Some(format!("sha256:{digest_hex}")),
+    )
+    .await
+}
+
+async fn oci_tags_list(
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    uri: &Uri,
+    repository: &str,
+) -> Result<Response, ServerError> {
+    let auth = oci_authorize(state, headers, Some(repository), TokenScope::Read)?;
+    let query = parse_query_map(uri)?;
+    let page_size = parse_oci_tag_list_page_size(query.get("n").map(String::as_str))?;
+    let last = query.get("last").map(String::as_str);
+    if let Some(last) = last {
+        crate::protocol_support::validate_oci_tag(last)?;
+    }
+    let tag_page = list_oci_tags(
+        state,
+        repository,
+        auth.as_ref().map(scope_from_auth),
+        page_size,
+        last,
+    )?;
+    let tags = tag_page.tags;
+    let has_more = tag_page.has_more;
+    let body = serde_json::to_vec(&json!({
+        "name": repository,
+        "tags": tags,
+    }))?;
+    let mut builder = Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "application/json")
+        .header(CONTENT_LENGTH, body.len().to_string());
+    if has_more && let Some(last_tag) = tags.last() {
+        builder = builder.header(
+            LINK,
+            oci_tags_list_next_link(repository, page_size, last_tag)?,
+        );
+    }
+    builder
+        .body(Body::from(body))
+        .map_err(|_error| ServerError::Overflow)
+}
+
+async fn oci_post_blob_upload(
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    uri: &Uri,
+    repository: &str,
+    body: Body,
+) -> Result<Response, ServerError> {
+    let auth = oci_authorize(state, headers, Some(repository), TokenScope::Write)?;
+    let scope = auth.as_ref().map(scope_from_auth);
+    validate_repository(repository)?;
+    let query = parse_query_map(uri)?;
+    if let Some(mount_digest) = query.get("mount") {
+        let digest_hex = parse_sha256_digest(mount_digest)?;
+        let from = query.get("from").map(String::as_str).unwrap_or(repository);
+        let source_key = oci_blob_key(from, &digest_hex, scope)?;
+        let target_key = oci_blob_key(repository, &digest_hex, scope)?;
+        match state
+            .backend
+            .copy_object_if_absent(&source_key, &target_key)
+        {
+            Ok(_stored) => {
+                return oci_created_response(
+                    &oci_blob_location(repository, &digest_hex),
+                    Some(&digest_hex),
+                );
+            }
+            Err(ServerError::NotFound) => {}
+            Err(error) => return Err(error),
+        }
+    }
+
+    if let Some(digest) = query.get("digest") {
+        let digest_hex = parse_sha256_digest(digest)?;
+        let mut body = RequestBodyReader::from_body(body, state.config.max_request_body_bytes())?;
+        let bytes = read_body_to_bytes(&mut body).await?;
+        if !bytes.is_empty() {
+            let observed = hex::encode(Sha256::digest(&bytes));
+            if observed != digest_hex {
+                return Err(ServerError::ExpectedBodyHashMismatch);
+            }
+            let object_key = oci_blob_key(repository, &digest_hex, scope)?;
+            let _stored = state
+                .backend
+                .put_object_bytes_if_absent(&object_key, bytes)?;
+            return oci_created_response(
+                &oci_blob_location(repository, &digest_hex),
+                Some(&digest_hex),
+            );
+        }
+    }
+
+    let session_id = create_upload_session(
+        state.config.root_dir(),
+        repository,
+        scope,
+        state.config.oci_upload_session_ttl_seconds(),
+        state.config.oci_upload_max_active_sessions(),
+    )
+    .await?;
+    Response::builder()
+        .status(StatusCode::ACCEPTED)
+        .header(LOCATION, upload_session_location(repository, &session_id))
+        .header(RANGE, "0-0")
+        .body(Body::empty())
+        .map_err(|_error| ServerError::Overflow)
+}
+
+async fn oci_patch_blob_upload(
+    state: &Arc<AppState>,
+    auth_headers: &HeaderMap,
+    headers: &HeaderMap,
+    repository: &str,
+    session_id: &str,
+    body: Body,
+) -> Result<Response, ServerError> {
+    let auth = oci_authorize(state, auth_headers, Some(repository), TokenScope::Write)?;
+    let scope = auth.as_ref().map(scope_from_auth);
+    validate_oci_repository_scope(repository, scope)?;
+    let mut body = RequestBodyReader::from_body(body, state.config.max_request_body_bytes())?;
+    let bytes = read_body_to_bytes(&mut body).await?;
+    let _lock = lock_upload_sessions(state.config.root_dir()).await?;
+    let session = read_upload_session(
+        state.config.root_dir(),
+        session_id,
+        state.config.oci_upload_session_ttl_seconds(),
+    )
+    .await?;
+    if session.repository != repository || session.scope_namespace != scope_namespace(scope) {
+        return Err(ServerError::NotFound);
+    }
+    let current_length = upload_length(state.config.root_dir(), session_id).await?;
+    if let Some(content_range) = headers.get(CONTENT_RANGE) {
+        let content_range = content_range
+            .to_str()
+            .map_err(|_error| ServerError::InvalidRangeHeader)?;
+        let expected_range = parse_upload_content_range(content_range)?;
+        if expected_range.start() != current_length {
+            return Err(ServerError::RangeNotSatisfiable);
+        }
+        let observed_end = expected_range
+            .start()
+            .checked_add(u64::try_from(bytes.len())?)
+            .and_then(|value| value.checked_sub(1))
+            .ok_or(ServerError::Overflow)?;
+        if observed_end != expected_range.end_inclusive() {
+            return Err(ServerError::RangeNotSatisfiable);
+        }
+    }
+    ensure_upload_growth_within_limit(state, current_length, bytes.len())?;
+    let new_length = append_upload_bytes(state.config.root_dir(), session_id, &bytes).await?;
+    touch_upload_session(state.config.root_dir(), session_id, session).await?;
+    let last = new_length.saturating_sub(1);
+    Response::builder()
+        .status(StatusCode::ACCEPTED)
+        .header(LOCATION, upload_session_location(repository, session_id))
+        .header(RANGE, format!("0-{last}"))
+        .body(Body::empty())
+        .map_err(|_error| ServerError::Overflow)
+}
+
+async fn oci_put_blob_upload(
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    uri: &Uri,
+    repository: &str,
+    session_id: &str,
+    body: Body,
+) -> Result<Response, ServerError> {
+    let auth = oci_authorize(state, headers, Some(repository), TokenScope::Write)?;
+    let scope = auth.as_ref().map(scope_from_auth);
+    validate_oci_repository_scope(repository, scope)?;
+    let query = parse_query_map(uri)?;
+    let digest = query.get("digest").ok_or(ServerError::InvalidDigest)?;
+    let digest_hex = parse_sha256_digest(digest)?;
+    let mut body = RequestBodyReader::from_body(body, state.config.max_request_body_bytes())?;
+    let final_bytes = read_body_to_bytes(&mut body).await?;
+    let _lock = lock_upload_sessions(state.config.root_dir()).await?;
+    let session = read_upload_session(
+        state.config.root_dir(),
+        session_id,
+        state.config.oci_upload_session_ttl_seconds(),
+    )
+    .await?;
+    if session.repository != repository || session.scope_namespace != scope_namespace(scope) {
+        return Err(ServerError::NotFound);
+    }
+    let current_length = upload_length(state.config.root_dir(), session_id).await?;
+    if let Some(content_range) = headers.get(CONTENT_RANGE) {
+        let content_range = content_range
+            .to_str()
+            .map_err(|_error| ServerError::InvalidRangeHeader)?;
+        let expected_range = parse_upload_content_range(content_range)?;
+        if expected_range.start() != current_length {
+            return Err(ServerError::RangeNotSatisfiable);
+        }
+        let observed_end = expected_range
+            .start()
+            .checked_add(u64::try_from(final_bytes.len())?)
+            .and_then(|value| value.checked_sub(1))
+            .ok_or(ServerError::Overflow)?;
+        if observed_end != expected_range.end_inclusive() {
+            return Err(ServerError::RangeNotSatisfiable);
+        }
+    }
+    ensure_upload_growth_within_limit(state, current_length, final_bytes.len())?;
+    if !final_bytes.is_empty() {
+        let _new_length =
+            append_upload_bytes(state.config.root_dir(), session_id, &final_bytes).await?;
+    }
+    let (observed, integrity) = upload_body_integrity(state.config.root_dir(), session_id).await?;
+    if observed != digest_hex {
+        return Err(ServerError::ExpectedBodyHashMismatch);
+    }
+    let object_key = oci_blob_key(repository, &digest_hex, scope)?;
+    let upload_path = upload_body_path_for_session(state.config.root_dir(), session_id)?;
+    let _stored =
+        state
+            .backend
+            .put_content_addressed_object_file(&object_key, &upload_path, &integrity)?;
+    delete_upload_session(state.config.root_dir(), session_id).await?;
+    oci_created_response(
+        &oci_blob_location(repository, &digest_hex),
+        Some(&digest_hex),
+    )
+}
+
+async fn oci_get_blob_upload(
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    repository: &str,
+    session_id: &str,
+) -> Result<Response, ServerError> {
+    let auth = oci_authorize(state, headers, Some(repository), TokenScope::Write)?;
+    let scope = auth.as_ref().map(scope_from_auth);
+    validate_oci_repository_scope(repository, scope)?;
+    let _lock = lock_upload_sessions(state.config.root_dir()).await?;
+    let session = read_upload_session(
+        state.config.root_dir(),
+        session_id,
+        state.config.oci_upload_session_ttl_seconds(),
+    )
+    .await?;
+    if session.repository != repository || session.scope_namespace != scope_namespace(scope) {
+        return Err(ServerError::NotFound);
+    }
+    let length = upload_length(state.config.root_dir(), session_id).await?;
+    touch_upload_session(state.config.root_dir(), session_id, session).await?;
+    let last = length.saturating_sub(1);
+    Response::builder()
+        .status(StatusCode::NO_CONTENT)
+        .header(LOCATION, upload_session_location(repository, session_id))
+        .header(RANGE, format!("0-{last}"))
+        .body(Body::empty())
+        .map_err(|_error| ServerError::Overflow)
+}
+
+async fn oci_delete_blob_upload(
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    repository: &str,
+    session_id: &str,
+) -> Result<Response, ServerError> {
+    let auth = oci_authorize(state, headers, Some(repository), TokenScope::Write)?;
+    let scope = auth.as_ref().map(scope_from_auth);
+    validate_oci_repository_scope(repository, scope)?;
+    let _lock = lock_upload_sessions(state.config.root_dir()).await?;
+    let session = read_upload_session(
+        state.config.root_dir(),
+        session_id,
+        state.config.oci_upload_session_ttl_seconds(),
+    )
+    .await?;
+    if session.repository != repository || session.scope_namespace != scope_namespace(scope) {
+        return Err(ServerError::NotFound);
+    }
+    delete_upload_session(state.config.root_dir(), session_id).await?;
+    Response::builder()
+        .status(StatusCode::NO_CONTENT)
+        .body(Body::empty())
+        .map_err(|_error| ServerError::Overflow)
+}
+
+async fn oci_put_manifest(
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    uri: &Uri,
+    repository: &str,
+    reference: &str,
+    body: Body,
+) -> Result<Response, ServerError> {
+    let auth = oci_authorize(state, headers, Some(repository), TokenScope::Write)?;
+    let scope = auth.as_ref().map(scope_from_auth);
+    let mut body = RequestBodyReader::from_body(body, state.config.max_request_body_bytes())?;
+    let bytes = read_body_to_bytes(&mut body).await?;
+    let digest_hex = hex::encode(Sha256::digest(&bytes));
+    let reference = parse_reference(reference)?;
+    if let OciReference::Digest(reference_digest) = &reference
+        && reference_digest != &digest_hex
+    {
+        return Err(ServerError::ExpectedBodyHashMismatch);
+    }
+    let media_type = headers
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or(OCI_IMAGE_MANIFEST_MEDIA_TYPE)
+        .to_owned();
+    validate_oci_manifest_document(state, repository, scope, &media_type, &bytes).await?;
+    let manifest_key = oci_manifest_key(repository, &digest_hex, scope)?;
+    let media_type_key = oci_manifest_media_type_key(repository, &digest_hex, scope)?;
+    let _stored_manifest = state
+        .backend
+        .put_object_bytes_if_absent(&manifest_key, bytes)?;
+    let _stored_media_type = state
+        .backend
+        .put_object_bytes_if_absent(&media_type_key, media_type.clone().into_bytes())?;
+    let mut accepted_tags = match reference {
+        OciReference::Tag(tag) => vec![tag],
+        OciReference::Digest(_) => Vec::new(),
+    };
+    accepted_tags.extend(parse_query_values(uri, "tag")?);
+    if accepted_tags.len() > MAX_OCI_MANIFEST_TAGS {
+        return Err(ServerError::InvalidManifestReference);
+    }
+    accepted_tags.sort();
+    accepted_tags.dedup();
+    if !accepted_tags.is_empty() {
+        update_oci_tags(state, repository, scope, &accepted_tags, &digest_hex).await?;
+    }
+
+    let mut builder = Response::builder()
+        .status(StatusCode::CREATED)
+        .header(LOCATION, oci_manifest_location(repository, &digest_hex))
+        .header("Docker-Content-Digest", format!("sha256:{digest_hex}"));
+    if !accepted_tags.is_empty() {
+        let joined = accepted_tags.join(", ");
+        builder = builder.header("OCI-Tag", joined);
+    }
+    builder
+        .body(Body::empty())
+        .map_err(|_error| ServerError::Overflow)
+}
+
+async fn oci_delete_manifest(
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    repository: &str,
+    reference: &str,
+) -> Result<Response, ServerError> {
+    let auth = oci_authorize(state, headers, Some(repository), TokenScope::Write)?;
+    let scope = auth.as_ref().map(scope_from_auth);
+    let OciReference::Digest(digest_hex) = parse_reference(reference)? else {
+        return Err(ServerError::InvalidManifestReference);
+    };
+    let manifest_key = oci_manifest_key(repository, &digest_hex, scope)?;
+    match state
+        .backend
+        .delete_object_if_present(&manifest_key)
+        .await?
+    {
+        DeleteOutcome::Deleted => {}
+        DeleteOutcome::NotFound => return Err(ServerError::NotFound),
+    }
+
+    let media_type_key = oci_manifest_media_type_key(repository, &digest_hex, scope)?;
+    let _deleted = state
+        .backend
+        .delete_object_if_present(&media_type_key)
+        .await?;
+    delete_oci_tags_pointing_to_digest(state, repository, scope, &digest_hex).await?;
+
+    Response::builder()
+        .status(StatusCode::ACCEPTED)
+        .body(Body::empty())
+        .map_err(|_error| ServerError::Overflow)
+}
+
+async fn resolve_manifest_digest(
+    state: &Arc<AppState>,
+    repository: &str,
+    reference: &str,
+    repository_scope: Option<&shardline_protocol::RepositoryScope>,
+) -> Result<String, ServerError> {
+    match parse_reference(reference)? {
+        OciReference::Digest(digest_hex) => Ok(digest_hex),
+        OciReference::Tag(tag) => {
+            load_oci_tag_digest(state, repository, repository_scope, &tag).await
+        }
+    }
+}
+
+async fn load_oci_tag_digest(
+    state: &Arc<AppState>,
+    repository: &str,
+    repository_scope: Option<&shardline_protocol::RepositoryScope>,
+    tag: &str,
+) -> Result<String, ServerError> {
+    let tag_key = oci_tag_key(repository, tag, repository_scope)?;
+    let bytes = state.backend.read_object(&tag_key).await?;
+    let digest_hex = String::from_utf8(bytes).map_err(|_error| ServerError::InvalidDigest)?;
+    parse_sha256_digest(&format!("sha256:{digest_hex}"))?;
+    Ok(digest_hex)
+}
+
+struct OciTagListPage {
+    tags: Vec<String>,
+    has_more: bool,
+}
+
+fn list_oci_tags(
+    state: &Arc<AppState>,
+    repository: &str,
+    repository_scope: Option<&shardline_protocol::RepositoryScope>,
+    page_size: usize,
+    last: Option<&str>,
+) -> Result<OciTagListPage, ServerError> {
+    let prefix = oci_tag_prefix(repository, repository_scope)?;
+    let start_after = last
+        .map(|tag| oci_tag_key(repository, tag, repository_scope))
+        .transpose()?;
+    let objects = state.backend.list_object_flat_namespace_page(
+        &prefix,
+        start_after.as_ref(),
+        page_size.saturating_add(1),
+    )?;
+    let mut tags = BTreeSet::new();
+    for object in objects {
+        let Some(tag) = object.key().as_str().rsplit('/').next() else {
+            continue;
+        };
+        crate::protocol_support::validate_oci_tag(tag)?;
+        let _inserted = tags.insert(tag.to_owned());
+    }
+    let has_more = tags.len() > page_size;
+    if has_more {
+        let _removed = tags.pop_last();
+    }
+    Ok(OciTagListPage {
+        tags: tags.into_iter().collect(),
+        has_more,
+    })
+}
+
+async fn update_oci_tags(
+    state: &Arc<AppState>,
+    repository: &str,
+    repository_scope: Option<&shardline_protocol::RepositoryScope>,
+    tags: &[String],
+    digest_hex: &str,
+) -> Result<(), ServerError> {
+    let digest_bytes = digest_hex.as_bytes().to_vec();
+    for tag in tags {
+        crate::protocol_support::validate_oci_tag(tag)?;
+        let tag_key = oci_tag_key(repository, tag, repository_scope)?;
+        let previous_digest = match state.backend.read_object(&tag_key).await {
+            Ok(bytes) => {
+                Some(String::from_utf8(bytes).map_err(|_error| ServerError::InvalidDigest)?)
+            }
+            Err(ServerError::NotFound) => None,
+            Err(error) => return Err(error),
+        };
+        let target_key = oci_tag_target_key(repository, digest_hex, tag, repository_scope)?;
+        state
+            .backend
+            .put_object_bytes_overwrite(&target_key, Vec::new())?;
+        state
+            .backend
+            .put_object_bytes_overwrite(&tag_key, digest_bytes.clone())?;
+        if let Some(previous_digest) = previous_digest
+            && previous_digest != digest_hex
+        {
+            let previous_target =
+                oci_tag_target_key(repository, &previous_digest, tag, repository_scope)?;
+            let _deleted = state
+                .backend
+                .delete_object_if_present(&previous_target)
+                .await?;
+        }
+    }
+    Ok(())
+}
+
+async fn delete_oci_tags_pointing_to_digest(
+    state: &Arc<AppState>,
+    repository: &str,
+    repository_scope: Option<&shardline_protocol::RepositoryScope>,
+    digest_hex: &str,
+) -> Result<(), ServerError> {
+    let prefix = oci_tag_target_prefix(repository, digest_hex, repository_scope)?;
+    let mut target_keys = Vec::new();
+    state.backend.visit_object_prefix(&prefix, |object| {
+        target_keys.push(object.key().clone());
+        Ok(())
+    })?;
+
+    for target_key in target_keys {
+        let Some(tag) = target_key.as_str().rsplit('/').next() else {
+            continue;
+        };
+        let tag_key = oci_tag_key(repository, tag, repository_scope)?;
+        match state.backend.read_object(&tag_key).await {
+            Ok(bytes) => {
+                let stored_digest =
+                    String::from_utf8(bytes).map_err(|_error| ServerError::InvalidDigest)?;
+                if stored_digest == digest_hex {
+                    let _deleted = state.backend.delete_object_if_present(&tag_key).await?;
+                }
+            }
+            Err(ServerError::NotFound) => {}
+            Err(error) => return Err(error),
+        }
+        let _deleted = state.backend.delete_object_if_present(&target_key).await?;
+    }
+    Ok(())
+}
+
+async fn validate_oci_manifest_document(
+    state: &Arc<AppState>,
+    repository: &str,
+    repository_scope: Option<&shardline_protocol::RepositoryScope>,
+    media_type: &str,
+    bytes: &[u8],
+) -> Result<(), ServerError> {
+    let document: Value =
+        serde_json::from_slice(bytes).map_err(|_error| ServerError::InvalidManifestReference)?;
+    validate_oci_schema_version(&document)?;
+    let normalized_media_type = normalize_media_type(media_type);
+    if let Some(document_media_type) = document.get("mediaType").and_then(Value::as_str)
+        && normalize_media_type(document_media_type) != normalized_media_type
+    {
+        return Err(ServerError::InvalidManifestReference);
+    }
+    if let Some(subject) = document.get("subject") {
+        let _subject_digest = validate_oci_descriptor(subject)?;
+    }
+
+    match normalized_media_type {
+        OCI_IMAGE_MANIFEST_MEDIA_TYPE | DOCKER_SCHEMA2_MANIFEST_MEDIA_TYPE => {
+            validate_oci_image_manifest_document(state, repository, repository_scope, &document)
+                .await
+        }
+        OCI_IMAGE_INDEX_MEDIA_TYPE | DOCKER_SCHEMA2_MANIFEST_LIST_MEDIA_TYPE => {
+            validate_oci_image_index_document(state, repository, repository_scope, &document).await
+        }
+        _ => Err(ServerError::InvalidManifestReference),
+    }
+}
+
+fn validate_oci_schema_version(document: &Value) -> Result<(), ServerError> {
+    if document.get("schemaVersion").and_then(Value::as_u64) != Some(2) {
+        return Err(ServerError::InvalidManifestReference);
+    }
+    Ok(())
+}
+
+async fn validate_oci_image_manifest_document(
+    state: &Arc<AppState>,
+    repository: &str,
+    repository_scope: Option<&shardline_protocol::RepositoryScope>,
+    document: &Value,
+) -> Result<(), ServerError> {
+    let config = document
+        .get("config")
+        .ok_or(ServerError::InvalidManifestReference)?;
+    let config_digest_hex = validate_oci_descriptor(config)?;
+    ensure_oci_blob_exists(state, repository, repository_scope, &config_digest_hex).await?;
+
+    let layers = document
+        .get("layers")
+        .and_then(Value::as_array)
+        .ok_or(ServerError::InvalidManifestReference)?;
+    for layer in layers {
+        let digest_hex = validate_oci_descriptor(layer)?;
+        ensure_oci_blob_exists(state, repository, repository_scope, &digest_hex).await?;
+    }
+
+    Ok(())
+}
+
+async fn validate_oci_image_index_document(
+    state: &Arc<AppState>,
+    repository: &str,
+    repository_scope: Option<&shardline_protocol::RepositoryScope>,
+    document: &Value,
+) -> Result<(), ServerError> {
+    let manifests = document
+        .get("manifests")
+        .and_then(Value::as_array)
+        .ok_or(ServerError::InvalidManifestReference)?;
+    for manifest in manifests {
+        let digest_hex = validate_oci_descriptor(manifest)?;
+        ensure_oci_manifest_exists(state, repository, repository_scope, &digest_hex).await?;
+    }
+
+    Ok(())
+}
+
+fn validate_oci_descriptor(descriptor: &Value) -> Result<String, ServerError> {
+    let descriptor = descriptor
+        .as_object()
+        .ok_or(ServerError::InvalidManifestReference)?;
+    let digest = descriptor
+        .get("digest")
+        .and_then(Value::as_str)
+        .ok_or(ServerError::InvalidManifestReference)?;
+    let digest_hex = parse_sha256_digest(digest)?;
+    let _size = descriptor
+        .get("size")
+        .and_then(Value::as_u64)
+        .ok_or(ServerError::InvalidManifestReference)?;
+    if descriptor
+        .get("mediaType")
+        .is_some_and(|media_type| !media_type.is_string())
+    {
+        return Err(ServerError::InvalidManifestReference);
+    }
+    Ok(digest_hex)
+}
+
+async fn ensure_oci_blob_exists(
+    state: &Arc<AppState>,
+    repository: &str,
+    repository_scope: Option<&shardline_protocol::RepositoryScope>,
+    digest_hex: &str,
+) -> Result<(), ServerError> {
+    let object_key = oci_blob_key(repository, digest_hex, repository_scope)?;
+    match state.backend.object_length(&object_key).await {
+        Ok(_length) => Ok(()),
+        Err(ServerError::NotFound) => Err(ServerError::InvalidManifestReference),
+        Err(error) => Err(error),
+    }
+}
+
+async fn ensure_oci_manifest_exists(
+    state: &Arc<AppState>,
+    repository: &str,
+    repository_scope: Option<&shardline_protocol::RepositoryScope>,
+    digest_hex: &str,
+) -> Result<(), ServerError> {
+    let object_key = oci_manifest_key(repository, digest_hex, repository_scope)?;
+    match state.backend.object_length(&object_key).await {
+        Ok(_length) => Ok(()),
+        Err(ServerError::NotFound) => Err(ServerError::InvalidManifestReference),
+        Err(error) => Err(error),
+    }
+}
+
+fn normalize_media_type(value: &str) -> &str {
+    value.split(';').next().map_or(value, str::trim)
+}
+
+fn ensure_manifest_representation_is_acceptable(
+    headers: &HeaderMap,
+    media_type: &str,
+) -> Result<(), ServerError> {
+    let normalized_media_type = normalize_media_type(media_type);
+    let Some((stored_type, stored_subtype)) = normalized_media_type.split_once('/') else {
+        return Err(ServerError::InvalidManifestReference);
+    };
+    let accepted = headers.get_all(ACCEPT);
+    let mut accepted_iter = accepted.iter().peekable();
+    if accepted_iter.peek().is_none() {
+        return Ok(());
+    }
+
+    for value in accepted_iter {
+        let value = value
+            .to_str()
+            .map_err(|_error| ServerError::NotAcceptable)?;
+        for candidate in value.split(',') {
+            let candidate = normalize_media_type(candidate);
+            if candidate.is_empty() {
+                continue;
+            }
+            if candidate == "*/*" || candidate == normalized_media_type {
+                return Ok(());
+            }
+            let Some((accepted_type, accepted_subtype)) = candidate.split_once('/') else {
+                continue;
+            };
+            if (accepted_type == "*" || accepted_type == stored_type)
+                && (accepted_subtype == "*" || accepted_subtype == stored_subtype)
+            {
+                return Ok(());
+            }
+        }
+    }
+
+    Err(ServerError::NotAcceptable)
+}
+
+async fn direct_object_response(
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    object_key: &shardline_storage::ObjectKey,
+    content_type: &str,
+    content_digest: Option<String>,
+) -> Result<Response, ServerError> {
+    let total_length = state.backend.object_length(object_key).await?;
+    let range = parse_optional_range(headers, total_length)?;
+    let byte_stream = state
+        .backend
+        .read_object_stream(object_key, total_length, range)
+        .await?;
+    let mut response = if let Some(range) = range {
+        let transfer_length = range.len().ok_or(ServerError::Overflow)?;
+        byte_range_stream_response(
+            byte_stream,
+            state.transfer_limiter.clone(),
+            range,
+            total_length,
+            transfer_length,
+        )
+    } else {
+        full_byte_stream_response(byte_stream, state.transfer_limiter.clone(), total_length)
+    };
+    let content_type_value = HeaderValue::from_str(content_type)
+        .map_err(|_error| ServerError::InvalidManifestReference)?;
+    response
+        .headers_mut()
+        .insert(CONTENT_TYPE, content_type_value);
+    if let Some(content_digest) = content_digest {
+        let digest_value =
+            HeaderValue::from_str(&content_digest).map_err(|_error| ServerError::InvalidDigest)?;
+        response
+            .headers_mut()
+            .insert("Docker-Content-Digest", digest_value);
+    }
+    Ok(response)
+}
+
+fn oci_authorize(
+    state: &AppState,
+    headers: &HeaderMap,
+    repository: Option<&str>,
+    required_scope: TokenScope,
+) -> Result<Option<super::AuthContext>, ServerError> {
+    match authorize(state, headers, required_scope) {
+        Ok(auth) => Ok(auth),
+        Err(ServerError::MissingAuthorization)
+        | Err(ServerError::InvalidAuthorizationHeader)
+        | Err(ServerError::InvalidToken(_)) => Err(ServerError::UnauthorizedChallenge(
+            oci_bearer_challenge(state.config.public_base_url(), repository, required_scope),
+        )),
+        Err(error) => Err(error),
+    }
+}
+
+fn oci_bearer_challenge(
+    public_base_url: &str,
+    repository: Option<&str>,
+    required_scope: TokenScope,
+) -> String {
+    let realm = format!("{}/v2/token", public_base_url.trim_end_matches('/'));
+    let mut challenge = format!("Bearer realm=\"{realm}\",service=\"{OCI_REGISTRY_SERVICE}\"");
+    if let Some(repository) = repository {
+        let actions = match required_scope {
+            TokenScope::Read => "pull",
+            TokenScope::Write => "pull,push",
+        };
+        let _ignored = write!(challenge, ",scope=\"repository:{repository}:{actions}\"");
+    }
+    challenge
+}
+
+fn verify_oci_registry_bootstrap_credentials(
+    headers: &HeaderMap,
+    signer: &TokenSigner,
+) -> Result<TokenClaims, ServerError> {
+    let header = headers
+        .get(AUTHORIZATION)
+        .ok_or(ServerError::MissingAuthorization)?
+        .to_str()
+        .map_err(|_error| ServerError::InvalidAuthorizationHeader)?;
+    if let Some(token) = header.strip_prefix("Bearer ") {
+        return signer.verify_now(token).map_err(ServerError::from);
+    }
+    let Some(encoded) = header.strip_prefix("Basic ") else {
+        return Err(ServerError::InvalidAuthorizationHeader);
+    };
+    if encoded.len() > MAX_OCI_TOKEN_BASIC_AUTH_BYTES {
+        return Err(ServerError::InvalidAuthorizationHeader);
+    }
+    let decoded = BASE64_STANDARD
+        .decode(encoded)
+        .map_err(|_error| ServerError::InvalidAuthorizationHeader)?;
+    let decoded =
+        std::str::from_utf8(&decoded).map_err(|_error| ServerError::InvalidAuthorizationHeader)?;
+    let Some((_username, password)) = decoded.split_once(':') else {
+        return Err(ServerError::InvalidAuthorizationHeader);
+    };
+    if password.trim().is_empty() {
+        return Err(ServerError::InvalidAuthorizationHeader);
+    }
+    signer.verify_now(password).map_err(ServerError::from)
+}
+
+fn parse_oci_registry_token_scope(
+    scope: Option<&str>,
+) -> Result<(Option<TokenScope>, Option<String>), ServerError> {
+    let Some(scope) = scope.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok((None, None));
+    };
+    let Some((resource_type, repository, actions)) =
+        scope
+            .split_once(':')
+            .and_then(|(resource_type, remainder)| {
+                remainder
+                    .rsplit_once(':')
+                    .map(|(repository, actions)| (resource_type, repository, actions))
+            })
+    else {
+        return Err(ServerError::InvalidManifestReference);
+    };
+    if resource_type != "repository" {
+        return Err(ServerError::InvalidManifestReference);
+    }
+    validate_repository(repository)?;
+    let requested_scope = parse_oci_registry_actions(actions)?;
+    Ok((Some(requested_scope), Some(repository.to_owned())))
+}
+
+fn parse_oci_registry_token_scopes(
+    scopes: &[String],
+) -> Result<(Option<TokenScope>, Option<String>), ServerError> {
+    let mut requested_scope = None;
+    let mut requested_repository: Option<String> = None;
+    for scope in scopes {
+        let (scope_value, repository) = parse_oci_registry_token_scope(Some(scope))?;
+        let Some(scope_value) = scope_value else {
+            continue;
+        };
+        let Some(repository) = repository else {
+            continue;
+        };
+        if let Some(existing_repository) = requested_repository.as_deref() {
+            if existing_repository != repository {
+                return Err(ServerError::InvalidManifestReference);
+            }
+        } else {
+            requested_repository = Some(repository);
+        }
+        requested_scope = Some(match requested_scope {
+            Some(TokenScope::Write) => TokenScope::Write,
+            Some(TokenScope::Read) if scope_value == TokenScope::Write => TokenScope::Write,
+            Some(existing_scope) => existing_scope,
+            None => scope_value,
+        });
+    }
+    Ok((requested_scope, requested_repository))
+}
+
+fn parse_oci_registry_actions(actions: &str) -> Result<TokenScope, ServerError> {
+    let mut saw_pull = false;
+    let mut saw_push = false;
+    for action in actions
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        match action {
+            "pull" => saw_pull = true,
+            "push" => saw_push = true,
+            _ => return Err(ServerError::InvalidManifestReference),
+        }
+    }
+    if saw_push {
+        return Ok(TokenScope::Write);
+    }
+    if saw_pull {
+        return Ok(TokenScope::Read);
+    }
+    Err(ServerError::InvalidManifestReference)
+}
+
+struct OciRegistryTokenQuery {
+    service: Option<String>,
+    scopes: Vec<String>,
+    _account: Option<String>,
+}
+
+fn parse_oci_registry_token_query(uri: &Uri) -> Result<OciRegistryTokenQuery, ServerError> {
+    Ok(OciRegistryTokenQuery {
+        service: single_bounded_query_value(uri, "service", MAX_OCI_TOKEN_QUERY_SERVICE_BYTES)?,
+        scopes: bounded_query_values(
+            uri,
+            "scope",
+            MAX_OCI_TOKEN_QUERY_SCOPE_BYTES,
+            MAX_OCI_TOKEN_QUERY_SCOPES,
+        )?,
+        _account: single_bounded_query_value(uri, "account", MAX_OCI_TOKEN_QUERY_ACCOUNT_BYTES)?,
+    })
+}
+
+fn single_bounded_query_value(
+    uri: &Uri,
+    key: &str,
+    max_bytes: usize,
+) -> Result<Option<String>, ServerError> {
+    let values = parse_query_values(uri, key)?;
+    if values.len() > 1 {
+        return Err(ServerError::InvalidManifestReference);
+    }
+    let Some(value) = values.into_iter().next() else {
+        return Ok(None);
+    };
+    let value = value.trim();
+    if value.is_empty() {
+        return Ok(None);
+    }
+    if value.len() > max_bytes {
+        return Err(ServerError::RequestQueryTooLarge);
+    }
+    Ok(Some(value.to_owned()))
+}
+
+fn bounded_query_values(
+    uri: &Uri,
+    key: &str,
+    max_bytes: usize,
+    max_values: usize,
+) -> Result<Vec<String>, ServerError> {
+    let values = parse_query_values(uri, key)?;
+    if values.len() > max_values {
+        return Err(ServerError::InvalidManifestReference);
+    }
+    let mut bounded = Vec::with_capacity(values.len());
+    for value in values {
+        let value = value.trim();
+        if value.is_empty() {
+            continue;
+        }
+        if value.len() > max_bytes {
+            return Err(ServerError::RequestQueryTooLarge);
+        }
+        bounded.push(value.to_owned());
+    }
+    Ok(bounded)
+}
+
+fn scope_allows_oci_exchange(
+    actual_scope: TokenScope,
+    requested_scope: Option<TokenScope>,
+) -> bool {
+    match requested_scope.unwrap_or(actual_scope) {
+        TokenScope::Read => actual_scope.allows_read(),
+        TokenScope::Write => actual_scope.allows_write(),
+    }
+}
+
+fn parse_optional_range(
+    headers: &HeaderMap,
+    total_length: u64,
+) -> Result<Option<ByteRange>, ServerError> {
+    let Some(range) = headers.get(RANGE) else {
+        return Ok(None);
+    };
+    let range = range
+        .to_str()
+        .map_err(|_error| ServerError::InvalidRangeHeader)?;
+    let range = parse_http_byte_range(range, total_length).map_err(ServerError::from)?;
+    Ok(Some(range))
+}
+
+pub(crate) fn parse_upload_content_range(value: &str) -> Result<ByteRange, ServerError> {
+    let value = value.trim();
+    let value = value.strip_prefix("bytes ").unwrap_or(value);
+    let value = value.split_once('/').map_or(value, |(range, _rest)| range);
+    let Some((start, end)) = value.split_once('-') else {
+        return Err(ServerError::InvalidRangeHeader);
+    };
+    let start = start
+        .parse::<u64>()
+        .map_err(|_error| ServerError::InvalidRangeHeader)?;
+    let end = end
+        .parse::<u64>()
+        .map_err(|_error| ServerError::InvalidRangeHeader)?;
+    ByteRange::new(start, end).map_err(|_error| ServerError::InvalidRangeHeader)
+}
+
+fn ensure_upload_growth_within_limit(
+    state: &Arc<AppState>,
+    current_length: u64,
+    additional_bytes: usize,
+) -> Result<(), ServerError> {
+    let additional_bytes = u64::try_from(additional_bytes)?;
+    let next_length = current_length
+        .checked_add(additional_bytes)
+        .ok_or(ServerError::Overflow)?;
+    let max_bytes = u64::try_from(state.config.max_request_body_bytes().get())?;
+    if next_length > max_bytes {
+        return Err(ServerError::RequestBodyTooLarge);
+    }
+
+    Ok(())
+}
+
+fn parse_query_map(uri: &Uri) -> Result<BTreeMap<String, String>, ServerError> {
+    let Some(query) = uri.query() else {
+        return Ok(BTreeMap::new());
+    };
+    if query.len() > MAX_PROTOCOL_QUERY_BYTES {
+        return Err(ServerError::RequestQueryTooLarge);
+    }
+
+    Ok(url::form_urlencoded::parse(query.as_bytes())
+        .into_owned()
+        .collect())
+}
+
+fn parse_query_values(uri: &Uri, key: &str) -> Result<Vec<String>, ServerError> {
+    let Some(query) = uri.query() else {
+        return Ok(Vec::new());
+    };
+    if query.len() > MAX_PROTOCOL_QUERY_BYTES {
+        return Err(ServerError::RequestQueryTooLarge);
+    }
+
+    Ok(url::form_urlencoded::parse(query.as_bytes())
+        .filter_map(|(candidate_key, value)| (candidate_key == key).then(|| value.into_owned()))
+        .collect())
+}
+
+fn parse_oci_tag_list_page_size(value: Option<&str>) -> Result<usize, ServerError> {
+    let Some(value) = value else {
+        return Ok(MAX_OCI_TAG_LIST_PAGE_SIZE);
+    };
+    let page_size = value
+        .parse::<usize>()
+        .map_err(|_error| ServerError::InvalidManifestReference)?;
+    if page_size == 0 || page_size > MAX_OCI_TAG_LIST_PAGE_SIZE {
+        return Err(ServerError::InvalidManifestReference);
+    }
+    Ok(page_size)
+}
+
+fn oci_tags_list_next_link(
+    repository: &str,
+    page_size: usize,
+    last_tag: &str,
+) -> Result<HeaderValue, ServerError> {
+    let query = url::form_urlencoded::Serializer::new(String::new())
+        .append_pair("n", &page_size.to_string())
+        .append_pair("last", last_tag)
+        .finish();
+    HeaderValue::from_str(&format!(
+        "</v2/{repository}/tags/list?{query}>; rel=\"next\""
+    ))
+    .map_err(|_error| ServerError::InvalidManifestReference)
+}
+
+fn oci_created_response(location: &str, digest_hex: Option<&str>) -> Result<Response, ServerError> {
+    let mut builder = Response::builder()
+        .status(StatusCode::CREATED)
+        .header(LOCATION, location);
+    if let Some(digest_hex) = digest_hex {
+        builder = builder.header("Docker-Content-Digest", format!("sha256:{digest_hex}"));
+    }
+    builder
+        .body(Body::empty())
+        .map_err(|_error| ServerError::Overflow)
+}
+
+pub(crate) enum OciPath {
+    Blob {
+        repository: String,
+        digest_hex: String,
+    },
+    BlobUploads {
+        repository: String,
+    },
+    BlobUploadSession {
+        repository: String,
+        session_id: String,
+    },
+    Manifest {
+        repository: String,
+        reference: String,
+    },
+    TagsList {
+        repository: String,
+    },
+}
+
+pub(crate) fn parse_oci_path(path: &str) -> Result<OciPath, ServerError> {
+    let path = path.trim_end_matches('/');
+    if let Some(repository) = path.strip_suffix("/blobs/uploads") {
+        validate_repository(repository)?;
+        return Ok(OciPath::BlobUploads {
+            repository: repository.to_owned(),
+        });
+    }
+    if let Some((repository, session_id)) = path.split_once("/blobs/uploads/") {
+        validate_repository(repository)?;
+        return Ok(OciPath::BlobUploadSession {
+            repository: repository.to_owned(),
+            session_id: session_id.to_owned(),
+        });
+    }
+    if let Some((repository, digest)) = path.split_once("/blobs/") {
+        validate_repository(repository)?;
+        return Ok(OciPath::Blob {
+            repository: repository.to_owned(),
+            digest_hex: parse_sha256_digest(digest)?,
+        });
+    }
+    if let Some((repository, reference)) = path.split_once("/manifests/") {
+        validate_repository(repository)?;
+        return Ok(OciPath::Manifest {
+            repository: repository.to_owned(),
+            reference: reference.to_owned(),
+        });
+    }
+    if let Some(repository) = path.strip_suffix("/tags/list") {
+        validate_repository(repository)?;
+        return Ok(OciPath::TagsList {
+            repository: repository.to_owned(),
+        });
+    }
+
+    Err(ServerError::NotFound)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OciPath, parse_oci_path};
+    use crate::ServerError;
+    use axum::http::Uri;
+
+    #[test]
+    fn oci_path_parser_accepts_supported_routes() {
+        assert!(matches!(
+            parse_oci_path("team/assets/blobs/sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+            Ok(OciPath::Blob { repository, digest_hex })
+                if repository == "team/assets"
+                    && digest_hex
+                        == "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        ));
+        assert!(matches!(
+            parse_oci_path("team/assets/blobs/uploads"),
+            Ok(OciPath::BlobUploads { repository }) if repository == "team/assets"
+        ));
+        assert!(matches!(
+            parse_oci_path("team/assets/blobs/uploads/0000000000000001"),
+            Ok(OciPath::BlobUploadSession { repository, session_id })
+                if repository == "team/assets" && session_id == "0000000000000001"
+        ));
+        assert!(matches!(
+            parse_oci_path("team/assets/manifests/v1"),
+            Ok(OciPath::Manifest { repository, reference })
+                if repository == "team/assets" && reference == "v1"
+        ));
+        assert!(matches!(
+            parse_oci_path("team/assets/tags/list"),
+            Ok(OciPath::TagsList { repository }) if repository == "team/assets"
+        ));
+    }
+
+    #[test]
+    fn oci_path_parser_rejects_invalid_repository_and_digest_inputs() {
+        assert!(matches!(
+            parse_oci_path("Team/assets/tags/list"),
+            Err(ServerError::InvalidRepositoryName)
+        ));
+        assert!(matches!(
+            parse_oci_path("team/assets/blobs/sha256:not-a-digest"),
+            Err(ServerError::InvalidDigest)
+        ));
+        assert!(matches!(
+            parse_oci_path("team/assets/unknown"),
+            Err(ServerError::NotFound)
+        ));
+    }
+
+    #[test]
+    fn upload_content_range_parser_accepts_common_client_formats() {
+        assert_eq!(
+            super::parse_upload_content_range("0-9")
+                .ok()
+                .map(|range| (range.start(), range.end_inclusive())),
+            Some((0, 9))
+        );
+        assert_eq!(
+            super::parse_upload_content_range("bytes 10-19/20")
+                .ok()
+                .map(|range| (range.start(), range.end_inclusive())),
+            Some((10, 19))
+        );
+        assert_eq!(
+            super::parse_upload_content_range("bytes 20-29/*")
+                .ok()
+                .map(|range| (range.start(), range.end_inclusive())),
+            Some((20, 29))
+        );
+    }
+
+    #[test]
+    fn protocol_query_parser_rejects_oversized_inputs() {
+        let uri = Uri::builder()
+            .path_and_query(format!(
+                "/v2/team/assets/blobs/uploads?mount={}",
+                "a".repeat(super::MAX_PROTOCOL_QUERY_BYTES + 1)
+            ))
+            .build();
+        assert!(uri.is_ok());
+        let Ok(uri) = uri else {
+            return;
+        };
+
+        assert!(matches!(
+            super::parse_query_map(&uri),
+            Err(ServerError::RequestQueryTooLarge)
+        ));
+        assert!(matches!(
+            super::parse_query_values(&uri, "mount"),
+            Err(ServerError::RequestQueryTooLarge)
+        ));
+    }
+}

--- a/crates/server/src/app/protocol_routes.rs
+++ b/crates/server/src/app/protocol_routes.rs
@@ -142,9 +142,10 @@ pub(super) async fn bazel_put_cas(
     if observed != hash {
         return Err(ServerError::ExpectedBodyHashMismatch);
     }
-    let _stored = state
-        .backend
-        .put_object_bytes_if_absent(&object_key, bytes)?;
+    let _stored =
+        state
+            .backend
+            .put_sha256_addressed_object_bytes_if_absent(&object_key, &hash, bytes)?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -310,9 +311,10 @@ pub(super) async fn lfs_put_object(
     if observed != oid {
         return Err(ServerError::ExpectedBodyHashMismatch);
     }
-    let _stored = state
-        .backend
-        .put_object_bytes_if_absent(&object_key, bytes)?;
+    let _stored =
+        state
+            .backend
+            .put_sha256_addressed_object_bytes_if_absent(&object_key, &oid, bytes)?;
     Ok(StatusCode::OK)
 }
 
@@ -707,9 +709,11 @@ async fn oci_post_blob_upload(
                 return Err(ServerError::ExpectedBodyHashMismatch);
             }
             let object_key = oci_blob_key(repository, &digest_hex, scope)?;
-            let _stored = state
-                .backend
-                .put_object_bytes_if_absent(&object_key, bytes)?;
+            let _stored = state.backend.put_sha256_addressed_object_bytes_if_absent(
+                &object_key,
+                &digest_hex,
+                bytes,
+            )?;
             return oci_created_response(
                 &oci_blob_location(repository, &digest_hex),
                 Some(&digest_hex),
@@ -841,10 +845,12 @@ async fn oci_put_blob_upload(
     }
     let object_key = oci_blob_key(repository, &digest_hex, scope)?;
     let upload_path = upload_body_path_for_session(state.config.root_dir(), session_id)?;
-    let _stored =
-        state
-            .backend
-            .put_content_addressed_object_file(&object_key, &upload_path, &integrity)?;
+    let _stored = state.backend.put_sha256_addressed_object_file(
+        &object_key,
+        &digest_hex,
+        &upload_path,
+        &integrity,
+    )?;
     delete_upload_session(state.config.root_dir(), session_id).await?;
     oci_created_response(
         &oci_blob_location(repository, &digest_hex),
@@ -935,9 +941,11 @@ async fn oci_put_manifest(
     validate_oci_manifest_document(state, repository, scope, &media_type, &bytes).await?;
     let manifest_key = oci_manifest_key(repository, &digest_hex, scope)?;
     let media_type_key = oci_manifest_media_type_key(repository, &digest_hex, scope)?;
-    let _stored_manifest = state
-        .backend
-        .put_object_bytes_if_absent(&manifest_key, bytes)?;
+    let _stored_manifest = state.backend.put_sha256_addressed_object_bytes_if_absent(
+        &manifest_key,
+        &digest_hex,
+        bytes,
+    )?;
     let _stored_media_type = state
         .backend
         .put_object_bytes_if_absent(&media_type_key, media_type.clone().into_bytes())?;

--- a/crates/server/src/app/tests.rs
+++ b/crates/server/src/app/tests.rs
@@ -187,6 +187,8 @@ mod transfer_http;
 
 mod provider_http;
 
+mod protocol_frontends_http;
+
 fn write_provider_config(root: &Path) -> Result<PathBuf, Box<dyn StdError>> {
     let path = root.join("providers.json");
     let bytes = to_vec(&json!({

--- a/crates/server/src/app/tests/protocol_frontends_http.rs
+++ b/crates/server/src/app/tests/protocol_frontends_http.rs
@@ -1,0 +1,2509 @@
+#![allow(clippy::indexing_slicing, clippy::panic_in_result_fn)]
+
+use std::{
+    error::Error as StdError,
+    fs,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    num::{NonZeroU64, NonZeroUsize},
+    path::Path,
+};
+
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use reqwest::{
+    Client, StatusCode,
+    header::{ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, LOCATION},
+};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use tokio::{net::TcpListener, spawn, task::JoinHandle};
+
+use super::{bearer_token, serve_with_listener, wait_for_health};
+use crate::{
+    ServerConfig, ServerError, ServerFrontend,
+    local_backend::chunk_hash,
+    object_store::ServerObjectStore,
+    oci_adapter::{oci_blob_key, oci_manifest_key, oci_manifest_media_type_key},
+};
+use shardline_protocol::{RepositoryProvider, TokenScope};
+use shardline_storage::{ObjectBody, ObjectIntegrity};
+
+struct ProtocolFrontendRuntime {
+    storage: tempfile::TempDir,
+    base_url: String,
+    server: JoinHandle<Result<(), ServerError>>,
+}
+
+struct ProtocolSharedRootRuntime {
+    base_url: String,
+    server: JoinHandle<Result<(), ServerError>>,
+}
+
+impl ProtocolFrontendRuntime {
+    fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    fn storage_path(&self) -> &Path {
+        self.storage.path()
+    }
+}
+
+impl Drop for ProtocolFrontendRuntime {
+    fn drop(&mut self) {
+        self.server.abort();
+    }
+}
+
+impl ProtocolSharedRootRuntime {
+    fn base_url(&self) -> &str {
+        &self.base_url
+    }
+}
+
+impl Drop for ProtocolSharedRootRuntime {
+    fn drop(&mut self) {
+        self.server.abort();
+    }
+}
+
+async fn start_protocol_runtime(
+    frontends: &[ServerFrontend],
+) -> Result<ProtocolFrontendRuntime, Box<dyn StdError>> {
+    start_protocol_runtime_with_max_request_body(
+        frontends,
+        NonZeroUsize::new(67_108_864).unwrap_or(NonZeroUsize::MIN),
+    )
+    .await
+}
+
+async fn start_protocol_runtime_with_max_request_body(
+    frontends: &[ServerFrontend],
+    max_request_body_bytes: NonZeroUsize,
+) -> Result<ProtocolFrontendRuntime, Box<dyn StdError>> {
+    let storage = tempfile::tempdir()?;
+    let listener = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)).await?;
+    let addr = listener.local_addr()?;
+    let base_url = format!("http://{addr}");
+    let config = ServerConfig::new(
+        addr,
+        base_url.clone(),
+        storage.path().to_path_buf(),
+        NonZeroUsize::new(4).unwrap_or(NonZeroUsize::MIN),
+    )
+    .with_max_request_body_bytes(max_request_body_bytes)
+    .with_token_signing_key(b"signing-key".to_vec())?
+    .with_server_frontends(frontends.iter().copied())?;
+    let server = spawn(async move { serve_with_listener(config, listener).await });
+    wait_for_health(&base_url).await?;
+
+    Ok(ProtocolFrontendRuntime {
+        storage,
+        base_url,
+        server,
+    })
+}
+
+async fn start_protocol_runtime_with_oci_limits(
+    frontends: &[ServerFrontend],
+    oci_upload_session_ttl_seconds: NonZeroU64,
+    oci_upload_max_active_sessions: NonZeroUsize,
+) -> Result<ProtocolFrontendRuntime, Box<dyn StdError>> {
+    let storage = tempfile::tempdir()?;
+    let listener = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)).await?;
+    let addr = listener.local_addr()?;
+    let base_url = format!("http://{addr}");
+    let config = ServerConfig::new(
+        addr,
+        base_url.clone(),
+        storage.path().to_path_buf(),
+        NonZeroUsize::new(4).unwrap_or(NonZeroUsize::MIN),
+    )
+    .with_oci_upload_session_ttl_seconds(oci_upload_session_ttl_seconds)
+    .with_oci_upload_max_active_sessions(oci_upload_max_active_sessions)
+    .with_token_signing_key(b"signing-key".to_vec())?
+    .with_server_frontends(frontends.iter().copied())?;
+    let server = spawn(async move { serve_with_listener(config, listener).await });
+    wait_for_health(&base_url).await?;
+
+    Ok(ProtocolFrontendRuntime {
+        storage,
+        base_url,
+        server,
+    })
+}
+
+async fn start_protocol_runtime_with_oci_token_limits(
+    frontends: &[ServerFrontend],
+    oci_registry_token_ttl_seconds: NonZeroU64,
+    oci_registry_token_max_in_flight_requests: NonZeroUsize,
+) -> Result<ProtocolFrontendRuntime, Box<dyn StdError>> {
+    let storage = tempfile::tempdir()?;
+    let listener = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)).await?;
+    let addr = listener.local_addr()?;
+    let base_url = format!("http://{addr}");
+    let config = ServerConfig::new(
+        addr,
+        base_url.clone(),
+        storage.path().to_path_buf(),
+        NonZeroUsize::new(4).unwrap_or(NonZeroUsize::MIN),
+    )
+    .with_oci_registry_token_ttl_seconds(oci_registry_token_ttl_seconds)
+    .with_oci_registry_token_max_in_flight_requests(oci_registry_token_max_in_flight_requests)
+    .with_token_signing_key(b"signing-key".to_vec())?
+    .with_server_frontends(frontends.iter().copied())?;
+    let server = spawn(async move { serve_with_listener(config, listener).await });
+    wait_for_health(&base_url).await?;
+
+    Ok(ProtocolFrontendRuntime {
+        storage,
+        base_url,
+        server,
+    })
+}
+
+async fn start_protocol_runtime_on_shared_root(
+    frontends: &[ServerFrontend],
+    root_dir: &Path,
+    configure: impl FnOnce(ServerConfig) -> ServerConfig,
+) -> Result<ProtocolSharedRootRuntime, Box<dyn StdError>> {
+    let listener = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)).await?;
+    let addr = listener.local_addr()?;
+    let base_url = format!("http://{addr}");
+    let config = configure(ServerConfig::new(
+        addr,
+        base_url.clone(),
+        root_dir.to_path_buf(),
+        NonZeroUsize::new(4).unwrap_or(NonZeroUsize::MIN),
+    ))
+    .with_token_signing_key(b"signing-key".to_vec())?
+    .with_server_frontends(frontends.iter().copied())?;
+    let server = spawn(async move { serve_with_listener(config, listener).await });
+    wait_for_health(&base_url).await?;
+
+    Ok(ProtocolSharedRootRuntime { base_url, server })
+}
+
+fn scoped_token(scope: TokenScope, owner: &str, repo: &str) -> Result<String, Box<dyn StdError>> {
+    bearer_token(
+        "protocol-user-1",
+        scope,
+        RepositoryProvider::GitHub,
+        owner,
+        repo,
+        Some("main"),
+    )
+}
+
+fn scoped_repository(
+    owner: &str,
+    repo: &str,
+) -> Result<shardline_protocol::RepositoryScope, Box<dyn StdError>> {
+    Ok(shardline_protocol::RepositoryScope::new(
+        RepositoryProvider::GitHub,
+        owner,
+        repo,
+        Some("main"),
+    )?)
+}
+
+fn seed_oci_blob(
+    runtime: &ProtocolFrontendRuntime,
+    repository: &str,
+    repository_scope: &shardline_protocol::RepositoryScope,
+    bytes: &[u8],
+) -> Result<String, Box<dyn StdError>> {
+    let digest_hex = hex::encode(Sha256::digest(bytes));
+    let object_key = oci_blob_key(repository, &digest_hex, Some(repository_scope))?;
+    let object_store = ServerObjectStore::local(runtime.storage_path().join("chunks"))?;
+    let integrity = ObjectIntegrity::new(chunk_hash(bytes), u64::try_from(bytes.len())?);
+    let _stored =
+        object_store.put_if_absent(&object_key, ObjectBody::from_slice(bytes), &integrity)?;
+    Ok(digest_hex)
+}
+
+fn seed_oci_manifest(
+    runtime: &ProtocolFrontendRuntime,
+    repository: &str,
+    repository_scope: &shardline_protocol::RepositoryScope,
+    media_type: &str,
+    bytes: &[u8],
+) -> Result<String, Box<dyn StdError>> {
+    let digest_hex = hex::encode(Sha256::digest(bytes));
+    let object_store = ServerObjectStore::local(runtime.storage_path().join("chunks"))?;
+
+    let manifest_key = oci_manifest_key(repository, &digest_hex, Some(repository_scope))?;
+    let manifest_integrity = ObjectIntegrity::new(chunk_hash(bytes), u64::try_from(bytes.len())?);
+    let _stored_manifest = object_store.put_if_absent(
+        &manifest_key,
+        ObjectBody::from_slice(bytes),
+        &manifest_integrity,
+    )?;
+
+    let media_type_key =
+        oci_manifest_media_type_key(repository, &digest_hex, Some(repository_scope))?;
+    let media_type_bytes = media_type.as_bytes();
+    let media_type_integrity = ObjectIntegrity::new(
+        chunk_hash(media_type_bytes),
+        u64::try_from(media_type_bytes.len())?,
+    );
+    let _stored_media_type = object_store.put_if_absent(
+        &media_type_key,
+        ObjectBody::from_slice(media_type_bytes),
+        &media_type_integrity,
+    )?;
+
+    Ok(digest_hex)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn lfs_frontend_round_trip_and_repository_scoping() -> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[ServerFrontend::Lfs]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+    let other_read_token = scoped_token(TokenScope::Read, "team", "other-assets")?;
+    let bytes = b"large-file-content";
+    let oid = hex::encode(Sha256::digest(bytes));
+
+    let batch_upload = client
+        .post(format!("{}/v1/lfs/objects/batch", runtime.base_url()))
+        .bearer_auth(&write_token)
+        .header(CONTENT_TYPE, "application/json")
+        .json(&json!({
+            "operation": "upload",
+            "transfers": ["basic"],
+            "objects": [{ "oid": oid, "size": bytes.len() }],
+        }))
+        .send()
+        .await?;
+    assert_eq!(batch_upload.status(), StatusCode::OK);
+    assert_eq!(
+        batch_upload
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok()),
+        Some("application/vnd.git-lfs+json")
+    );
+    let batch_upload = batch_upload.json::<Value>().await?;
+    assert_eq!(batch_upload["transfer"], "basic");
+    assert_eq!(
+        batch_upload["objects"][0]["actions"]["upload"]["href"],
+        format!("{}/v1/lfs/objects/{oid}", runtime.base_url())
+    );
+
+    let upload = client
+        .put(format!("{}/v1/lfs/objects/{oid}", runtime.base_url()))
+        .bearer_auth(&write_token)
+        .body(bytes.as_slice().to_vec())
+        .send()
+        .await?;
+    assert_eq!(upload.status(), StatusCode::OK);
+
+    let head = client
+        .head(format!("{}/v1/lfs/objects/{oid}", runtime.base_url()))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(head.status(), StatusCode::OK);
+    assert_eq!(
+        head.headers()
+            .get(CONTENT_LENGTH)
+            .and_then(|value| value.to_str().ok()),
+        Some("18")
+    );
+
+    let batch_download = client
+        .post(format!("{}/v1/lfs/objects/batch", runtime.base_url()))
+        .bearer_auth(&read_token)
+        .header(CONTENT_TYPE, "application/json")
+        .json(&json!({
+            "operation": "download",
+            "objects": [{ "oid": oid, "size": bytes.len() }],
+        }))
+        .send()
+        .await?;
+    assert_eq!(batch_download.status(), StatusCode::OK);
+    let batch_download = batch_download.json::<Value>().await?;
+    assert_eq!(
+        batch_download["objects"][0]["actions"]["download"]["href"],
+        format!("{}/v1/lfs/objects/{oid}", runtime.base_url())
+    );
+
+    let download = client
+        .get(format!("{}/v1/lfs/objects/{oid}", runtime.base_url()))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(download.status(), StatusCode::OK);
+    assert_eq!(
+        download
+            .headers()
+            .get("Docker-Content-Digest")
+            .and_then(|value| value.to_str().ok()),
+        Some(format!("sha256:{oid}").as_str())
+    );
+    assert_eq!(download.bytes().await?.as_ref(), bytes);
+
+    let wrong_scope = client
+        .get(format!("{}/v1/lfs/objects/{oid}", runtime.base_url()))
+        .bearer_auth(&other_read_token)
+        .send()
+        .await?;
+    assert_eq!(wrong_scope.status(), StatusCode::NOT_FOUND);
+
+    let missing_auth = client
+        .get(format!("{}/v1/lfs/objects/{oid}", runtime.base_url()))
+        .send()
+        .await?;
+    assert_eq!(missing_auth.status(), StatusCode::UNAUTHORIZED);
+
+    let mismatched_upload = client
+        .put(format!("{}/v1/lfs/objects/{oid}", runtime.base_url()))
+        .bearer_auth(&write_token)
+        .body("wrong-body".as_bytes().to_vec())
+        .send()
+        .await?;
+    assert_eq!(mismatched_upload.status(), StatusCode::BAD_REQUEST);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bazel_http_frontend_round_trip_and_hash_validation() -> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[ServerFrontend::BazelHttp]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+    let other_read_token = scoped_token(TokenScope::Read, "team", "other-assets")?;
+
+    let ac_hash = "a".repeat(64);
+    let ac_body = b"{\"exitCode\":0}";
+    let ac_put = client
+        .put(format!(
+            "{}/v1/bazel/cache/ac/{ac_hash}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .body(ac_body.as_slice().to_vec())
+        .send()
+        .await?;
+    assert_eq!(ac_put.status(), StatusCode::NO_CONTENT);
+
+    let ac_get = client
+        .get(format!(
+            "{}/v1/bazel/cache/ac/{ac_hash}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(ac_get.status(), StatusCode::OK);
+    assert_eq!(ac_get.bytes().await?.as_ref(), ac_body);
+
+    let cas_body = b"compiled-artifact";
+    let cas_hash = hex::encode(Sha256::digest(cas_body));
+    let cas_put = client
+        .put(format!(
+            "{}/v1/bazel/cache/cas/{cas_hash}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .body(cas_body.as_slice().to_vec())
+        .send()
+        .await?;
+    assert_eq!(cas_put.status(), StatusCode::NO_CONTENT);
+
+    let cas_get = client
+        .get(format!(
+            "{}/v1/bazel/cache/cas/{cas_hash}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(cas_get.status(), StatusCode::OK);
+    assert_eq!(cas_get.bytes().await?.as_ref(), cas_body);
+
+    let wrong_scope = client
+        .get(format!(
+            "{}/v1/bazel/cache/cas/{cas_hash}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&other_read_token)
+        .send()
+        .await?;
+    assert_eq!(wrong_scope.status(), StatusCode::NOT_FOUND);
+
+    let missing_auth = client
+        .get(format!(
+            "{}/v1/bazel/cache/ac/{ac_hash}",
+            runtime.base_url()
+        ))
+        .send()
+        .await?;
+    assert_eq!(missing_auth.status(), StatusCode::UNAUTHORIZED);
+
+    let mismatched_cas = client
+        .put(format!(
+            "{}/v1/bazel/cache/cas/{cas_hash}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .body("wrong-artifact".as_bytes().to_vec())
+        .send()
+        .await?;
+    assert_eq!(mismatched_cas.status(), StatusCode::BAD_REQUEST);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn lfs_frontend_rejects_excessive_batch_cardinality() -> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[ServerFrontend::Lfs]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let objects = (0..=1024)
+        .map(|index| {
+            json!({
+                "oid": format!("{index:064x}"),
+                "size": 1,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let response = client
+        .post(format!("{}/v1/lfs/objects/batch", runtime.base_url()))
+        .bearer_auth(&write_token)
+        .header(CONTENT_TYPE, "application/json")
+        .json(&json!({
+            "operation": "upload",
+            "transfers": ["basic"],
+            "objects": objects,
+        }))
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn lfs_frontend_rejects_unsupported_transfer_adapters() -> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[ServerFrontend::Lfs]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+
+    let response = client
+        .post(format!("{}/v1/lfs/objects/batch", runtime.base_url()))
+        .bearer_auth(&write_token)
+        .header(CONTENT_TYPE, "application/json")
+        .json(&json!({
+            "operation": "upload",
+            "transfers": ["tus.io", "ssh"],
+            "objects": [{
+                "oid": format!("{:064x}", 1),
+                "size": 1
+            }],
+        }))
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let body = response.json::<Value>().await?;
+    assert_eq!(body["message"], "unsupported transfer adapter");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn lfs_frontend_batch_reports_stored_object_size() -> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[ServerFrontend::Lfs]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+    let bytes = b"authoritative-lfs-size";
+    let oid = hex::encode(Sha256::digest(bytes));
+
+    let upload = client
+        .put(format!("{}/v1/lfs/objects/{oid}", runtime.base_url()))
+        .bearer_auth(&write_token)
+        .body(bytes.as_slice().to_vec())
+        .send()
+        .await?;
+    assert_eq!(upload.status(), StatusCode::OK);
+
+    let upload_batch = client
+        .post(format!("{}/v1/lfs/objects/batch", runtime.base_url()))
+        .bearer_auth(&write_token)
+        .header(CONTENT_TYPE, "application/json")
+        .json(&json!({
+            "operation": "upload",
+            "objects": [{ "oid": oid, "size": 1 }],
+        }))
+        .send()
+        .await?;
+    assert_eq!(upload_batch.status(), StatusCode::OK);
+    let upload_batch = upload_batch.json::<Value>().await?;
+    assert_eq!(upload_batch["objects"][0]["size"], bytes.len());
+    assert!(upload_batch["objects"][0]["actions"].is_null());
+
+    let download_batch = client
+        .post(format!("{}/v1/lfs/objects/batch", runtime.base_url()))
+        .bearer_auth(&read_token)
+        .header(CONTENT_TYPE, "application/json")
+        .json(&json!({
+            "operation": "download",
+            "objects": [{ "oid": oid, "size": 1 }],
+        }))
+        .send()
+        .await?;
+    assert_eq!(download_batch.status(), StatusCode::OK);
+    let download_batch = download_batch.json::<Value>().await?;
+    assert_eq!(download_batch["objects"][0]["size"], bytes.len());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_blob_manifest_and_tag_round_trip() -> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+    let other_read_token = scoped_token(TokenScope::Read, "team", "other-assets")?;
+
+    let root = client
+        .get(format!("{}/v2/", runtime.base_url()))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(root.status(), StatusCode::OK);
+    assert_eq!(
+        root.headers()
+            .get("Docker-Distribution-API-Version")
+            .and_then(|value| value.to_str().ok()),
+        Some("registry/2.0")
+    );
+
+    let blob_bytes = br#"{"architecture":"amd64","os":"linux"}"#;
+    let blob_digest = hex::encode(Sha256::digest(blob_bytes));
+    let blob_upload = client
+        .post(format!(
+            "{}/v2/team/assets/blobs/uploads?digest=sha256:{blob_digest}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .body(blob_bytes.as_slice().to_vec())
+        .send()
+        .await?;
+    assert_eq!(blob_upload.status(), StatusCode::CREATED);
+    assert_eq!(
+        blob_upload
+            .headers()
+            .get("Docker-Content-Digest")
+            .and_then(|value| value.to_str().ok()),
+        Some(format!("sha256:{blob_digest}").as_str())
+    );
+
+    let manifest = json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": format!("sha256:{blob_digest}"),
+            "size": blob_bytes.len(),
+        },
+        "layers": [],
+    });
+    let manifest_bytes = serde_json::to_vec(&manifest)?;
+    let manifest_digest = hex::encode(Sha256::digest(&manifest_bytes));
+    let manifest_put = client
+        .put(format!(
+            "{}/v2/team/assets/manifests/v1?tag=stable",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .header(CONTENT_TYPE, "application/vnd.oci.image.manifest.v1+json")
+        .body(manifest_bytes.clone())
+        .send()
+        .await?;
+    assert_eq!(manifest_put.status(), StatusCode::CREATED);
+    assert_eq!(
+        manifest_put
+            .headers()
+            .get("Docker-Content-Digest")
+            .and_then(|value| value.to_str().ok()),
+        Some(format!("sha256:{manifest_digest}").as_str())
+    );
+
+    let manifest_head = client
+        .head(format!(
+            "{}/v2/team/assets/manifests/v1",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(manifest_head.status(), StatusCode::OK);
+    assert_eq!(
+        manifest_head
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok()),
+        Some("application/vnd.oci.image.manifest.v1+json")
+    );
+
+    let manifest_get = client
+        .get(format!(
+            "{}/v2/team/assets/manifests/v1",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(manifest_get.status(), StatusCode::OK);
+    assert_eq!(
+        manifest_get.bytes().await?.as_ref(),
+        manifest_bytes.as_slice()
+    );
+
+    let tags = client
+        .get(format!("{}/v2/team/assets/tags/list", runtime.base_url()))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(tags.status(), StatusCode::OK);
+    let tags = tags.json::<Value>().await?;
+    assert_eq!(tags["name"], "team/assets");
+    assert_eq!(tags["tags"], json!(["stable", "v1"]));
+
+    let blob_get = client
+        .get(format!(
+            "{}/v2/team/assets/blobs/sha256:{blob_digest}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(blob_get.status(), StatusCode::OK);
+    assert_eq!(blob_get.bytes().await?.as_ref(), blob_bytes);
+
+    let wrong_scope = client
+        .get(format!(
+            "{}/v2/team/assets/blobs/sha256:{blob_digest}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&other_read_token)
+        .send()
+        .await?;
+    assert_eq!(wrong_scope.status(), StatusCode::NOT_FOUND);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_auth_challenges_missing_tokens_and_forbids_read_only_writes()
+-> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+
+    let missing_root_auth = client
+        .get(format!("{}/v2/", runtime.base_url()))
+        .send()
+        .await?;
+    assert_eq!(missing_root_auth.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        missing_root_auth
+            .headers()
+            .get("WWW-Authenticate")
+            .and_then(|value| value.to_str().ok()),
+        Some(
+            format!(
+                "Bearer realm=\"{}/v2/token\",service=\"shardline\"",
+                runtime.base_url()
+            )
+            .as_str()
+        )
+    );
+
+    let insufficient_scope = client
+        .post(format!(
+            "{}/v2/team/assets/blobs/uploads",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(insufficient_scope.status(), StatusCode::FORBIDDEN);
+    assert!(
+        insufficient_scope
+            .headers()
+            .get("WWW-Authenticate")
+            .is_none()
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_registry_token_exchange_supports_basic_client_credentials()
+-> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+
+    let blob_bytes = br#"{"architecture":"amd64","os":"linux"}"#;
+    let blob_digest = hex::encode(Sha256::digest(blob_bytes));
+    let blob_upload = client
+        .post(format!(
+            "{}/v2/team/assets/blobs/uploads?digest=sha256:{blob_digest}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .body(blob_bytes.as_slice().to_vec())
+        .send()
+        .await?;
+    assert_eq!(blob_upload.status(), StatusCode::CREATED);
+
+    let manifest = serde_json::to_vec(&json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": format!("sha256:{blob_digest}"),
+            "size": blob_bytes.len(),
+        },
+        "layers": [],
+    }))?;
+    let manifest_put = client
+        .put(format!(
+            "{}/v2/team/assets/manifests/v1",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .header(CONTENT_TYPE, "application/vnd.oci.image.manifest.v1+json")
+        .body(manifest)
+        .send()
+        .await?;
+    assert_eq!(manifest_put.status(), StatusCode::CREATED);
+
+    let missing_auth = client
+        .get(format!(
+            "{}/v2/team/assets/manifests/v1",
+            runtime.base_url()
+        ))
+        .send()
+        .await?;
+    assert_eq!(missing_auth.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        missing_auth
+            .headers()
+            .get("WWW-Authenticate")
+            .and_then(|value| value.to_str().ok()),
+        Some(
+            format!(
+                "Bearer realm=\"{}/v2/token\",service=\"shardline\",scope=\"repository:team/assets:pull\"",
+                runtime.base_url()
+            )
+            .as_str()
+        )
+    );
+
+    let basic_credentials = BASE64_STANDARD.encode(format!("builder:{read_token}"));
+    let exchanged = client
+        .get(format!(
+            "{}/v2/token?service=shardline&scope=repository:team/assets:pull&account=protocol-user-1",
+            runtime.base_url()
+        ))
+        .header(AUTHORIZATION, format!("Basic {basic_credentials}"))
+        .send()
+        .await?;
+    assert_eq!(exchanged.status(), StatusCode::OK);
+    let exchanged = exchanged.json::<Value>().await?;
+    let registry_token = exchanged["token"].as_str().ok_or("missing token")?;
+    assert_eq!(exchanged["access_token"], exchanged["token"]);
+
+    let fetched = client
+        .get(format!(
+            "{}/v2/team/assets/manifests/v1",
+            runtime.base_url()
+        ))
+        .bearer_auth(registry_token)
+        .send()
+        .await?;
+    assert_eq!(fetched.status(), StatusCode::OK);
+
+    let denied_push = client
+        .get(format!(
+            "{}/v2/token?service=shardline&scope=repository:team/assets:pull,push&account=protocol-user-1",
+            runtime.base_url()
+        ))
+        .header(AUTHORIZATION, format!("Basic {basic_credentials}"))
+        .send()
+        .await?;
+    assert_eq!(denied_push.status(), StatusCode::FORBIDDEN);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_registry_token_exchange_rejects_duplicate_service_or_oversized_query_values()
+-> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+    let basic_credentials = BASE64_STANDARD.encode(format!("stexs:{read_token}"));
+
+    let duplicate_service = client
+        .get(format!(
+            "{}/v2/token?service=shardline&service=shardline&scope=repository:team/assets:pull",
+            runtime.base_url()
+        ))
+        .header(AUTHORIZATION, format!("Basic {basic_credentials}"))
+        .send()
+        .await?;
+    assert_eq!(duplicate_service.status(), StatusCode::BAD_REQUEST);
+
+    let oversized_scope = client
+        .get(format!(
+            "{}/v2/token?service=shardline&scope={}",
+            runtime.base_url(),
+            "a".repeat(2_048)
+        ))
+        .header(AUTHORIZATION, format!("Basic {basic_credentials}"))
+        .send()
+        .await?;
+    assert_eq!(oversized_scope.status(), StatusCode::URI_TOO_LONG);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_registry_token_exchange_merges_repeated_scope_values_for_one_repository()
+-> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let basic_credentials = BASE64_STANDARD.encode(format!("stexs:{write_token}"));
+
+    let exchanged = client
+        .get(format!(
+            "{}/v2/token?service=shardline&scope=repository:team/assets:pull&scope=repository:team/assets:pull,push",
+            runtime.base_url()
+        ))
+        .header(AUTHORIZATION, format!("Basic {basic_credentials}"))
+        .send()
+        .await?;
+    assert_eq!(exchanged.status(), StatusCode::OK);
+
+    let exchanged = exchanged.json::<Value>().await?;
+    let registry_token = exchanged["token"].as_str().ok_or("missing token")?;
+    let write_probe = client
+        .post(format!(
+            "{}/v2/team/assets/blobs/uploads",
+            runtime.base_url()
+        ))
+        .bearer_auth(registry_token)
+        .send()
+        .await?;
+    assert_eq!(write_probe.status(), StatusCode::ACCEPTED);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_registry_token_exchange_uses_dedicated_ttl_and_reports_metrics()
+-> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime_with_oci_token_limits(
+        &[ServerFrontend::Oci],
+        NonZeroU64::new(1).unwrap_or(NonZeroU64::MIN),
+        NonZeroUsize::new(4).unwrap_or(NonZeroUsize::MIN),
+    )
+    .await?;
+    let client = Client::new();
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+    let basic_credentials = BASE64_STANDARD.encode(format!("stexs:{read_token}"));
+
+    let exchanged = client
+        .get(format!(
+            "{}/v2/token?service=shardline&scope=repository:team/assets:pull",
+            runtime.base_url()
+        ))
+        .header(AUTHORIZATION, format!("Basic {basic_credentials}"))
+        .send()
+        .await?;
+    assert_eq!(exchanged.status(), StatusCode::OK);
+    let exchanged = exchanged.json::<Value>().await?;
+    let expires_in = exchanged["expires_in"]
+        .as_u64()
+        .ok_or("missing expires_in")?;
+    assert!(expires_in <= 1);
+
+    let metrics = client
+        .get(format!("{}/metrics", runtime.base_url()))
+        .send()
+        .await?;
+    assert_eq!(metrics.status(), StatusCode::OK);
+    let metrics = metrics.text().await?;
+    assert!(metrics.contains("shardline_oci_registry_token_ttl_seconds 1"));
+    assert!(metrics.contains("shardline_oci_registry_token_max_in_flight_requests 4"));
+    assert!(metrics.contains("shardline_oci_registry_token_requests_total 1"));
+    assert!(metrics.contains("shardline_oci_registry_token_rate_limited_total 0"));
+    assert!(metrics.contains("shardline_oci_registry_token_active_requests 0"));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_manifest_get_honors_accept_headers() -> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+
+    let blob_bytes = br#"{"architecture":"amd64","os":"linux"}"#;
+    let blob_digest = hex::encode(Sha256::digest(blob_bytes));
+    let blob_upload = client
+        .post(format!(
+            "{}/v2/team/assets/blobs/uploads?digest=sha256:{blob_digest}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .body(blob_bytes.as_slice().to_vec())
+        .send()
+        .await?;
+    assert_eq!(blob_upload.status(), StatusCode::CREATED);
+
+    let manifest = serde_json::to_vec(&json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": format!("sha256:{blob_digest}"),
+            "size": blob_bytes.len(),
+        },
+        "layers": [],
+    }))?;
+    let manifest_put = client
+        .put(format!(
+            "{}/v2/team/assets/manifests/v1",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .header(CONTENT_TYPE, "application/vnd.oci.image.manifest.v1+json")
+        .body(manifest)
+        .send()
+        .await?;
+    assert_eq!(manifest_put.status(), StatusCode::CREATED);
+
+    let exact_accept = client
+        .get(format!(
+            "{}/v2/team/assets/manifests/v1",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .header(ACCEPT, "application/vnd.oci.image.manifest.v1+json")
+        .send()
+        .await?;
+    assert_eq!(exact_accept.status(), StatusCode::OK);
+
+    let wildcard_accept = client
+        .head(format!(
+            "{}/v2/team/assets/manifests/v1",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .header(ACCEPT, "application/*")
+        .send()
+        .await?;
+    assert_eq!(wildcard_accept.status(), StatusCode::OK);
+
+    let incompatible_accept = client
+        .get(format!(
+            "{}/v2/team/assets/manifests/v1",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .header(ACCEPT, "application/vnd.oci.image.index.v1+json")
+        .send()
+        .await?;
+    assert_eq!(incompatible_accept.status(), StatusCode::NOT_ACCEPTABLE);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_blob_head_range_and_manifest_digest_resolution_work()
+-> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+
+    let blob_bytes = b"abcdefghij";
+    let blob_digest = hex::encode(Sha256::digest(blob_bytes));
+    let blob_upload = client
+        .post(format!(
+            "{}/v2/team/assets/blobs/uploads?digest=sha256:{blob_digest}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .body(blob_bytes.as_slice().to_vec())
+        .send()
+        .await?;
+    assert_eq!(blob_upload.status(), StatusCode::CREATED);
+
+    let blob_head = client
+        .head(format!(
+            "{}/v2/team/assets/blobs/sha256:{blob_digest}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(blob_head.status(), StatusCode::OK);
+    assert_eq!(
+        blob_head
+            .headers()
+            .get(CONTENT_LENGTH)
+            .and_then(|value| value.to_str().ok()),
+        Some("10")
+    );
+    assert_eq!(
+        blob_head
+            .headers()
+            .get("Docker-Content-Digest")
+            .and_then(|value| value.to_str().ok()),
+        Some(format!("sha256:{blob_digest}").as_str())
+    );
+
+    let blob_range = client
+        .get(format!(
+            "{}/v2/team/assets/blobs/sha256:{blob_digest}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .header("Range", "bytes=2-5")
+        .send()
+        .await?;
+    assert_eq!(blob_range.status(), StatusCode::PARTIAL_CONTENT);
+    assert_eq!(
+        blob_range
+            .headers()
+            .get("Content-Range")
+            .and_then(|value| value.to_str().ok()),
+        Some("bytes 2-5/10")
+    );
+    assert_eq!(blob_range.bytes().await?.as_ref(), b"cdef");
+
+    let manifest_bytes = serde_json::to_vec(&json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": format!("sha256:{blob_digest}"),
+            "size": blob_bytes.len(),
+        },
+        "layers": [],
+    }))?;
+    let manifest_digest = hex::encode(Sha256::digest(&manifest_bytes));
+    let manifest_put = client
+        .put(format!(
+            "{}/v2/team/assets/manifests/v1",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .header(CONTENT_TYPE, "application/vnd.oci.image.manifest.v1+json")
+        .body(manifest_bytes.clone())
+        .send()
+        .await?;
+    assert_eq!(manifest_put.status(), StatusCode::CREATED);
+
+    let manifest_head = client
+        .head(format!(
+            "{}/v2/team/assets/manifests/sha256:{manifest_digest}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(manifest_head.status(), StatusCode::OK);
+    assert_eq!(
+        manifest_head
+            .headers()
+            .get("Docker-Content-Digest")
+            .and_then(|value| value.to_str().ok()),
+        Some(format!("sha256:{manifest_digest}").as_str())
+    );
+
+    let manifest_get = client
+        .get(format!(
+            "{}/v2/team/assets/manifests/sha256:{manifest_digest}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(manifest_get.status(), StatusCode::OK);
+    assert_eq!(
+        manifest_get.bytes().await?.as_ref(),
+        manifest_bytes.as_slice()
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_index_manifest_round_trip_preserves_media_type()
+-> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+    let repository_scope = scoped_repository("team", "assets")?;
+
+    let child_manifest_a = serde_json::to_vec(&json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": format!("sha256:{}", "a".repeat(64)),
+            "size": 11,
+        },
+        "layers": [],
+    }))?;
+    let child_manifest_b = serde_json::to_vec(&json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": format!("sha256:{}", "b".repeat(64)),
+            "size": 12,
+        },
+        "layers": [],
+    }))?;
+    let child_manifest_a_digest = seed_oci_manifest(
+        &runtime,
+        "team/assets",
+        &repository_scope,
+        "application/vnd.oci.image.manifest.v1+json",
+        &child_manifest_a,
+    )?;
+    let child_manifest_b_digest = seed_oci_manifest(
+        &runtime,
+        "team/assets",
+        &repository_scope,
+        "application/vnd.oci.image.manifest.v1+json",
+        &child_manifest_b,
+    )?;
+
+    let index_bytes = serde_json::to_vec(&json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": [{
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "digest": format!("sha256:{child_manifest_a_digest}"),
+            "size": 123,
+            "platform": {
+                "architecture": "amd64",
+                "os": "linux",
+            },
+        }, {
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "digest": format!("sha256:{child_manifest_b_digest}"),
+            "size": 456,
+            "platform": {
+                "architecture": "arm64",
+                "os": "linux",
+            },
+        }],
+    }))?;
+    let index_digest = hex::encode(Sha256::digest(&index_bytes));
+
+    let put = client
+        .put(format!(
+            "{}/v2/team/assets/manifests/multi",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .header(CONTENT_TYPE, "application/vnd.oci.image.index.v1+json")
+        .body(index_bytes.clone())
+        .send()
+        .await?;
+    assert_eq!(put.status(), StatusCode::CREATED);
+    assert_eq!(
+        put.headers()
+            .get("Docker-Content-Digest")
+            .and_then(|value| value.to_str().ok()),
+        Some(format!("sha256:{index_digest}").as_str())
+    );
+
+    let head = client
+        .head(format!(
+            "{}/v2/team/assets/manifests/multi",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(head.status(), StatusCode::OK);
+    assert_eq!(
+        head.headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok()),
+        Some("application/vnd.oci.image.index.v1+json")
+    );
+
+    let get = client
+        .get(format!(
+            "{}/v2/team/assets/manifests/sha256:{index_digest}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(get.status(), StatusCode::OK);
+    assert_eq!(
+        get.headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok()),
+        Some("application/vnd.oci.image.index.v1+json")
+    );
+    assert_eq!(get.bytes().await?.as_ref(), index_bytes.as_slice());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_rejects_manifests_with_missing_blob_references()
+-> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let manifest_bytes = serde_json::to_vec(&json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "size": 17,
+            "digest": format!("sha256:{}", "1".repeat(64)),
+        },
+        "layers": [{
+            "mediaType": "application/vnd.oci.image.layer.v1.tar",
+            "size": 23,
+            "digest": format!("sha256:{}", "2".repeat(64)),
+        }],
+    }))?;
+
+    let response = client
+        .put(format!(
+            "{}/v2/team/assets/manifests/v1",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .header(CONTENT_TYPE, "application/vnd.oci.image.manifest.v1+json")
+        .body(manifest_bytes)
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_rejects_indexes_with_missing_child_manifests() -> Result<(), Box<dyn StdError>>
+{
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let index_bytes = serde_json::to_vec(&json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": [{
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "size": 91,
+            "digest": format!("sha256:{}", "3".repeat(64)),
+            "platform": {
+                "architecture": "amd64",
+                "os": "linux",
+            },
+        }],
+    }))?;
+
+    let response = client
+        .put(format!(
+            "{}/v2/team/assets/manifests/multi",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .header(CONTENT_TYPE, "application/vnd.oci.image.index.v1+json")
+        .body(index_bytes)
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_rejects_unsupported_or_mismatched_manifest_media_types()
+-> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let repository_scope = scoped_repository("team", "assets")?;
+    let config_bytes = br#"{"architecture":"amd64"}"#;
+    let layer_bytes = b"layer-bytes";
+    let config_digest = seed_oci_blob(&runtime, "team/assets", &repository_scope, config_bytes)?;
+    let layer_digest = seed_oci_blob(&runtime, "team/assets", &repository_scope, layer_bytes)?;
+    let mismatched_manifest = serde_json::to_vec(&json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "size": config_bytes.len(),
+            "digest": format!("sha256:{config_digest}"),
+        },
+        "layers": [{
+            "mediaType": "application/vnd.oci.image.layer.v1.tar",
+            "size": layer_bytes.len(),
+            "digest": format!("sha256:{layer_digest}"),
+        }],
+    }))?;
+
+    let mismatched = client
+        .put(format!(
+            "{}/v2/team/assets/manifests/v1",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .header(CONTENT_TYPE, "application/vnd.oci.image.manifest.v1+json")
+        .body(mismatched_manifest)
+        .send()
+        .await?;
+    assert_eq!(mismatched.status(), StatusCode::BAD_REQUEST);
+
+    let unsupported = client
+        .put(format!(
+            "{}/v2/team/assets/manifests/v1",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .header(CONTENT_TYPE, "text/plain")
+        .body(br#"{"schemaVersion":2}"#.to_vec())
+        .send()
+        .await?;
+    assert_eq!(unsupported.status(), StatusCode::BAD_REQUEST);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_mounts_existing_blob_into_nested_repository() -> Result<(), Box<dyn StdError>>
+{
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+    let repository_scope = scoped_repository("team", "assets")?;
+    let source_bytes = b"mounted blob";
+    let digest_hex = seed_oci_blob(
+        &runtime,
+        "team/assets/source",
+        &repository_scope,
+        source_bytes,
+    )?;
+
+    let mount = client
+        .post(format!(
+            "{}/v2/team/assets/target/blobs/uploads?mount=sha256:{digest_hex}&from=team/assets/source",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(mount.status(), StatusCode::CREATED);
+    assert_eq!(
+        mount
+            .headers()
+            .get("Docker-Content-Digest")
+            .and_then(|value| value.to_str().ok()),
+        Some(format!("sha256:{digest_hex}").as_str())
+    );
+
+    let mounted_blob = client
+        .get(format!(
+            "{}/v2/team/assets/target/blobs/sha256:{digest_hex}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(mounted_blob.status(), StatusCode::OK);
+    assert_eq!(mounted_blob.bytes().await?.as_ref(), source_bytes);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_tags_list_is_paginated_and_validates_inputs() -> Result<(), Box<dyn StdError>>
+{
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+    let repository_scope = scoped_repository("team", "assets")?;
+
+    for tag in ["v3", "v1", "v2"] {
+        let config_bytes = tag.as_bytes();
+        let config_digest =
+            seed_oci_blob(&runtime, "team/assets", &repository_scope, config_bytes)?;
+        let manifest = serde_json::to_vec(&json!({
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "config": {
+                "mediaType": "application/vnd.oci.image.config.v1+json",
+                "digest": format!("sha256:{config_digest}"),
+                "size": config_bytes.len(),
+            },
+            "layers": [],
+        }))?;
+        let response = client
+            .put(format!(
+                "{}/v2/team/assets/manifests/{tag}",
+                runtime.base_url()
+            ))
+            .bearer_auth(&write_token)
+            .header(CONTENT_TYPE, "application/vnd.oci.image.manifest.v1+json")
+            .body(manifest)
+            .send()
+            .await?;
+        assert_eq!(response.status(), StatusCode::CREATED);
+    }
+
+    let first_page = client
+        .get(format!(
+            "{}/v2/team/assets/tags/list?n=2",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(first_page.status(), StatusCode::OK);
+    assert_eq!(
+        first_page
+            .headers()
+            .get("link")
+            .and_then(|value| value.to_str().ok()),
+        Some("</v2/team/assets/tags/list?n=2&last=v2>; rel=\"next\"")
+    );
+    let first_page = first_page.json::<Value>().await?;
+    assert_eq!(first_page["tags"], json!(["v1", "v2"]));
+
+    let second_page = client
+        .get(format!(
+            "{}/v2/team/assets/tags/list?n=2&last=v2",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(second_page.status(), StatusCode::OK);
+    assert!(second_page.headers().get("link").is_none());
+    let second_page = second_page.json::<Value>().await?;
+    assert_eq!(second_page["tags"], json!(["v3"]));
+
+    let invalid_page_size = client
+        .get(format!(
+            "{}/v2/team/assets/tags/list?n=0",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(invalid_page_size.status(), StatusCode::BAD_REQUEST);
+
+    let invalid_last = client
+        .get(format!(
+            "{}/v2/team/assets/tags/list?last=bad/tag",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(invalid_last.status(), StatusCode::BAD_REQUEST);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_chunked_upload_and_invalid_tag_rejection() -> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+
+    let start_upload = client
+        .post(format!(
+            "{}/v2/team/assets/blobs/uploads",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(start_upload.status(), StatusCode::ACCEPTED);
+    let upload_location = start_upload
+        .headers()
+        .get(LOCATION)
+        .and_then(|value| value.to_str().ok())
+        .ok_or("missing upload location")?;
+    let upload_url = format!("{}{}", runtime.base_url(), upload_location);
+
+    let patch = client
+        .patch(&upload_url)
+        .bearer_auth(&write_token)
+        .header(CONTENT_RANGE, "0-3")
+        .body(b"abcd".to_vec())
+        .send()
+        .await?;
+    assert_eq!(patch.status(), StatusCode::ACCEPTED);
+
+    let status = client
+        .get(&upload_url)
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(status.status(), StatusCode::NO_CONTENT);
+    assert_eq!(
+        status
+            .headers()
+            .get("range")
+            .and_then(|value| value.to_str().ok()),
+        Some("0-3")
+    );
+
+    let blob_bytes = b"abcdefgh";
+    let blob_digest = hex::encode(Sha256::digest(blob_bytes));
+    let complete = client
+        .put(format!("{upload_url}?digest=sha256:{blob_digest}"))
+        .bearer_auth(&write_token)
+        .header(CONTENT_RANGE, "4-7")
+        .body(b"efgh".to_vec())
+        .send()
+        .await?;
+    assert_eq!(complete.status(), StatusCode::CREATED);
+
+    let blob_get = client
+        .get(format!(
+            "{}/v2/team/assets/blobs/sha256:{blob_digest}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(blob_get.status(), StatusCode::OK);
+    assert_eq!(blob_get.bytes().await?.as_ref(), blob_bytes);
+
+    let manifest = json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": format!("sha256:{blob_digest}"),
+            "size": blob_bytes.len(),
+        },
+        "layers": [],
+    });
+    let invalid_tag = client
+        .put(format!(
+            "{}/v2/team/assets/manifests/v2?tag=bad/tag",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .header(CONTENT_TYPE, "application/vnd.oci.image.manifest.v1+json")
+        .body(serde_json::to_vec(&manifest)?)
+        .send()
+        .await?;
+    assert_eq!(invalid_tag.status(), StatusCode::BAD_REQUEST);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_delete_upload_session_cancels_pending_blob() -> Result<(), Box<dyn StdError>>
+{
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+
+    let start_upload = client
+        .post(format!(
+            "{}/v2/team/assets/blobs/uploads",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(start_upload.status(), StatusCode::ACCEPTED);
+    let upload_location = start_upload
+        .headers()
+        .get(LOCATION)
+        .and_then(|value| value.to_str().ok())
+        .ok_or("missing upload location")?;
+    let upload_url = format!("{}{}", runtime.base_url(), upload_location);
+
+    let patch = client
+        .patch(&upload_url)
+        .bearer_auth(&write_token)
+        .body(b"abcd".to_vec())
+        .send()
+        .await?;
+    assert_eq!(patch.status(), StatusCode::ACCEPTED);
+
+    let delete = client
+        .delete(&upload_url)
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(delete.status(), StatusCode::NO_CONTENT);
+
+    let status = client
+        .get(&upload_url)
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(status.status(), StatusCode::NOT_FOUND);
+
+    let finalize = client
+        .put(format!(
+            "{upload_url}?digest=sha256:{}",
+            hex::encode(Sha256::digest(b"abcdefgh"))
+        ))
+        .bearer_auth(&write_token)
+        .body(b"efgh".to_vec())
+        .send()
+        .await?;
+    assert_eq!(finalize.status(), StatusCode::NOT_FOUND);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_delete_manifest_by_digest_removes_tags_but_leaves_blobs()
+-> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+
+    let blob_bytes = br#"{"architecture":"amd64","os":"linux"}"#;
+    let blob_digest = hex::encode(Sha256::digest(blob_bytes));
+    let blob_upload = client
+        .post(format!(
+            "{}/v2/team/assets/blobs/uploads?digest=sha256:{blob_digest}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .body(blob_bytes.as_slice().to_vec())
+        .send()
+        .await?;
+    assert_eq!(blob_upload.status(), StatusCode::CREATED);
+
+    let manifest_bytes = serde_json::to_vec(&json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": format!("sha256:{blob_digest}"),
+            "size": blob_bytes.len(),
+        },
+        "layers": [],
+    }))?;
+    let manifest_digest = hex::encode(Sha256::digest(&manifest_bytes));
+    let manifest_put = client
+        .put(format!(
+            "{}/v2/team/assets/manifests/v1?tag=stable",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .header(CONTENT_TYPE, "application/vnd.oci.image.manifest.v1+json")
+        .body(manifest_bytes)
+        .send()
+        .await?;
+    assert_eq!(manifest_put.status(), StatusCode::CREATED);
+
+    let delete_by_tag = client
+        .delete(format!(
+            "{}/v2/team/assets/manifests/v1",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(delete_by_tag.status(), StatusCode::BAD_REQUEST);
+
+    let delete = client
+        .delete(format!(
+            "{}/v2/team/assets/manifests/sha256:{manifest_digest}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(delete.status(), StatusCode::ACCEPTED);
+
+    let manifest_by_digest = client
+        .get(format!(
+            "{}/v2/team/assets/manifests/sha256:{manifest_digest}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(manifest_by_digest.status(), StatusCode::NOT_FOUND);
+
+    let manifest_by_tag = client
+        .get(format!(
+            "{}/v2/team/assets/manifests/v1",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(manifest_by_tag.status(), StatusCode::NOT_FOUND);
+
+    let tags = client
+        .get(format!("{}/v2/team/assets/tags/list", runtime.base_url()))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(tags.status(), StatusCode::OK);
+    let tags = tags.json::<Value>().await?;
+    assert_eq!(tags["tags"], json!([]));
+
+    let blob = client
+        .get(format!(
+            "{}/v2/team/assets/blobs/sha256:{blob_digest}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(blob.status(), StatusCode::OK);
+    assert_eq!(blob.bytes().await?.as_ref(), blob_bytes);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_retagging_preserves_latest_manifest_when_old_digest_is_deleted()
+-> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+
+    async fn upload_manifest(
+        client: &Client,
+        runtime: &ProtocolFrontendRuntime,
+        write_token: &str,
+        blob_bytes: &[u8],
+    ) -> Result<String, Box<dyn StdError>> {
+        let blob_digest = hex::encode(Sha256::digest(blob_bytes));
+        let blob_upload = client
+            .post(format!(
+                "{}/v2/team/assets/blobs/uploads?digest=sha256:{blob_digest}",
+                runtime.base_url()
+            ))
+            .bearer_auth(write_token)
+            .body(blob_bytes.to_vec())
+            .send()
+            .await?;
+        assert_eq!(blob_upload.status(), StatusCode::CREATED);
+
+        let manifest_bytes = serde_json::to_vec(&json!({
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "config": {
+                "mediaType": "application/vnd.oci.image.config.v1+json",
+                "digest": format!("sha256:{blob_digest}"),
+                "size": blob_bytes.len(),
+            },
+            "layers": [],
+        }))?;
+        let manifest_digest = hex::encode(Sha256::digest(&manifest_bytes));
+        let manifest_put = client
+            .put(format!(
+                "{}/v2/team/assets/manifests/latest",
+                runtime.base_url()
+            ))
+            .bearer_auth(write_token)
+            .header(CONTENT_TYPE, "application/vnd.oci.image.manifest.v1+json")
+            .body(manifest_bytes)
+            .send()
+            .await?;
+        assert_eq!(manifest_put.status(), StatusCode::CREATED);
+
+        Ok(manifest_digest)
+    }
+
+    let first_digest =
+        upload_manifest(&client, &runtime, &write_token, br#"{"version":1}"#).await?;
+    let second_digest =
+        upload_manifest(&client, &runtime, &write_token, br#"{"version":2}"#).await?;
+    assert_ne!(first_digest, second_digest);
+
+    let delete_first = client
+        .delete(format!(
+            "{}/v2/team/assets/manifests/sha256:{first_digest}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(delete_first.status(), StatusCode::ACCEPTED);
+
+    let latest = client
+        .get(format!(
+            "{}/v2/team/assets/manifests/latest",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(latest.status(), StatusCode::OK);
+    assert_eq!(
+        latest
+            .headers()
+            .get("Docker-Content-Digest")
+            .and_then(|value| value.to_str().ok()),
+        Some(format!("sha256:{second_digest}").as_str())
+    );
+
+    let delete_second = client
+        .delete(format!(
+            "{}/v2/team/assets/manifests/sha256:{second_digest}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(delete_second.status(), StatusCode::ACCEPTED);
+
+    let missing = client
+        .get(format!(
+            "{}/v2/team/assets/manifests/latest",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_rejects_manifest_digest_reference_mismatch() -> Result<(), Box<dyn StdError>>
+{
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let manifest_bytes = serde_json::to_vec(&json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": format!("sha256:{}", "2".repeat(64)),
+            "size": 0,
+        },
+        "layers": [],
+    }))?;
+
+    let response = client
+        .put(format!(
+            "{}/v2/team/assets/manifests/sha256:{}",
+            runtime.base_url(),
+            "1".repeat(64)
+        ))
+        .bearer_auth(&write_token)
+        .header(CONTENT_TYPE, "application/vnd.oci.image.manifest.v1+json")
+        .body(manifest_bytes)
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_rejects_cross_scope_upload_session_access() -> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let other_write_token = bearer_token(
+        "protocol-user-2",
+        TokenScope::Write,
+        RepositoryProvider::Generic,
+        "team",
+        "assets",
+        Some("main"),
+    )?;
+
+    let start_upload = client
+        .post(format!(
+            "{}/v2/team/assets/blobs/uploads",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(start_upload.status(), StatusCode::ACCEPTED);
+    let upload_location = start_upload
+        .headers()
+        .get(LOCATION)
+        .and_then(|value| value.to_str().ok())
+        .ok_or("missing upload location")?;
+    let upload_url = format!("{}{}", runtime.base_url(), upload_location);
+
+    let patch = client
+        .patch(&upload_url)
+        .bearer_auth(&other_write_token)
+        .body(b"abcd".to_vec())
+        .send()
+        .await?;
+    assert_eq!(patch.status(), StatusCode::NOT_FOUND);
+
+    let status = client
+        .get(&upload_url)
+        .bearer_auth(&other_write_token)
+        .send()
+        .await?;
+    assert_eq!(status.status(), StatusCode::NOT_FOUND);
+
+    let delete = client
+        .delete(&upload_url)
+        .bearer_auth(&other_write_token)
+        .send()
+        .await?;
+    assert_eq!(delete.status(), StatusCode::NOT_FOUND);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_rejects_repository_paths_outside_token_scope() -> Result<(), Box<dyn StdError>>
+{
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+
+    let create_upload = client
+        .post(format!(
+            "{}/v2/team/other/blobs/uploads",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(create_upload.status(), StatusCode::NOT_FOUND);
+
+    let tags = client
+        .get(format!("{}/v2/team/other/tags/list", runtime.base_url()))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(tags.status(), StatusCode::NOT_FOUND);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_rejects_excessive_manifest_tag_aliases() -> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let manifest = serde_json::to_vec(&json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": format!("sha256:{}", "1".repeat(64)),
+            "size": 0,
+        },
+        "layers": [],
+    }))?;
+    let query = (0..129)
+        .map(|index| format!("tag=t{index}"))
+        .collect::<Vec<_>>()
+        .join("&");
+
+    let response = client
+        .put(format!(
+            "{}/v2/team/assets/manifests/v1?{query}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .header(CONTENT_TYPE, "application/vnd.oci.image.manifest.v1+json")
+        .body(manifest)
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_rejects_oversized_query_strings() -> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let oversized_from = "a".repeat(16_385);
+
+    let response = client
+        .post(format!(
+            "{}/v2/team/assets/blobs/uploads?mount=sha256:{}&from={oversized_from}",
+            runtime.base_url(),
+            "1".repeat(64)
+        ))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::URI_TOO_LONG);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_rejects_cumulative_chunked_upload_growth_past_limit()
+-> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime_with_max_request_body(
+        &[ServerFrontend::Oci],
+        NonZeroUsize::new(8).unwrap_or(NonZeroUsize::MIN),
+    )
+    .await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+
+    let start_upload = client
+        .post(format!(
+            "{}/v2/team/assets/blobs/uploads",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(start_upload.status(), StatusCode::ACCEPTED);
+    let upload_location = start_upload
+        .headers()
+        .get(LOCATION)
+        .and_then(|value| value.to_str().ok())
+        .ok_or("missing upload location")?;
+    let upload_url = format!("{}{}", runtime.base_url(), upload_location);
+
+    let first_patch = client
+        .patch(&upload_url)
+        .bearer_auth(&write_token)
+        .header(CONTENT_RANGE, "0-7")
+        .body(b"abcdefgh".to_vec())
+        .send()
+        .await?;
+    assert_eq!(first_patch.status(), StatusCode::ACCEPTED);
+
+    let second_patch = client
+        .patch(&upload_url)
+        .bearer_auth(&write_token)
+        .body(b"i".to_vec())
+        .send()
+        .await?;
+    assert_eq!(second_patch.status(), StatusCode::PAYLOAD_TOO_LARGE);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_mount_copy_is_not_limited_by_request_body_budget()
+-> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime_with_max_request_body(
+        &[ServerFrontend::Oci],
+        NonZeroUsize::new(8).unwrap_or(NonZeroUsize::MIN),
+    )
+    .await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let repository_scope = scoped_repository("team", "assets")?;
+    let digest_hex = seed_oci_blob(
+        &runtime,
+        "team/assets/source",
+        &repository_scope,
+        b"012345678",
+    )?;
+
+    let response = client
+        .post(format!(
+            "{}/v2/team/assets/target/blobs/uploads?mount=sha256:{digest_hex}&from=team/assets/source",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let expected_digest_header = format!("sha256:{digest_hex}");
+    assert_eq!(
+        response
+            .headers()
+            .get("Docker-Content-Digest")
+            .and_then(|value| value.to_str().ok()),
+        Some(expected_digest_header.as_str())
+    );
+
+    let mounted = client
+        .get(format!(
+            "{}/v2/team/assets/target/blobs/sha256:{digest_hex}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(mounted.status(), StatusCode::OK);
+    assert_eq!(mounted.bytes().await?.as_ref(), b"012345678");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_rejects_excessive_live_upload_sessions() -> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime_with_oci_limits(
+        &[ServerFrontend::Oci],
+        NonZeroU64::new(60).unwrap_or(NonZeroU64::MIN),
+        NonZeroUsize::new(1).unwrap_or(NonZeroUsize::MIN),
+    )
+    .await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+
+    let first = client
+        .post(format!(
+            "{}/v2/team/assets/blobs/uploads",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(first.status(), StatusCode::ACCEPTED);
+
+    let second = client
+        .post(format!(
+            "{}/v2/team/assets/blobs/uploads",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_reclaims_orphaned_upload_sessions_with_missing_body()
+-> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime_with_oci_limits(
+        &[ServerFrontend::Oci],
+        NonZeroU64::new(60).unwrap_or(NonZeroU64::MIN),
+        NonZeroUsize::new(1).unwrap_or(NonZeroUsize::MIN),
+    )
+    .await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+
+    let first = client
+        .post(format!(
+            "{}/v2/team/assets/blobs/uploads",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(first.status(), StatusCode::ACCEPTED);
+    let upload_location = first
+        .headers()
+        .get(LOCATION)
+        .and_then(|value| value.to_str().ok())
+        .ok_or("missing upload location")?;
+    let session_id = upload_location
+        .rsplit('/')
+        .next()
+        .ok_or("missing upload session id")?;
+    fs::remove_file(
+        runtime
+            .storage_path()
+            .join("oci-uploads")
+            .join(format!("{session_id}.bin")),
+    )?;
+
+    let second = client
+        .post(format!(
+            "{}/v2/team/assets/blobs/uploads",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(second.status(), StatusCode::ACCEPTED);
+
+    let stale = client
+        .get(format!("{}{}", runtime.base_url(), upload_location))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(stale.status(), StatusCode::NOT_FOUND);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_expires_idle_upload_sessions() -> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime_with_oci_limits(
+        &[ServerFrontend::Oci],
+        NonZeroU64::new(1).unwrap_or(NonZeroU64::MIN),
+        NonZeroUsize::new(8).unwrap_or(NonZeroUsize::MIN),
+    )
+    .await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+
+    let start_upload = client
+        .post(format!(
+            "{}/v2/team/assets/blobs/uploads",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(start_upload.status(), StatusCode::ACCEPTED);
+    let upload_location = start_upload
+        .headers()
+        .get(LOCATION)
+        .and_then(|value| value.to_str().ok())
+        .ok_or("missing upload location")?;
+    let upload_url = format!("{}{}", runtime.base_url(), upload_location);
+
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    let status = client
+        .get(&upload_url)
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(status.status(), StatusCode::NOT_FOUND);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_shared_root_upload_sessions_work_across_runtime_instances()
+-> Result<(), Box<dyn StdError>> {
+    let shared_root = tempfile::tempdir()?;
+    let first = start_protocol_runtime_on_shared_root(
+        &[ServerFrontend::Oci],
+        shared_root.path(),
+        |config| config,
+    )
+    .await?;
+    let second = start_protocol_runtime_on_shared_root(
+        &[ServerFrontend::Oci],
+        shared_root.path(),
+        |config| config,
+    )
+    .await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+
+    let start_upload = client
+        .post(format!("{}/v2/team/assets/blobs/uploads", first.base_url()))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(start_upload.status(), StatusCode::ACCEPTED);
+    let upload_location = start_upload
+        .headers()
+        .get(LOCATION)
+        .and_then(|value| value.to_str().ok())
+        .ok_or("missing upload location")?;
+    let upload_url = format!("{}{}", second.base_url(), upload_location);
+
+    let patch = client
+        .patch(&upload_url)
+        .bearer_auth(&write_token)
+        .header(CONTENT_RANGE, "0-3")
+        .body(b"abcd".to_vec())
+        .send()
+        .await?;
+    assert_eq!(patch.status(), StatusCode::ACCEPTED);
+
+    let blob_bytes = b"abcdefgh";
+    let blob_digest = hex::encode(Sha256::digest(blob_bytes));
+    let finalize = client
+        .put(format!(
+            "{}{}?digest=sha256:{blob_digest}",
+            first.base_url(),
+            upload_location
+        ))
+        .bearer_auth(&write_token)
+        .header(CONTENT_RANGE, "4-7")
+        .body(b"efgh".to_vec())
+        .send()
+        .await?;
+    assert_eq!(finalize.status(), StatusCode::CREATED);
+
+    let blob = client
+        .get(format!(
+            "{}/v2/team/assets/blobs/sha256:{blob_digest}",
+            second.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(blob.status(), StatusCode::OK);
+    assert_eq!(blob.bytes().await?.as_ref(), blob_bytes);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_shared_root_upload_session_limits_span_runtime_instances()
+-> Result<(), Box<dyn StdError>> {
+    let shared_root = tempfile::tempdir()?;
+    let first = start_protocol_runtime_on_shared_root(
+        &[ServerFrontend::Oci],
+        shared_root.path(),
+        |config| {
+            config
+                .with_oci_upload_session_ttl_seconds(NonZeroU64::new(60).unwrap_or(NonZeroU64::MIN))
+                .with_oci_upload_max_active_sessions(
+                    NonZeroUsize::new(1).unwrap_or(NonZeroUsize::MIN),
+                )
+        },
+    )
+    .await?;
+    let second = start_protocol_runtime_on_shared_root(
+        &[ServerFrontend::Oci],
+        shared_root.path(),
+        |config| {
+            config
+                .with_oci_upload_session_ttl_seconds(NonZeroU64::new(60).unwrap_or(NonZeroU64::MIN))
+                .with_oci_upload_max_active_sessions(
+                    NonZeroUsize::new(1).unwrap_or(NonZeroUsize::MIN),
+                )
+        },
+    )
+    .await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+
+    let first_create = client
+        .post(format!("{}/v2/team/assets/blobs/uploads", first.base_url()))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(first_create.status(), StatusCode::ACCEPTED);
+
+    let second_create = client
+        .post(format!(
+            "{}/v2/team/assets/blobs/uploads",
+            second.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(second_create.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn oci_frontend_shared_root_manifest_deletes_are_visible_across_runtime_instances()
+-> Result<(), Box<dyn StdError>> {
+    let shared_root = tempfile::tempdir()?;
+    let first = start_protocol_runtime_on_shared_root(
+        &[ServerFrontend::Oci],
+        shared_root.path(),
+        |config| config,
+    )
+    .await?;
+    let second = start_protocol_runtime_on_shared_root(
+        &[ServerFrontend::Oci],
+        shared_root.path(),
+        |config| config,
+    )
+    .await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+
+    let blob_bytes = br#"{"architecture":"amd64","os":"linux"}"#;
+    let blob_digest = hex::encode(Sha256::digest(blob_bytes));
+    let blob_upload = client
+        .post(format!(
+            "{}/v2/team/assets/blobs/uploads?digest=sha256:{blob_digest}",
+            first.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .body(blob_bytes.as_slice().to_vec())
+        .send()
+        .await?;
+    assert_eq!(blob_upload.status(), StatusCode::CREATED);
+
+    let manifest_bytes = serde_json::to_vec(&json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": format!("sha256:{blob_digest}"),
+            "size": blob_bytes.len(),
+        },
+        "layers": [],
+    }))?;
+    let manifest_digest = hex::encode(Sha256::digest(&manifest_bytes));
+    let manifest_put = client
+        .put(format!(
+            "{}/v2/team/assets/manifests/v1?tag=stable",
+            first.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .header(CONTENT_TYPE, "application/vnd.oci.image.manifest.v1+json")
+        .body(manifest_bytes)
+        .send()
+        .await?;
+    assert_eq!(manifest_put.status(), StatusCode::CREATED);
+
+    let visible_on_second = client
+        .get(format!("{}/v2/team/assets/manifests/v1", second.base_url()))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(visible_on_second.status(), StatusCode::OK);
+
+    let delete = client
+        .delete(format!(
+            "{}/v2/team/assets/manifests/sha256:{manifest_digest}",
+            second.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .send()
+        .await?;
+    assert_eq!(delete.status(), StatusCode::ACCEPTED);
+
+    let missing_on_first = client
+        .get(format!("{}/v2/team/assets/manifests/v1", first.base_url()))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(missing_on_first.status(), StatusCode::NOT_FOUND);
+
+    Ok(())
+}

--- a/crates/server/src/app/tests/protocol_frontends_http.rs
+++ b/crates/server/src/app/tests/protocol_frontends_http.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::indexing_slicing, clippy::panic_in_result_fn)]
 
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
 use std::{
     error::Error as StdError,
     fs,
@@ -17,12 +19,17 @@ use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use tokio::{net::TcpListener, spawn, task::JoinHandle};
 
-use super::{bearer_token, serve_with_listener, wait_for_health};
+use super::{
+    bearer_token, serve_with_listener, single_chunk_xorb, single_file_shard, wait_for_health,
+};
 use crate::{
-    ServerConfig, ServerError, ServerFrontend,
+    FileReconstructionResponse, ServerConfig, ServerError, ServerFrontend,
+    bazel_http_adapter::{BazelCacheKind, bazel_cache_object_key},
+    lfs_adapter::lfs_object_key,
     local_backend::chunk_hash,
     object_store::ServerObjectStore,
     oci_adapter::{oci_blob_key, oci_manifest_key, oci_manifest_media_type_key},
+    protocol_support::shared_sha256_object_key,
 };
 use shardline_protocol::{RepositoryProvider, TokenScope};
 use shardline_storage::{ObjectBody, ObjectIntegrity};
@@ -559,6 +566,165 @@ async fn lfs_frontend_batch_reports_stored_object_size() -> Result<(), Box<dyn S
     assert_eq!(download_batch.status(), StatusCode::OK);
     let download_batch = download_batch.json::<Value>().await?;
     assert_eq!(download_batch["objects"][0]["size"], bytes.len());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mixed_frontends_share_digest_addressed_storage_and_keep_xet_working()
+-> Result<(), Box<dyn StdError>> {
+    let runtime = start_protocol_runtime(&[
+        ServerFrontend::Xet,
+        ServerFrontend::Lfs,
+        ServerFrontend::BazelHttp,
+        ServerFrontend::Oci,
+    ])
+    .await?;
+    let client = Client::new();
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+    let repository_scope = scoped_repository("team", "assets")?;
+
+    let shared_bytes = b"shared-frontends-payload";
+    let digest_hex = hex::encode(Sha256::digest(shared_bytes));
+
+    let lfs_upload = client
+        .put(format!(
+            "{}/v1/lfs/objects/{digest_hex}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .body(shared_bytes.as_slice().to_vec())
+        .send()
+        .await?;
+    assert_eq!(lfs_upload.status(), StatusCode::OK);
+
+    let bazel_upload = client
+        .put(format!(
+            "{}/v1/bazel/cache/cas/{digest_hex}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .body(shared_bytes.as_slice().to_vec())
+        .send()
+        .await?;
+    assert_eq!(bazel_upload.status(), StatusCode::NO_CONTENT);
+
+    let oci_upload = client
+        .post(format!(
+            "{}/v2/team/assets/blobs/uploads?digest=sha256:{digest_hex}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&write_token)
+        .body(shared_bytes.as_slice().to_vec())
+        .send()
+        .await?;
+    assert_eq!(oci_upload.status(), StatusCode::CREATED);
+
+    let lfs_download = client
+        .get(format!(
+            "{}/v1/lfs/objects/{digest_hex}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(lfs_download.status(), StatusCode::OK);
+    assert_eq!(lfs_download.bytes().await?.as_ref(), shared_bytes);
+
+    let bazel_download = client
+        .get(format!(
+            "{}/v1/bazel/cache/cas/{digest_hex}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(bazel_download.status(), StatusCode::OK);
+    assert_eq!(bazel_download.bytes().await?.as_ref(), shared_bytes);
+
+    let oci_download = client
+        .get(format!(
+            "{}/v2/team/assets/blobs/sha256:{digest_hex}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(oci_download.status(), StatusCode::OK);
+    assert_eq!(oci_download.bytes().await?.as_ref(), shared_bytes);
+
+    let (first_xorb, first_hash) = single_chunk_xorb(b"abcd");
+    let (second_xorb, second_hash) = single_chunk_xorb(b"efgh");
+    for (xorb_body, xorb_hash) in [
+        (first_xorb, first_hash.as_str()),
+        (second_xorb, second_hash.as_str()),
+    ] {
+        let uploaded = client
+            .post(format!(
+                "{}/v1/xorbs/default/{xorb_hash}",
+                runtime.base_url()
+            ))
+            .bearer_auth(&write_token)
+            .body(xorb_body)
+            .send()
+            .await?;
+        assert!(uploaded.status().is_success());
+    }
+    let (shard_body, file_hash) =
+        single_file_shard(&[(b"abcd", &first_hash), (b"efgh", &second_hash)]);
+    let shard_upload = client
+        .post(format!("{}/v1/shards", runtime.base_url()))
+        .bearer_auth(&write_token)
+        .body(shard_body)
+        .send()
+        .await?;
+    assert!(shard_upload.status().is_success());
+
+    let reconstruction = client
+        .get(format!(
+            "{}/v1/reconstructions/{file_hash}",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    assert_eq!(reconstruction.status(), StatusCode::OK);
+    let reconstruction = reconstruction.json::<FileReconstructionResponse>().await?;
+    assert_eq!(reconstruction.terms.len(), 2);
+    assert!(reconstruction.fetch_info.contains_key(&first_hash));
+    assert!(reconstruction.fetch_info.contains_key(&second_hash));
+
+    let object_store = ServerObjectStore::local(runtime.storage_path().join("chunks"))?;
+    let lfs_key = lfs_object_key(&digest_hex, Some(&repository_scope))?;
+    let bazel_key =
+        bazel_cache_object_key(BazelCacheKind::Cas, &digest_hex, Some(&repository_scope))?;
+    let oci_key = oci_blob_key("team/assets", &digest_hex, Some(&repository_scope))?;
+    let shared_key = shared_sha256_object_key(&digest_hex)?;
+    let lfs_path = object_store
+        .local_path_for_key(&lfs_key)
+        .ok_or("expected local object path for lfs object")?;
+    let bazel_path = object_store
+        .local_path_for_key(&bazel_key)
+        .ok_or("expected local object path for bazel object")?;
+    let oci_path = object_store
+        .local_path_for_key(&oci_key)
+        .ok_or("expected local object path for oci object")?;
+    let shared_path = object_store
+        .local_path_for_key(&shared_key)
+        .ok_or("expected local object path for shared object")?;
+
+    #[cfg(unix)]
+    {
+        let lfs_metadata = fs::metadata(&lfs_path)?;
+        let bazel_metadata = fs::metadata(&bazel_path)?;
+        let oci_metadata = fs::metadata(&oci_path)?;
+        let shared_metadata = fs::metadata(&shared_path)?;
+        assert_eq!(lfs_metadata.ino(), bazel_metadata.ino());
+        assert_eq!(lfs_metadata.ino(), oci_metadata.ino());
+        assert_eq!(lfs_metadata.ino(), shared_metadata.ino());
+        assert!(shared_metadata.nlink() >= 4);
+    }
 
     Ok(())
 }

--- a/crates/server/src/app/tests/transfer_http.rs
+++ b/crates/server/src/app/tests/transfer_http.rs
@@ -1,6 +1,7 @@
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     num::NonZeroUsize,
+    sync::Arc,
     time::Duration,
 };
 
@@ -9,8 +10,9 @@ use reqwest::{
     Client, StatusCode,
     header::{CONTENT_TYPE, RANGE},
 };
+use shardline_index::xet_hash_hex_string;
 use shardline_protocol::{RepositoryProvider, TokenScope};
-use tokio::{net::TcpListener, spawn, time::timeout};
+use tokio::{net::TcpListener, spawn, sync::Semaphore, time::timeout};
 
 use super::{
     AppState, STREAM_READ_BUFFER_BYTES, acquire_chunk_transfer_permit, bearer_token, chunk_hash,
@@ -21,8 +23,8 @@ use super::{
 };
 use crate::{
     FileReconstructionResponse, LocalBackend, ReadyResponse, ServerConfig, ServerRole,
-    XorbUploadResponse, backend::ServerBackend, reconstruction_cache::ReconstructionCacheService,
-    transfer_limiter::TransferLimiter,
+    XorbUploadResponse, app::ProtocolMetrics, backend::ServerBackend,
+    reconstruction_cache::ReconstructionCacheService, transfer_limiter::TransferLimiter,
 };
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -934,6 +936,8 @@ async fn chunk_transfer_permit_uses_stored_chunk_length() {
         provider_tokens: None,
         reconstruction_cache,
         transfer_limiter: TransferLimiter::new(chunk_size, NonZeroUsize::MIN),
+        oci_registry_token_limiter: Arc::new(Semaphore::new(1)),
+        protocol_metrics: ProtocolMetrics::default(),
     };
 
     let first = acquire_chunk_transfer_permit(&state, &hash).await;
@@ -1192,6 +1196,11 @@ async fn metrics_route_reports_runtime_configuration() {
     assert!(body.contains("shardline_auth_enabled 1"));
     assert!(body.contains("shardline_provider_tokens_enabled 0"));
     assert!(body.contains("shardline_metrics_auth_enabled 0"));
+    assert!(body.contains("shardline_oci_registry_token_ttl_seconds 300"));
+    assert!(body.contains("shardline_oci_registry_token_max_in_flight_requests 64"));
+    assert!(body.contains("shardline_oci_registry_token_requests_total 0"));
+    assert!(body.contains("shardline_oci_registry_token_rate_limited_total 0"));
+    assert!(body.contains("shardline_oci_registry_token_active_requests 0"));
 
     server.abort();
 }
@@ -1424,7 +1433,7 @@ async fn write_routes_reject_read_only_tokens() {
     let response = Client::new()
         .post(format!(
             "{base_url}/v1/xorbs/default/{}",
-            chunk_hash(b"aaaa").api_hex_string()
+            xet_hash_hex_string(chunk_hash(b"aaaa"))
         ))
         .bearer_auth(token)
         .body("aaaa".as_bytes().to_vec())

--- a/crates/server/src/backend.rs
+++ b/crates/server/src/backend.rs
@@ -262,6 +262,22 @@ impl ServerBackend {
         }
     }
 
+    pub(crate) fn put_sha256_addressed_object_bytes_if_absent(
+        &self,
+        object_key: &ObjectKey,
+        digest_hex: &str,
+        bytes: Vec<u8>,
+    ) -> Result<PutOutcome, ServerError> {
+        match self {
+            Self::Local(backend) => {
+                backend.put_sha256_addressed_object_bytes_if_absent(object_key, digest_hex, bytes)
+            }
+            Self::Postgres(backend) => {
+                backend.put_sha256_addressed_object_bytes_if_absent(object_key, digest_hex, bytes)
+            }
+        }
+    }
+
     pub(crate) fn copy_object_if_absent(
         &self,
         source: &ObjectKey,
@@ -284,18 +300,19 @@ impl ServerBackend {
         }
     }
 
-    pub(crate) fn put_content_addressed_object_file(
+    pub(crate) fn put_sha256_addressed_object_file(
         &self,
         object_key: &ObjectKey,
+        digest_hex: &str,
         path: &std::path::Path,
         integrity: &shardline_storage::ObjectIntegrity,
     ) -> Result<PutOutcome, ServerError> {
         match self {
             Self::Local(backend) => {
-                backend.put_content_addressed_object_file(object_key, path, integrity)
+                backend.put_sha256_addressed_object_file(object_key, digest_hex, path, integrity)
             }
             Self::Postgres(backend) => {
-                backend.put_content_addressed_object_file(object_key, path, integrity)
+                backend.put_sha256_addressed_object_file(object_key, digest_hex, path, integrity)
             }
         }
     }

--- a/crates/server/src/backend.rs
+++ b/crates/server/src/backend.rs
@@ -7,6 +7,7 @@ use std::{num::NonZeroUsize, path::PathBuf};
 
 use axum::body::Bytes;
 use shardline_protocol::{ByteRange, RepositoryScope};
+use shardline_storage::{DeleteOutcome, ObjectKey, ObjectMetadata, ObjectPrefix, PutOutcome};
 #[cfg(test)]
 use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
 
@@ -247,6 +248,129 @@ impl ServerBackend {
         match self {
             Self::Local(backend) => backend.object_backend_name(),
             Self::Postgres(backend) => backend.object_backend_name(),
+        }
+    }
+
+    pub(crate) fn put_object_bytes_if_absent(
+        &self,
+        object_key: &ObjectKey,
+        bytes: Vec<u8>,
+    ) -> Result<PutOutcome, ServerError> {
+        match self {
+            Self::Local(backend) => backend.put_object_bytes_if_absent(object_key, bytes),
+            Self::Postgres(backend) => backend.put_object_bytes_if_absent(object_key, bytes),
+        }
+    }
+
+    pub(crate) fn copy_object_if_absent(
+        &self,
+        source: &ObjectKey,
+        destination: &ObjectKey,
+    ) -> Result<PutOutcome, ServerError> {
+        match self {
+            Self::Local(backend) => backend.copy_object_if_absent(source, destination),
+            Self::Postgres(backend) => backend.copy_object_if_absent(source, destination),
+        }
+    }
+
+    pub(crate) fn put_object_bytes_overwrite(
+        &self,
+        object_key: &ObjectKey,
+        bytes: Vec<u8>,
+    ) -> Result<(), ServerError> {
+        match self {
+            Self::Local(backend) => backend.put_object_bytes_overwrite(object_key, bytes),
+            Self::Postgres(backend) => backend.put_object_bytes_overwrite(object_key, bytes),
+        }
+    }
+
+    pub(crate) fn put_content_addressed_object_file(
+        &self,
+        object_key: &ObjectKey,
+        path: &std::path::Path,
+        integrity: &shardline_storage::ObjectIntegrity,
+    ) -> Result<PutOutcome, ServerError> {
+        match self {
+            Self::Local(backend) => {
+                backend.put_content_addressed_object_file(object_key, path, integrity)
+            }
+            Self::Postgres(backend) => {
+                backend.put_content_addressed_object_file(object_key, path, integrity)
+            }
+        }
+    }
+
+    pub(crate) async fn object_length(&self, object_key: &ObjectKey) -> Result<u64, ServerError> {
+        match self {
+            Self::Local(backend) => backend.object_length(object_key).await,
+            Self::Postgres(backend) => backend.object_length(object_key).await,
+        }
+    }
+
+    pub(crate) async fn read_object(&self, object_key: &ObjectKey) -> Result<Vec<u8>, ServerError> {
+        match self {
+            Self::Local(backend) => backend.read_object(object_key).await,
+            Self::Postgres(backend) => backend.read_object(object_key).await,
+        }
+    }
+
+    pub(crate) async fn read_object_stream(
+        &self,
+        object_key: &ObjectKey,
+        total_length: u64,
+        range: Option<ByteRange>,
+    ) -> Result<ServerByteStream, ServerError> {
+        match self {
+            Self::Local(backend) => {
+                backend
+                    .read_object_stream(object_key, total_length, range)
+                    .await
+            }
+            Self::Postgres(backend) => {
+                backend
+                    .read_object_stream(object_key, total_length, range)
+                    .await
+            }
+        }
+    }
+
+    pub(crate) fn visit_object_prefix<Visitor>(
+        &self,
+        prefix: &ObjectPrefix,
+        visitor: Visitor,
+    ) -> Result<(), ServerError>
+    where
+        Visitor: FnMut(ObjectMetadata) -> Result<(), ServerError>,
+    {
+        match self {
+            Self::Local(backend) => backend.visit_object_prefix(prefix, visitor),
+            Self::Postgres(backend) => backend.visit_object_prefix(prefix, visitor),
+        }
+    }
+
+    pub(crate) fn list_object_flat_namespace_page(
+        &self,
+        prefix: &ObjectPrefix,
+        start_after: Option<&ObjectKey>,
+        limit: usize,
+    ) -> Result<Vec<ObjectMetadata>, ServerError> {
+        match self {
+            Self::Local(backend) => {
+                backend.list_object_flat_namespace_page(prefix, start_after, limit)
+            }
+            Self::Postgres(backend) => {
+                backend.list_object_flat_namespace_page(prefix, start_after, limit)
+            }
+        }
+    }
+
+    pub(crate) async fn delete_object_if_present(
+        &self,
+        object_key: &ObjectKey,
+    ) -> Result<DeleteOutcome, ServerError> {
+        match self {
+            Self::Local(backend) => backend.delete_object_if_present(object_key).await,
+            Self::Postgres(backend) => backend.delete_object_if_present(object_key).await,
         }
     }
 }

--- a/crates/server/src/backup.rs
+++ b/crates/server/src/backup.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 use serde_json::to_writer;
 use shardline_index::{
     AsyncIndexStore, LocalIndexStore, PostgresIndexStore, PostgresRecordStore, RecordStore,
+    xet_hash_hex_string,
 };
 use shardline_storage::{ObjectMetadata, ObjectPrefix};
 
@@ -79,7 +80,7 @@ impl BackupManifestObjectEntry {
         Self {
             key: metadata.key().as_str().to_owned(),
             length: metadata.length(),
-            checksum: metadata.checksum().map(|hash| hash.api_hex_string()),
+            checksum: metadata.checksum().map(xet_hash_hex_string),
         }
     }
 }

--- a/crates/server/src/bazel_http_adapter.rs
+++ b/crates/server/src/bazel_http_adapter.rs
@@ -1,0 +1,37 @@
+use shardline_protocol::RepositoryScope;
+use shardline_storage::ObjectKey;
+
+use crate::{
+    ServerError,
+    protocol_support::{object_key, scope_namespace},
+    validation::validate_content_hash,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BazelCacheKind {
+    Ac,
+    Cas,
+}
+
+impl BazelCacheKind {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ac => "ac",
+            Self::Cas => "cas",
+        }
+    }
+}
+
+pub(crate) fn bazel_cache_object_key(
+    kind: BazelCacheKind,
+    hash_hex: &str,
+    repository_scope: Option<&RepositoryScope>,
+) -> Result<ObjectKey, ServerError> {
+    validate_content_hash(hash_hex)?;
+    object_key(&format!(
+        "protocols/bazel/{}/{}/{}",
+        scope_namespace(repository_scope),
+        kind.as_str(),
+        hash_hex
+    ))
+}

--- a/crates/server/src/chunk_store.rs
+++ b/crates/server/src/chunk_store.rs
@@ -1,3 +1,4 @@
+use shardline_index::xet_hash_hex_string;
 use shardline_protocol::ShardlineHash;
 use shardline_storage::{ObjectKey, ObjectKeyError};
 
@@ -11,7 +12,7 @@ pub(crate) fn chunk_object_key(hash_hex: &str) -> Result<ObjectKey, ServerError>
 pub(crate) fn chunk_object_key_for_computed_hash(
     hash: ShardlineHash,
 ) -> Result<(String, ObjectKey), ServerError> {
-    let hash_hex = hash.api_hex_string();
+    let hash_hex = xet_hash_hex_string(hash);
     let object_key = chunk_object_key_from_valid_hash_hex(&hash_hex)?;
     Ok((hash_hex, object_key))
 }

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -50,6 +50,10 @@ pub struct ServerConfig {
     reconstruction_cache_adapter: ReconstructionCacheAdapter,
     reconstruction_cache_ttl_seconds: NonZeroU64,
     reconstruction_cache_memory_max_entries: NonZeroUsize,
+    oci_upload_session_ttl_seconds: NonZeroU64,
+    oci_upload_max_active_sessions: NonZeroUsize,
+    oci_registry_token_ttl_seconds: NonZeroU64,
+    oci_registry_token_max_in_flight_requests: NonZeroUsize,
     reconstruction_cache_redis_url: Option<SecretString>,
     index_postgres_url: Option<SecretString>,
     token_signing_key: Option<SecretBytes>,
@@ -93,6 +97,22 @@ impl fmt::Debug for ServerConfig {
             .field(
                 "reconstruction_cache_memory_max_entries",
                 &self.reconstruction_cache_memory_max_entries,
+            )
+            .field(
+                "oci_upload_session_ttl_seconds",
+                &self.oci_upload_session_ttl_seconds,
+            )
+            .field(
+                "oci_upload_max_active_sessions",
+                &self.oci_upload_max_active_sessions,
+            )
+            .field(
+                "oci_registry_token_ttl_seconds",
+                &self.oci_registry_token_ttl_seconds,
+            )
+            .field(
+                "oci_registry_token_max_in_flight_requests",
+                &self.oci_registry_token_max_in_flight_requests,
             )
             .field(
                 "reconstruction_cache_redis_url",
@@ -179,6 +199,23 @@ const DEFAULT_PARALLELISM_FALLBACK: NonZeroUsize = match NonZeroUsize::new(8) {
     Some(value) => value,
     None => NonZeroUsize::MIN,
 };
+const DEFAULT_OCI_UPLOAD_SESSION_TTL_SECONDS: NonZeroU64 = match NonZeroU64::new(3_600) {
+    Some(value) => value,
+    None => NonZeroU64::MIN,
+};
+const DEFAULT_OCI_UPLOAD_MAX_ACTIVE_SESSIONS: NonZeroUsize = match NonZeroUsize::new(1_024) {
+    Some(value) => value,
+    None => NonZeroUsize::MIN,
+};
+const DEFAULT_OCI_REGISTRY_TOKEN_TTL_SECONDS: NonZeroU64 = match NonZeroU64::new(300) {
+    Some(value) => value,
+    None => NonZeroU64::MIN,
+};
+const DEFAULT_OCI_REGISTRY_TOKEN_MAX_IN_FLIGHT_REQUESTS: NonZeroUsize = match NonZeroUsize::new(64)
+{
+    Some(value) => value,
+    None => NonZeroUsize::MIN,
+};
 
 #[cfg(test)]
 type SecretFileReadHook = Box<dyn FnOnce() + Send>;
@@ -230,6 +267,11 @@ impl ServerConfig {
             reconstruction_cache_ttl_seconds: DEFAULT_RECONSTRUCTION_CACHE_TTL_SECONDS,
             reconstruction_cache_memory_max_entries:
                 DEFAULT_RECONSTRUCTION_CACHE_MEMORY_MAX_ENTRIES,
+            oci_upload_session_ttl_seconds: DEFAULT_OCI_UPLOAD_SESSION_TTL_SECONDS,
+            oci_upload_max_active_sessions: DEFAULT_OCI_UPLOAD_MAX_ACTIVE_SESSIONS,
+            oci_registry_token_ttl_seconds: DEFAULT_OCI_REGISTRY_TOKEN_TTL_SECONDS,
+            oci_registry_token_max_in_flight_requests:
+                DEFAULT_OCI_REGISTRY_TOKEN_MAX_IN_FLIGHT_REQUESTS,
             reconstruction_cache_redis_url: None,
             index_postgres_url: None,
             token_signing_key: None,
@@ -349,6 +391,28 @@ impl ServerConfig {
         self.reconstruction_cache_memory_max_entries
     }
 
+    /// Returns the maximum idle lifetime for OCI upload sessions.
+    #[must_use]
+    pub(crate) const fn oci_upload_session_ttl_seconds(&self) -> NonZeroU64 {
+        self.oci_upload_session_ttl_seconds
+    }
+
+    /// Returns the maximum number of live OCI upload sessions allowed per server root.
+    #[must_use]
+    pub(crate) const fn oci_upload_max_active_sessions(&self) -> NonZeroUsize {
+        self.oci_upload_max_active_sessions
+    }
+
+    #[must_use]
+    pub(crate) const fn oci_registry_token_ttl_seconds(&self) -> NonZeroU64 {
+        self.oci_registry_token_ttl_seconds
+    }
+
+    #[must_use]
+    pub(crate) const fn oci_registry_token_max_in_flight_requests(&self) -> NonZeroUsize {
+        self.oci_registry_token_max_in_flight_requests
+    }
+
     /// Returns the optional Redis URL for the reconstruction cache.
     #[must_use]
     pub(crate) fn reconstruction_cache_redis_url(&self) -> Option<&str> {
@@ -461,6 +525,44 @@ impl ServerConfig {
         self.reconstruction_cache_ttl_seconds = reconstruction_cache_ttl_seconds;
         self.reconstruction_cache_memory_max_entries = reconstruction_cache_memory_max_entries;
         self.reconstruction_cache_redis_url = None;
+        self
+    }
+
+    /// Overrides the maximum idle lifetime for OCI upload sessions.
+    #[must_use]
+    pub const fn with_oci_upload_session_ttl_seconds(
+        mut self,
+        oci_upload_session_ttl_seconds: NonZeroU64,
+    ) -> Self {
+        self.oci_upload_session_ttl_seconds = oci_upload_session_ttl_seconds;
+        self
+    }
+
+    /// Overrides the maximum number of live OCI upload sessions per server root.
+    #[must_use]
+    pub const fn with_oci_upload_max_active_sessions(
+        mut self,
+        oci_upload_max_active_sessions: NonZeroUsize,
+    ) -> Self {
+        self.oci_upload_max_active_sessions = oci_upload_max_active_sessions;
+        self
+    }
+
+    #[must_use]
+    pub const fn with_oci_registry_token_ttl_seconds(
+        mut self,
+        oci_registry_token_ttl_seconds: NonZeroU64,
+    ) -> Self {
+        self.oci_registry_token_ttl_seconds = oci_registry_token_ttl_seconds;
+        self
+    }
+
+    #[must_use]
+    pub const fn with_oci_registry_token_max_in_flight_requests(
+        mut self,
+        oci_registry_token_max_in_flight_requests: NonZeroUsize,
+    ) -> Self {
+        self.oci_registry_token_max_in_flight_requests = oci_registry_token_max_in_flight_requests;
         self
     }
 
@@ -919,6 +1021,30 @@ pub enum ServerConfigError {
     /// The in-memory reconstruction-cache capacity was zero.
     #[error("reconstruction cache memory max entries must be greater than zero")]
     ZeroReconstructionCacheMemoryMaxEntries,
+    /// The OCI upload-session TTL could not be parsed.
+    #[error("invalid oci upload session ttl")]
+    OciUploadSessionTtl(ParseIntError),
+    /// The OCI upload-session TTL was zero.
+    #[error("oci upload session ttl must be greater than zero")]
+    ZeroOciUploadSessionTtlSeconds,
+    /// The OCI upload live-session ceiling could not be parsed.
+    #[error("invalid oci upload max active sessions")]
+    OciUploadMaxActiveSessions(ParseIntError),
+    /// The OCI upload live-session ceiling was zero.
+    #[error("oci upload max active sessions must be greater than zero")]
+    ZeroOciUploadMaxActiveSessions,
+    /// The OCI registry token TTL could not be parsed.
+    #[error("invalid oci registry token ttl")]
+    OciRegistryTokenTtl(ParseIntError),
+    /// The OCI registry token TTL was zero.
+    #[error("oci registry token ttl must be greater than zero")]
+    ZeroOciRegistryTokenTtlSeconds,
+    /// The OCI registry token in-flight request ceiling could not be parsed.
+    #[error("invalid oci registry token max in-flight requests")]
+    OciRegistryTokenMaxInFlightRequests(ParseIntError),
+    /// The OCI registry token in-flight request ceiling was zero.
+    #[error("oci registry token max in-flight requests must be greater than zero")]
+    ZeroOciRegistryTokenMaxInFlightRequests,
     /// The Redis reconstruction-cache URL was empty.
     #[error("reconstruction cache redis url must not be empty")]
     EmptyReconstructionCacheRedisUrl,

--- a/crates/server/src/config/env.rs
+++ b/crates/server/src/config/env.rs
@@ -118,6 +118,41 @@ pub(super) fn load_server_config_from_env() -> Result<ServerConfig, ServerConfig
     else {
         return Err(ServerConfigError::ZeroReconstructionCacheMemoryMaxEntries);
     };
+    let raw_oci_upload_session_ttl_seconds = var("SHARDLINE_OCI_UPLOAD_SESSION_TTL_SECONDS")
+        .unwrap_or_else(|_error| "3600".to_owned())
+        .parse::<u64>()
+        .map_err(ServerConfigError::OciUploadSessionTtl)?;
+    let Some(oci_upload_session_ttl_seconds) = NonZeroU64::new(raw_oci_upload_session_ttl_seconds)
+    else {
+        return Err(ServerConfigError::ZeroOciUploadSessionTtlSeconds);
+    };
+    let raw_oci_upload_max_active_sessions = var("SHARDLINE_OCI_UPLOAD_MAX_ACTIVE_SESSIONS")
+        .unwrap_or_else(|_error| "1024".to_owned())
+        .parse::<usize>()
+        .map_err(ServerConfigError::OciUploadMaxActiveSessions)?;
+    let Some(oci_upload_max_active_sessions) =
+        NonZeroUsize::new(raw_oci_upload_max_active_sessions)
+    else {
+        return Err(ServerConfigError::ZeroOciUploadMaxActiveSessions);
+    };
+    let raw_oci_registry_token_ttl_seconds = var("SHARDLINE_OCI_REGISTRY_TOKEN_TTL_SECONDS")
+        .unwrap_or_else(|_error| "300".to_owned())
+        .parse::<u64>()
+        .map_err(ServerConfigError::OciRegistryTokenTtl)?;
+    let Some(oci_registry_token_ttl_seconds) = NonZeroU64::new(raw_oci_registry_token_ttl_seconds)
+    else {
+        return Err(ServerConfigError::ZeroOciRegistryTokenTtlSeconds);
+    };
+    let raw_oci_registry_token_max_in_flight_requests =
+        var("SHARDLINE_OCI_REGISTRY_TOKEN_MAX_IN_FLIGHT_REQUESTS")
+            .unwrap_or_else(|_error| "64".to_owned())
+            .parse::<usize>()
+            .map_err(ServerConfigError::OciRegistryTokenMaxInFlightRequests)?;
+    let Some(oci_registry_token_max_in_flight_requests) =
+        NonZeroUsize::new(raw_oci_registry_token_max_in_flight_requests)
+    else {
+        return Err(ServerConfigError::ZeroOciRegistryTokenMaxInFlightRequests);
+    };
     let reconstruction_cache_redis_url = var("SHARDLINE_RECONSTRUCTION_CACHE_REDIS_URL").ok();
     let index_postgres_url = var("SHARDLINE_INDEX_POSTGRES_URL").ok();
     let token_signing_key = optional_token_signing_key_from_sources(
@@ -155,6 +190,10 @@ pub(super) fn load_server_config_from_env() -> Result<ServerConfig, ServerConfig
         .with_shard_metadata_limits(shard_metadata_limits)
         .with_upload_max_in_flight_chunks(upload_max_in_flight_chunks)
         .with_transfer_max_in_flight_chunks(transfer_max_in_flight_chunks)
+        .with_oci_upload_session_ttl_seconds(oci_upload_session_ttl_seconds)
+        .with_oci_upload_max_active_sessions(oci_upload_max_active_sessions)
+        .with_oci_registry_token_ttl_seconds(oci_registry_token_ttl_seconds)
+        .with_oci_registry_token_max_in_flight_requests(oci_registry_token_max_in_flight_requests)
         .with_reconstruction_cache_memory(
             reconstruction_cache_ttl_seconds,
             reconstruction_cache_memory_max_entries,
@@ -273,6 +312,17 @@ mod tests {
         let deduplicated = parse_server_frontends_env("xet, xet");
         assert!(deduplicated.is_ok());
         assert_eq!(deduplicated.ok(), Some(vec![ServerFrontend::Xet]));
+        let multiple = parse_server_frontends_env("xet,lfs,bazel-http,oci");
+        assert!(multiple.is_ok());
+        assert_eq!(
+            multiple.ok(),
+            Some(vec![
+                ServerFrontend::Xet,
+                ServerFrontend::Lfs,
+                ServerFrontend::BazelHttp,
+                ServerFrontend::Oci,
+            ])
+        );
     }
 
     #[test]
@@ -284,6 +334,6 @@ mod tests {
         let empty_segments = parse_server_frontends_env(",xet,,");
         assert!(empty_segments.is_ok());
         assert_eq!(empty_segments.ok(), Some(vec![ServerFrontend::Xet]));
-        assert!(parse_server_frontends_env("lfs").is_err());
+        assert!(parse_server_frontends_env("unknown").is_err());
     }
 }

--- a/crates/server/src/config/tests.rs
+++ b/crates/server/src/config/tests.rs
@@ -90,6 +90,10 @@ fn server_config_keeps_bind_address_and_public_url() {
         config.reconstruction_cache_memory_max_entries(),
         DEFAULT_RECONSTRUCTION_CACHE_MEMORY_MAX_ENTRIES
     );
+    assert_eq!(config.oci_upload_session_ttl_seconds().get(), 3_600);
+    assert_eq!(config.oci_upload_max_active_sessions().get(), 1_024);
+    assert_eq!(config.oci_registry_token_ttl_seconds().get(), 300);
+    assert_eq!(config.oci_registry_token_max_in_flight_requests().get(), 64);
     assert_eq!(config.index_postgres_url(), None);
     assert_eq!(config.token_signing_key(), None);
     assert_eq!(config.metrics_token(), None);
@@ -353,6 +357,47 @@ fn server_config_can_disable_reconstruction_cache() {
     assert_eq!(
         config.reconstruction_cache_adapter(),
         ReconstructionCacheAdapter::Disabled
+    );
+}
+
+#[test]
+fn server_config_allows_oci_upload_limits_override() {
+    let bind_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
+    let root_dir = PathBuf::from("/tmp/shardline");
+    let ttl = NonZeroU64::new(90).unwrap_or(NonZeroU64::MIN);
+    let sessions = NonZeroUsize::new(32).unwrap_or(NonZeroUsize::MIN);
+    let config = ServerConfig::new(
+        bind_addr,
+        "https://assets.example.test".to_owned(),
+        root_dir,
+        NonZeroUsize::MIN,
+    )
+    .with_oci_upload_session_ttl_seconds(ttl)
+    .with_oci_upload_max_active_sessions(sessions);
+
+    assert_eq!(config.oci_upload_session_ttl_seconds(), ttl);
+    assert_eq!(config.oci_upload_max_active_sessions(), sessions);
+}
+
+#[test]
+fn server_config_allows_oci_registry_token_limits_override() {
+    let bind_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
+    let root_dir = PathBuf::from("/tmp/shardline");
+    let ttl = NonZeroU64::new(45).unwrap_or(NonZeroU64::MIN);
+    let in_flight = NonZeroUsize::new(7).unwrap_or(NonZeroUsize::MIN);
+    let config = ServerConfig::new(
+        bind_addr,
+        "https://assets.example.test".to_owned(),
+        root_dir,
+        NonZeroUsize::MIN,
+    )
+    .with_oci_registry_token_ttl_seconds(ttl)
+    .with_oci_registry_token_max_in_flight_requests(in_flight);
+
+    assert_eq!(config.oci_registry_token_ttl_seconds(), ttl);
+    assert_eq!(
+        config.oci_registry_token_max_in_flight_requests(),
+        in_flight
     );
 }
 

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -2,7 +2,7 @@ use std::{io::Error as IoError, num::TryFromIntError};
 
 use axum::{
     Error as AxumError, Json,
-    http::StatusCode,
+    http::{HeaderValue, StatusCode, header::WWW_AUTHENTICATE},
     response::{IntoResponse, Response},
 };
 use serde::Serialize;
@@ -12,12 +12,14 @@ use shardline_index::{
     FileRecordInvariantError, LocalIndexStoreError, MemoryIndexStoreError, MemoryRecordStoreError,
     PostgresMetadataStoreError, QuarantineCandidateError, RetentionHoldError, WebhookDeliveryError,
 };
-use shardline_protocol::{HashParseError, HttpRangeParseError, TokenCodecError, XorbParseError};
+use shardline_protocol::{HashParseError, HttpRangeParseError, TokenCodecError};
 use shardline_storage::{LocalObjectStoreError, ObjectPrefixError, S3ObjectStoreError};
 use thiserror::Error;
 use tokio::task::JoinError;
 
-use crate::{config::ServerConfigError, provider::ProviderServiceError};
+use crate::{
+    config::ServerConfigError, provider::ProviderServiceError, xet_adapter::XorbParseError,
+};
 
 /// Lifecycle metadata consistency failure.
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
@@ -350,6 +352,30 @@ pub enum ServerError {
     /// The uploaded body did not match the expected SHA-256 identifier.
     #[error("uploaded body hash did not match the expected sha256")]
     ExpectedBodyHashMismatch,
+    /// A digest string was malformed.
+    #[error("digest must use sha256:<64 lowercase hex> format")]
+    InvalidDigest,
+    /// A repository name or namespace path was malformed.
+    #[error("repository name was invalid")]
+    InvalidRepositoryName,
+    /// A manifest reference or tag was malformed.
+    #[error("manifest reference was invalid")]
+    InvalidManifestReference,
+    /// The requested representation does not match any accepted media type.
+    #[error("requested representation was not acceptable")]
+    NotAcceptable,
+    /// The request requires a protocol-specific authentication challenge.
+    #[error("authorization challenge required")]
+    UnauthorizedChallenge(String),
+    /// An upload session identifier was malformed.
+    #[error("upload session identifier was invalid")]
+    InvalidUploadSession,
+    /// Too many OCI upload sessions are currently active.
+    #[error("too many active oci upload sessions")]
+    TooManyUploadSessions,
+    /// Too many OCI registry token exchanges are currently active.
+    #[error("too many active oci registry token requests")]
+    TooManyRegistryTokenRequests,
     /// Redis reconstruction cache was selected without a URL.
     #[error("redis reconstruction cache requires a redis url")]
     MissingReconstructionCacheRedisUrl,
@@ -387,9 +413,15 @@ impl ServerError {
         match self {
             Self::InvalidFileId
             | Self::InvalidContentHash
+            | Self::InvalidDigest
+            | Self::InvalidRepositoryName
+            | Self::InvalidManifestReference
+            | Self::InvalidUploadSession
             | Self::InvalidXorbPrefix
             | Self::HashParse(_)
             | Self::ObjectPrefix(_) => StatusCode::BAD_REQUEST,
+            Self::NotAcceptable => StatusCode::NOT_ACCEPTABLE,
+            Self::UnauthorizedChallenge(_) => StatusCode::UNAUTHORIZED,
             Self::InvalidRangeHeader => StatusCode::BAD_REQUEST,
             Self::RangeNotSatisfiable => StatusCode::RANGE_NOT_SATISFIABLE,
             Self::XorbHashMismatch
@@ -420,6 +452,9 @@ impl ServerError {
             | Self::ProviderDenied => StatusCode::FORBIDDEN,
             Self::InvalidProviderTokenRequest | Self::InvalidProviderWebhookPayload => {
                 StatusCode::BAD_REQUEST
+            }
+            Self::TooManyUploadSessions | Self::TooManyRegistryTokenRequests => {
+                StatusCode::TOO_MANY_REQUESTS
             }
             Self::TransferLimiterClosed => StatusCode::SERVICE_UNAVAILABLE,
             Self::Io(_)
@@ -455,10 +490,32 @@ impl ServerError {
 impl IntoResponse for ServerError {
     fn into_response(self) -> Response {
         let status = self.status_code();
+        let should_attach_default_challenge = matches!(
+            self,
+            Self::MissingAuthorization | Self::InvalidAuthorizationHeader | Self::InvalidToken(_)
+        );
+        let custom_challenge = if let Self::UnauthorizedChallenge(custom_header) = &self {
+            Some(custom_header.as_str())
+        } else {
+            None
+        };
         let body = ErrorBody {
             error: self.to_string(),
         };
-        (status, Json(body)).into_response()
+        let mut response = (status, Json(body)).into_response();
+        if let Some(custom_header) = custom_challenge {
+            if let Ok(header_value) = HeaderValue::from_str(custom_header) {
+                response
+                    .headers_mut()
+                    .insert(WWW_AUTHENTICATE, header_value);
+            }
+        } else if should_attach_default_challenge {
+            response.headers_mut().insert(
+                WWW_AUTHENTICATE,
+                HeaderValue::from_static("Bearer realm=\"shardline\""),
+            );
+        }
+        response
     }
 }
 

--- a/crates/server/src/fsck.rs
+++ b/crates/server/src/fsck.rs
@@ -9,7 +9,7 @@ mod record_checks;
 
 use shardline_index::{
     AsyncIndexStore, FileRecord, FileRecordInvariantError, LocalIndexStore, PostgresIndexStore,
-    PostgresRecordStore,
+    PostgresRecordStore, xet_hash_hex_string,
 };
 use shardline_storage::ObjectKey;
 use thiserror::Error;
@@ -702,7 +702,7 @@ where
         .visit_dedupe_shard_mappings(|mapping| {
             report.inspected_dedupe_shard_mappings =
                 checked_increment(report.inspected_dedupe_shard_mappings)?;
-            let chunk_hash_hex = mapping.chunk_hash().api_hex_string();
+            let chunk_hash_hex = xet_hash_hex_string(mapping.chunk_hash());
             let shard_location =
                 object_location_display(object_root, object_store, mapping.shard_object_key());
             let metadata = match object_store.metadata(mapping.shard_object_key())? {
@@ -777,7 +777,7 @@ where
         .map_err(Into::into)?;
     for file_id in file_ids {
         report.inspected_reconstructions = checked_increment(report.inspected_reconstructions)?;
-        let file_id_hex = file_id.hash().api_hex_string();
+        let file_id_hex = xet_hash_hex_string(file_id.hash());
         let Some(reconstruction) = index_store
             .reconstruction(&file_id)
             .await
@@ -813,7 +813,7 @@ where
                     FsckIssueKind::MissingReconstructionXorb,
                     file_id_hex.clone(),
                     FsckIssueDetail::MissingReconstructionXorb {
-                        xorb_hash: object_id.hash().api_hex_string(),
+                        xorb_hash: xet_hash_hex_string(object_id.hash()),
                     },
                 )?;
             }

--- a/crates/server/src/fsck/record_checks.rs
+++ b/crates/server/src/fsck/record_checks.rs
@@ -1,8 +1,7 @@
 use std::{io::Cursor, path::Path};
 
-use shardline_index::{FileChunkRecord, FileRecord, RecordStore, StoredRecord};
-use shardline_protocol::{
-    ShardlineHash, try_for_each_serialized_xorb_chunk, validate_serialized_xorb,
+use shardline_index::{
+    FileChunkRecord, FileRecord, RecordStore, StoredRecord, parse_xet_hash_hex, xet_hash_hex_string,
 };
 
 use super::{
@@ -19,7 +18,10 @@ use crate::{
     overflow::{checked_add, checked_increment},
     record_store::parse_stored_file_record_bytes,
     validation::{validate_content_hash, validate_identifier},
-    xet_adapter::{map_xorb_visit_error, xorb_object_key},
+    xet_adapter::{
+        map_xorb_visit_error, try_for_each_serialized_xorb_chunk, validate_serialized_xorb,
+        xorb_object_key,
+    },
 };
 
 pub(super) async fn scan_record_tree<RecordAdapter>(
@@ -308,7 +310,7 @@ fn inspect_chunks(
         };
 
         let chunk_bytes = read_full_object(object_store, &object_key, metadata.length())?;
-        let actual_hash = chunk_hash(&chunk_bytes).api_hex_string();
+        let actual_hash = xet_hash_hex_string(chunk_hash(&chunk_bytes));
         if actual_hash != chunk.hash {
             push_issue(
                 report,
@@ -394,7 +396,7 @@ fn inspect_native_xet_term(
     };
 
     let xorb_bytes = read_full_object(object_store, &object_key, metadata.length())?;
-    let expected_hash = ShardlineHash::parse_api_hex(&chunk.hash)?;
+    let expected_hash = parse_xet_hash_hex(&chunk.hash)?;
     let mut reader = Cursor::new(xorb_bytes);
     let validated = validate_serialized_xorb(&mut reader, expected_hash)?;
     let range_start = usize::try_from(chunk.range_start)?;
@@ -424,7 +426,7 @@ fn inspect_native_xet_term(
         let unpacked_length = u64::try_from(decoded_chunk.data().len())?;
         actual_length = checked_add(actual_length, unpacked_length)?;
 
-        let chunk_hash_hex = decoded_chunk.descriptor().hash().api_hex_string();
+        let chunk_hash_hex = xet_hash_hex_string(decoded_chunk.descriptor().hash());
         let chunk_object_key = chunk_object_key(&chunk_hash_hex)?;
         reachability
             .referenced_object_keys
@@ -448,7 +450,7 @@ fn inspect_native_xet_term(
 
         let chunk_bytes =
             read_full_object(object_store, &chunk_object_key, chunk_metadata.length())?;
-        let actual_chunk_hash = chunk_hash(&chunk_bytes).api_hex_string();
+        let actual_chunk_hash = xet_hash_hex_string(chunk_hash(&chunk_bytes));
         if actual_chunk_hash != chunk_hash_hex {
             push_issue(
                 report,

--- a/crates/server/src/fsck/tests.rs
+++ b/crates/server/src/fsck/tests.rs
@@ -4,7 +4,7 @@ use axum::body::Bytes;
 use shardline_index::{
     FileId, FileReconstruction, IndexStore, LocalIndexStore, LocalRecordStore,
     ProviderRepositoryState, QuarantineCandidate, ReconstructionTerm, RecordStore, RetentionHold,
-    StoredObjectId, WebhookDelivery,
+    StoredObjectId, WebhookDelivery, xet_hash_hex_string,
 };
 use shardline_protocol::{ChunkRange, RepositoryProvider, ShardlineHash};
 use shardline_storage::ObjectKey;
@@ -262,7 +262,10 @@ async fn fsck_reports_hash_and_length_mismatch_for_corrupted_chunk_body() {
         .join(&first_chunk.hash);
     let rewritten = fs::write(&chunk_path, b"corrupted").await;
     assert!(rewritten.is_ok());
-    assert_ne!(chunk_hash(b"corrupted").api_hex_string(), first_chunk.hash);
+    assert_ne!(
+        xet_hash_hex_string(chunk_hash(b"corrupted")),
+        first_chunk.hash
+    );
 
     let report = run_local_fsck(storage.path().to_path_buf()).await;
     assert!(report.is_ok());

--- a/crates/server/src/fuzz.rs
+++ b/crates/server/src/fuzz.rs
@@ -1,21 +1,66 @@
 use std::io::Cursor;
 
-use shardline_index::FileRecord;
-use shardline_protocol::{ByteRange, ShardlineHash, validate_serialized_xorb};
+use shardline_index::{FileRecord, parse_xet_hash_hex};
+use shardline_protocol::{ByteRange, ShardlineHash};
 
 use crate::{
     InvalidReconstructionResponseError, InvalidSerializedShardError, ServerError,
+    app::{parse_oci_path, parse_upload_content_range},
+    bazel_http_adapter::{BazelCacheKind, bazel_cache_object_key},
     config::ShardMetadataLimits,
+    lfs_adapter::lfs_object_key,
     lifecycle_repair::{
         QuarantineRepairAction, RetentionHoldRepairAction, WebhookDeliveryRepairAction,
         classify_quarantine_repair_action, classify_retention_hold_repair_action,
         classify_webhook_delivery_repair_action,
     },
+    oci_adapter::{oci_blob_key, oci_manifest_key, parse_reference},
+    protocol_support::{parse_sha256_digest, validate_oci_repository_name, validate_oci_tag},
+    server_frontend::ServerFrontend,
     xet_adapter::{
         build_reconstruction_response, build_xorb_transfer_url, normalize_serialized_xorb,
-        reconstruction_v2_from_v1, retained_shard_chunk_hashes,
+        reconstruction_v2_from_v1, retained_shard_chunk_hashes, validate_serialized_xorb,
     },
 };
+
+/// Summary of Git LFS frontend validation used by fuzz targets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FuzzLfsFrontendSummary {
+    /// Whether the supplied oid passed validation.
+    pub oid_accepts: bool,
+    /// Whether object-key derivation was deterministic.
+    pub key_is_stable: bool,
+}
+
+/// Summary of Bazel HTTP cache frontend validation used by fuzz targets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FuzzBazelHttpFrontendSummary {
+    /// Whether the supplied hash is accepted for `ac` objects.
+    pub ac_accepts: bool,
+    /// Whether the supplied hash is accepted for `cas` objects.
+    pub cas_accepts: bool,
+}
+
+/// Summary of OCI frontend parsing and validation used by fuzz targets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FuzzOciFrontendSummary {
+    /// Whether the repository name passed validation.
+    pub repository_accepts: bool,
+    /// Whether the reference passed tag-or-digest parsing.
+    pub reference_accepts: bool,
+    /// Whether the digest string passed parsing.
+    pub digest_accepts: bool,
+    /// Whether the upload session identifier passed validation.
+    pub session_accepts: bool,
+    /// Whether the upload content-range parser accepted the value.
+    pub content_range_accepts: bool,
+    /// Whether the OCI route parser accepted the supplied path.
+    pub path_accepts: bool,
+    /// Whether the blob key derivation accepted the repository and digest.
+    pub blob_accepts: bool,
+    /// Whether the manifest key derivation accepted the repository and digest.
+    pub manifest_accepts: bool,
+}
 
 /// Summary of a normalized and validated xorb payload used by fuzz targets.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -111,6 +156,27 @@ pub struct FuzzReconstructionResponseSummary {
     pub total_unpacked_length: u64,
 }
 
+/// Summary of protocol-frontend parser and key validation used by fuzz targets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FuzzProtocolFrontendSummary {
+    /// Whether the frontend selector token parsed successfully.
+    pub frontend_accepts: bool,
+    /// Whether the digest parser accepted the supplied digest string.
+    pub digest_accepts: bool,
+    /// Whether the Git LFS object-key derivation accepted the supplied oid.
+    pub lfs_accepts: bool,
+    /// Whether the Bazel cache key derivation accepted the supplied hash.
+    pub bazel_accepts: bool,
+    /// Whether the OCI repository validator accepted the repository name.
+    pub oci_repository_accepts: bool,
+    /// Whether the OCI tag/reference validator accepted the supplied reference.
+    pub oci_reference_accepts: bool,
+    /// Whether the OCI blob key derivation accepted the input tuple.
+    pub oci_blob_accepts: bool,
+    /// Whether the OCI manifest key derivation accepted the input tuple.
+    pub oci_manifest_accepts: bool,
+}
+
 /// Builds a reconstruction response and checks protocol-shape invariants for fuzzing.
 ///
 /// # Errors
@@ -130,7 +196,7 @@ pub fn fuzz_reconstruction_response_summary(
 
     let mut total_unpacked_length = 0_u64;
     for term in &response.terms {
-        ShardlineHash::parse_api_hex(&term.hash)?;
+        parse_xet_hash_hex(&term.hash)?;
         ensure_reconstruction_response_invariant(
             term.unpacked_length > 0,
             InvalidReconstructionResponseError::TermHadZeroUnpackedLength,
@@ -151,7 +217,7 @@ pub fn fuzz_reconstruction_response_summary(
 
     let mut fetch_ranges = 0_usize;
     for (hash, fetch_entries) in &response.fetch_info {
-        ShardlineHash::parse_api_hex(hash)?;
+        parse_xet_hash_hex(hash)?;
         ensure_reconstruction_response_invariant(
             !fetch_entries.is_empty(),
             InvalidReconstructionResponseError::EmptyFetchList,
@@ -251,6 +317,169 @@ pub fn fuzz_reconstruction_response_summary(
         v2_ranges,
         offset_into_first_range: response.offset_into_first_range,
         total_unpacked_length,
+    })
+}
+
+/// Parses protocol frontend selectors and validates protocol-specific object keys.
+///
+/// # Errors
+///
+/// Returns [`ServerError`] when a successfully-derived object key cannot preserve a
+/// stable, deterministic storage representation.
+pub fn fuzz_protocol_frontend_summary(
+    frontend: &str,
+    oid: &str,
+    digest: &str,
+    repository: &str,
+    reference: &str,
+) -> Result<FuzzProtocolFrontendSummary, ServerError> {
+    let frontend_accepts = ServerFrontend::parse(frontend).is_ok();
+    let digest_accepts = parse_sha256_digest(digest).is_ok();
+
+    let lfs_accepts = match lfs_object_key(oid, None) {
+        Ok(key) => {
+            let repeated = lfs_object_key(oid, None)?;
+            key.as_str() == repeated.as_str()
+        }
+        Err(_) => false,
+    };
+
+    let bazel_accepts = match bazel_cache_object_key(BazelCacheKind::Cas, oid, None) {
+        Ok(key) => {
+            let repeated = bazel_cache_object_key(BazelCacheKind::Cas, oid, None)?;
+            key.as_str() == repeated.as_str()
+        }
+        Err(_) => false,
+    };
+
+    let oci_repository_accepts = validate_oci_repository_name(repository).is_ok();
+    let oci_reference_accepts =
+        parse_reference(reference).is_ok() || validate_oci_tag(reference).is_ok();
+
+    let digest_hex = parse_sha256_digest(digest).ok();
+    let oci_blob_accepts = if let Some(digest_hex) = digest_hex.as_deref() {
+        match oci_blob_key(repository, digest_hex, None) {
+            Ok(key) => {
+                let repeated = oci_blob_key(repository, digest_hex, None)?;
+                key.as_str() == repeated.as_str()
+            }
+            Err(_) => false,
+        }
+    } else {
+        false
+    };
+    let oci_manifest_accepts = if let Some(digest_hex) = digest_hex.as_deref() {
+        match oci_manifest_key(repository, digest_hex, None) {
+            Ok(key) => {
+                let repeated = oci_manifest_key(repository, digest_hex, None)?;
+                key.as_str() == repeated.as_str()
+            }
+            Err(_) => false,
+        }
+    } else {
+        false
+    };
+
+    Ok(FuzzProtocolFrontendSummary {
+        frontend_accepts,
+        digest_accepts,
+        lfs_accepts,
+        bazel_accepts,
+        oci_repository_accepts,
+        oci_reference_accepts,
+        oci_blob_accepts,
+        oci_manifest_accepts,
+    })
+}
+
+/// Validates Git LFS object identity and key determinism for fuzzing.
+///
+/// # Errors
+///
+/// Returns [`ServerError`] when a successfully-derived object key cannot be recomputed
+/// deterministically.
+pub fn fuzz_lfs_frontend_summary(oid: &str) -> Result<FuzzLfsFrontendSummary, ServerError> {
+    let (oid_accepts, key_is_stable) = match lfs_object_key(oid, None) {
+        Ok(key) => {
+            let repeated = lfs_object_key(oid, None)?;
+            (true, key.as_str() == repeated.as_str())
+        }
+        Err(_) => (false, false),
+    };
+
+    Ok(FuzzLfsFrontendSummary {
+        oid_accepts,
+        key_is_stable,
+    })
+}
+
+/// Validates Bazel HTTP cache key derivation for fuzzing.
+///
+/// # Errors
+///
+/// Returns [`ServerError`] when a successfully-derived Bazel cache key cannot be
+/// recomputed deterministically.
+pub fn fuzz_bazel_http_frontend_summary(
+    hash_hex: &str,
+) -> Result<FuzzBazelHttpFrontendSummary, ServerError> {
+    let ac_accepts = match bazel_cache_object_key(BazelCacheKind::Ac, hash_hex, None) {
+        Ok(key) => {
+            let repeated = bazel_cache_object_key(BazelCacheKind::Ac, hash_hex, None)?;
+            key.as_str() == repeated.as_str()
+        }
+        Err(_) => false,
+    };
+    let cas_accepts = match bazel_cache_object_key(BazelCacheKind::Cas, hash_hex, None) {
+        Ok(key) => {
+            let repeated = bazel_cache_object_key(BazelCacheKind::Cas, hash_hex, None)?;
+            key.as_str() == repeated.as_str()
+        }
+        Err(_) => false,
+    };
+
+    Ok(FuzzBazelHttpFrontendSummary {
+        ac_accepts,
+        cas_accepts,
+    })
+}
+
+/// Validates OCI path parsing and identity derivation for fuzzing.
+///
+/// # Errors
+///
+/// Returns [`ServerError`] when a successfully-derived OCI storage key cannot be
+/// recomputed deterministically.
+pub fn fuzz_oci_frontend_summary(
+    repository: &str,
+    reference: &str,
+    digest: &str,
+    session_id: &str,
+    content_range: &str,
+    path: &str,
+) -> Result<FuzzOciFrontendSummary, ServerError> {
+    let repository_accepts = validate_oci_repository_name(repository).is_ok();
+    let reference_accepts = parse_reference(reference).is_ok();
+    let digest_accepts = parse_sha256_digest(digest).is_ok();
+    let session_accepts = crate::protocol_support::validate_upload_session_id(session_id).is_ok();
+    let content_range_accepts = parse_upload_content_range(content_range).is_ok();
+    let path_accepts = parse_oci_path(path).is_ok();
+    let digest_hex = parse_sha256_digest(digest).ok();
+    let blob_accepts = digest_hex
+        .as_deref()
+        .is_some_and(|digest_hex| oci_blob_key(repository, digest_hex, None).is_ok());
+    let manifest_accepts = digest_hex
+        .as_deref()
+        .is_some_and(|digest_hex| oci_manifest_key(repository, digest_hex, None).is_ok());
+
+    Ok(FuzzOciFrontendSummary {
+        repository_accepts,
+        reference_accepts,
+        digest_accepts,
+        session_accepts,
+        content_range_accepts,
+        path_accepts,
+        blob_accepts,
+        manifest_accepts,
     })
 }
 
@@ -376,7 +605,7 @@ pub fn fuzz_retained_shard_chunk_hashes(
         }
     }
     for hash in &dedupe_chunk_hashes {
-        ShardlineHash::parse_api_hex(hash).map_err(ServerError::from)?;
+        parse_xet_hash_hex(hash).map_err(ServerError::from)?;
     }
 
     Ok(FuzzRetainedShardSummary {

--- a/crates/server/src/gc/reachability.rs
+++ b/crates/server/src/gc/reachability.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
-use shardline_index::{AsyncIndexStore, FileRecordStorageLayout, RecordStore, StoredRecord};
+use shardline_index::{
+    AsyncIndexStore, FileRecordStorageLayout, RecordStore, StoredRecord, xet_hash_hex_string,
+};
 use shardline_storage::{ObjectKey, ObjectPrefix, ObjectStore};
 
 use crate::{
@@ -56,7 +58,7 @@ where
 
     index_store
         .visit_dedupe_shard_mappings(|mapping| {
-            let chunk_hash_hex = mapping.chunk_hash().api_hex_string();
+            let chunk_hash_hex = xet_hash_hex_string(mapping.chunk_hash());
             if reachability
                 .live_dedupe_chunk_hashes
                 .contains(&chunk_hash_hex)

--- a/crates/server/src/gc/tests.rs
+++ b/crates/server/src/gc/tests.rs
@@ -11,9 +11,9 @@ use serde::Serialize;
 use serde_json::to_vec;
 use shardline_index::{
     DedupeShardMapping, IndexStore, LocalIndexStore, QuarantineCandidate, RetentionHold,
-    WebhookDelivery,
+    WebhookDelivery, parse_xet_hash_hex, xet_hash_hex_string,
 };
-use shardline_protocol::{RepositoryProvider, ShardlineHash, unix_now_seconds_lossy};
+use shardline_protocol::{RepositoryProvider, unix_now_seconds_lossy};
 use shardline_storage::ObjectKey;
 use tokio::fs;
 
@@ -780,7 +780,7 @@ async fn exercise_gc_stale_dedupe_mapping_does_not_keep_retained_shard_alive()
     let shard_path =
         write_orphan_object(storage.path(), &shard_key, b"serialized retained shard").await?;
     let index_store = LocalIndexStore::new(storage.path().to_path_buf())?;
-    let chunk_hash = ShardlineHash::parse_api_hex(&chunk_hash)?;
+    let chunk_hash = parse_xet_hash_hex(&chunk_hash)?;
     let mapping = DedupeShardMapping::new(chunk_hash, shard_key);
     index_store.upsert_dedupe_shard_mapping(&mapping)?;
 
@@ -1008,7 +1008,7 @@ async fn write_orphan_chunk(
     let hash = if hash_seed.len() == 64 && hash_seed.bytes().all(|byte| byte.is_ascii_hexdigit()) {
         hash_seed.to_owned()
     } else {
-        chunk_hash(bytes).api_hex_string()
+        xet_hash_hex_string(chunk_hash(bytes))
     };
     let path = root.join("chunks").join(&hash[..2]).join(&hash);
     let Some(parent) = path.parent() else {

--- a/crates/server/src/lfs_adapter.rs
+++ b/crates/server/src/lfs_adapter.rs
@@ -1,0 +1,65 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use shardline_protocol::RepositoryScope;
+use shardline_storage::ObjectKey;
+
+use crate::{
+    ServerError,
+    protocol_support::{object_key, scope_namespace},
+    validation::validate_content_hash,
+};
+
+pub(crate) const LFS_CONTENT_TYPE: &str = "application/vnd.git-lfs+json";
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LfsBatchRequest {
+    pub(crate) operation: String,
+    #[serde(default)]
+    pub(crate) transfers: Vec<String>,
+    pub(crate) objects: Vec<LfsObjectRequest>,
+    #[serde(default)]
+    pub(crate) hash_algo: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LfsObjectRequest {
+    pub(crate) oid: String,
+    pub(crate) size: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct LfsBatchResponse {
+    pub(crate) transfer: String,
+    pub(crate) objects: Vec<LfsObjectResponse>,
+    pub(crate) hash_algo: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct LfsObjectResponse {
+    pub(crate) oid: String,
+    pub(crate) size: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) authenticated: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) actions: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) error: Option<LfsObjectError>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct LfsObjectError {
+    pub(crate) code: u16,
+    pub(crate) message: String,
+}
+
+pub(crate) fn lfs_object_key(
+    oid: &str,
+    repository_scope: Option<&RepositoryScope>,
+) -> Result<ObjectKey, ServerError> {
+    validate_content_hash(oid)?;
+    object_key(&format!(
+        "protocols/lfs/{}/objects/{}",
+        scope_namespace(repository_scope),
+        oid
+    ))
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -29,6 +29,7 @@ mod app;
 mod auth;
 mod backend;
 mod backup;
+mod bazel_http_adapter;
 mod chunk_store;
 mod clock;
 mod config;
@@ -39,16 +40,18 @@ mod fsck;
 mod fuzz;
 mod gc;
 mod ingest_bench;
+mod lfs_adapter;
 mod lifecycle_repair;
 mod local_backend;
-#[cfg(test)]
 mod local_fs;
 mod local_path;
 mod model;
 mod object_store;
+mod oci_adapter;
 mod ops_record_store;
 mod overflow;
 mod postgres_backend;
+mod protocol_support;
 mod provider;
 mod provider_events;
 mod rebuild;
@@ -86,8 +89,11 @@ pub use fsck::{
     LocalFsckReport, ProviderRepositoryStateTimestampField, run_fsck, run_local_fsck,
 };
 pub use fuzz::{
-    FuzzLifecycleRepairSummary, FuzzReconstructionResponseSummary, FuzzRetainedShardSummary,
-    FuzzValidatedXorbSummary, fuzz_lifecycle_repair_summary, fuzz_normalize_and_validate_xorb,
+    FuzzBazelHttpFrontendSummary, FuzzLfsFrontendSummary, FuzzLifecycleRepairSummary,
+    FuzzOciFrontendSummary, FuzzProtocolFrontendSummary, FuzzReconstructionResponseSummary,
+    FuzzRetainedShardSummary, FuzzValidatedXorbSummary, fuzz_bazel_http_frontend_summary,
+    fuzz_lfs_frontend_summary, fuzz_lifecycle_repair_summary, fuzz_normalize_and_validate_xorb,
+    fuzz_oci_frontend_summary, fuzz_protocol_frontend_summary,
     fuzz_reconstruction_response_summary, fuzz_retained_shard_chunk_hashes,
 };
 pub use gc::{
@@ -127,4 +133,8 @@ pub use server_role::{ServerRole, ServerRoleParseError};
 pub use storage_migration::{
     StorageMigrationEndpoint, StorageMigrationOptions, StorageMigrationReport,
     run_storage_migration,
+};
+pub use xet_adapter::{
+    DecodedXorbChunk, ValidatedXorb, ValidatedXorbChunk, XorbParseError, XorbVisitError,
+    decode_serialized_xorb_chunks, try_for_each_serialized_xorb_chunk, validate_serialized_xorb,
 };

--- a/crates/server/src/lifecycle_repair.rs
+++ b/crates/server/src/lifecycle_repair.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, path::PathBuf};
 
 use shardline_index::{
     AsyncIndexStore, FileRecordStorageLayout, LocalIndexStore, PostgresIndexStore,
-    PostgresRecordStore, RecordStore,
+    PostgresRecordStore, RecordStore, xet_hash_hex_string,
 };
 
 use crate::{
@@ -363,7 +363,7 @@ where
 
     index_store
         .visit_dedupe_shard_mappings(|mapping| {
-            let chunk_hash_hex = mapping.chunk_hash().api_hex_string();
+            let chunk_hash_hex = xet_hash_hex_string(mapping.chunk_hash());
             if reachability
                 .live_dedupe_chunk_hashes
                 .contains(&chunk_hash_hex)

--- a/crates/server/src/local_backend.rs
+++ b/crates/server/src/local_backend.rs
@@ -24,6 +24,7 @@ use crate::{
     },
     object_store::{ServerObjectStore, read_full_object, reconstruct_file_record_bytes},
     overflow::{checked_add, checked_increment},
+    protocol_support::shared_sha256_object_key,
     upload_ingest::{FileUploadIngestor, RequestBodyReader},
     validation::{ensure_directory, validate_identifier},
     xet_adapter::{
@@ -234,6 +235,26 @@ impl LocalBackend {
             .put_if_absent(object_key, ObjectBody::from_vec(bytes), &integrity)
     }
 
+    pub(crate) fn put_sha256_addressed_object_bytes_if_absent(
+        &self,
+        object_key: &ObjectKey,
+        digest_hex: &str,
+        bytes: Vec<u8>,
+    ) -> Result<PutOutcome, ServerError> {
+        let canonical_key = shared_sha256_object_key(digest_hex)?;
+        let integrity = ObjectIntegrity::new(chunk_hash(&bytes), u64::try_from(bytes.len())?);
+        let canonical_outcome = self.object_store().put_if_absent(
+            &canonical_key,
+            ObjectBody::from_vec(bytes),
+            &integrity,
+        )?;
+        if canonical_key == *object_key {
+            return Ok(canonical_outcome);
+        }
+        self.object_store()
+            .copy_if_absent(&canonical_key, object_key)
+    }
+
     pub(crate) fn copy_object_if_absent(
         &self,
         source: &ObjectKey,
@@ -252,14 +273,22 @@ impl LocalBackend {
             .put_overwrite(object_key, ObjectBody::from_vec(bytes), &integrity)
     }
 
-    pub(crate) fn put_content_addressed_object_file(
+    pub(crate) fn put_sha256_addressed_object_file(
         &self,
         object_key: &ObjectKey,
+        digest_hex: &str,
         path: &std::path::Path,
         integrity: &ObjectIntegrity,
     ) -> Result<PutOutcome, ServerError> {
+        let canonical_key = shared_sha256_object_key(digest_hex)?;
+        let canonical_outcome =
+            self.object_store()
+                .put_content_addressed_file(&canonical_key, path, integrity)?;
+        if canonical_key == *object_key {
+            return Ok(canonical_outcome);
+        }
         self.object_store()
-            .put_content_addressed_file(object_key, path, integrity)
+            .copy_if_absent(&canonical_key, object_key)
     }
 
     /// Stores a raw xorb body under its content hash.

--- a/crates/server/src/local_backend.rs
+++ b/crates/server/src/local_backend.rs
@@ -7,7 +7,9 @@ use shardline_index::{
     FileChunkRecord, FileRecord, IndexStore, LocalIndexStore, LocalRecordStore, RecordStore,
 };
 use shardline_protocol::{ByteRange, RepositoryScope, ShardlineHash};
-use shardline_storage::{ObjectKey, ObjectPrefix};
+use shardline_storage::{
+    DeleteOutcome, ObjectBody, ObjectIntegrity, ObjectKey, ObjectMetadata, ObjectPrefix, PutOutcome,
+};
 use tokio::task;
 
 use crate::{
@@ -222,6 +224,44 @@ impl LocalBackend {
         Ok(response)
     }
 
+    pub(crate) fn put_object_bytes_if_absent(
+        &self,
+        object_key: &ObjectKey,
+        bytes: Vec<u8>,
+    ) -> Result<PutOutcome, ServerError> {
+        let integrity = ObjectIntegrity::new(chunk_hash(&bytes), u64::try_from(bytes.len())?);
+        self.object_store()
+            .put_if_absent(object_key, ObjectBody::from_vec(bytes), &integrity)
+    }
+
+    pub(crate) fn copy_object_if_absent(
+        &self,
+        source: &ObjectKey,
+        destination: &ObjectKey,
+    ) -> Result<PutOutcome, ServerError> {
+        self.object_store().copy_if_absent(source, destination)
+    }
+
+    pub(crate) fn put_object_bytes_overwrite(
+        &self,
+        object_key: &ObjectKey,
+        bytes: Vec<u8>,
+    ) -> Result<(), ServerError> {
+        let integrity = ObjectIntegrity::new(chunk_hash(&bytes), u64::try_from(bytes.len())?);
+        self.object_store()
+            .put_overwrite(object_key, ObjectBody::from_vec(bytes), &integrity)
+    }
+
+    pub(crate) fn put_content_addressed_object_file(
+        &self,
+        object_key: &ObjectKey,
+        path: &std::path::Path,
+        integrity: &ObjectIntegrity,
+    ) -> Result<PutOutcome, ServerError> {
+        self.object_store()
+            .put_content_addressed_file(object_key, path, integrity)
+    }
+
     /// Stores a raw xorb body under its content hash.
     ///
     /// # Errors
@@ -376,6 +416,71 @@ impl LocalBackend {
         })
         .await
         .map_err(ServerError::BlockingTask)?
+    }
+
+    pub(crate) async fn object_length(&self, object_key: &ObjectKey) -> Result<u64, ServerError> {
+        let metadata = self.object_store().metadata(object_key)?;
+        let Some(metadata) = metadata else {
+            return Err(ServerError::NotFound);
+        };
+        Ok(metadata.length())
+    }
+
+    pub(crate) async fn read_object(&self, object_key: &ObjectKey) -> Result<Vec<u8>, ServerError> {
+        let object_store = self.object_store();
+        let metadata = object_store.metadata(object_key)?;
+        let Some(metadata) = metadata else {
+            return Err(ServerError::NotFound);
+        };
+        let object_key = object_key.clone();
+        task::spawn_blocking(move || {
+            read_full_object(&object_store, &object_key, metadata.length())
+        })
+        .await
+        .map_err(ServerError::BlockingTask)?
+    }
+
+    pub(crate) async fn read_object_stream(
+        &self,
+        object_key: &ObjectKey,
+        total_length: u64,
+        range: Option<ByteRange>,
+    ) -> Result<ServerByteStream, ServerError> {
+        let object_store = self.object_store();
+        if let Some(range) = range {
+            return object_byte_range_stream(object_store, object_key.clone(), total_length, range)
+                .await;
+        }
+
+        object_byte_stream(object_store, object_key.clone(), total_length).await
+    }
+
+    pub(crate) fn visit_object_prefix<Visitor>(
+        &self,
+        prefix: &ObjectPrefix,
+        visitor: Visitor,
+    ) -> Result<(), ServerError>
+    where
+        Visitor: FnMut(ObjectMetadata) -> Result<(), ServerError>,
+    {
+        self.object_store().visit_prefix(prefix, visitor)
+    }
+
+    pub(crate) fn list_object_flat_namespace_page(
+        &self,
+        prefix: &ObjectPrefix,
+        start_after: Option<&ObjectKey>,
+        limit: usize,
+    ) -> Result<Vec<ObjectMetadata>, ServerError> {
+        self.object_store()
+            .list_flat_namespace_page(prefix, start_after, limit)
+    }
+
+    pub(crate) async fn delete_object_if_present(
+        &self,
+        object_key: &ObjectKey,
+    ) -> Result<DeleteOutcome, ServerError> {
+        self.object_store().delete_if_present(object_key)
     }
 
     /// Loads the stored byte length for a chunk object.

--- a/crates/server/src/model.rs
+++ b/crates/server/src/model.rs
@@ -238,6 +238,17 @@ pub struct GitLfsAuthenticateResponse {
     pub expires_in: u64,
 }
 
+/// OCI registry bearer-token exchange response.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OciRegistryTokenResponse {
+    /// Bearer token returned by the registry token service.
+    pub token: String,
+    /// Duplicate bearer token field used by some clients.
+    pub access_token: String,
+    /// Relative token lifetime in seconds.
+    pub expires_in: u64,
+}
+
 /// Provider webhook handling response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProviderWebhookResponse {

--- a/crates/server/src/object_store.rs
+++ b/crates/server/src/object_store.rs
@@ -126,6 +126,19 @@ impl ServerObjectStore {
         }
     }
 
+    pub(crate) fn put_overwrite(
+        &self,
+        key: &ObjectKey,
+        body: ObjectBody<'_>,
+        integrity: &ObjectIntegrity,
+    ) -> Result<(), ServerError> {
+        match self {
+            Self::Local(store) => Ok(store.put_overwrite(key, body, integrity)?),
+            Self::S3(store) => Ok(store.put_overwrite(key, body, integrity)?),
+            Self::Blackhole => Ok(()),
+        }
+    }
+
     pub(crate) fn read_range(
         &self,
         key: &ObjectKey,
@@ -161,11 +174,57 @@ impl ServerObjectStore {
         }
     }
 
+    pub(crate) fn list_flat_namespace_page(
+        &self,
+        prefix: &ObjectPrefix,
+        start_after: Option<&ObjectKey>,
+        limit: usize,
+    ) -> Result<Vec<ObjectMetadata>, ServerError> {
+        match self {
+            Self::Local(store) => Ok(store.list_flat_namespace_page(prefix, start_after, limit)?),
+            Self::S3(store) => Ok(store.list_flat_namespace_page(prefix, start_after, limit)?),
+            Self::Blackhole => Ok(Vec::new()),
+        }
+    }
+
     pub(crate) fn local_path_for_key(&self, key: &ObjectKey) -> Option<PathBuf> {
         match self {
             Self::Local(store) => Some(store.path_for_key(key)),
             Self::S3(_store) => None,
             Self::Blackhole => None,
+        }
+    }
+
+    pub(crate) fn delete_if_present(&self, key: &ObjectKey) -> Result<DeleteOutcome, ServerError> {
+        match self {
+            Self::Local(store) => Ok(store.delete_if_present(key)?),
+            Self::S3(store) => Ok(store.delete_if_present(key)?),
+            Self::Blackhole => Ok(DeleteOutcome::NotFound),
+        }
+    }
+
+    pub(crate) fn copy_if_absent(
+        &self,
+        source: &ObjectKey,
+        destination: &ObjectKey,
+    ) -> Result<PutOutcome, ServerError> {
+        match self {
+            Self::Local(store) => Ok(store.copy_object_if_absent(source, destination)?),
+            Self::S3(store) => Ok(store.copy_object_if_absent(source, destination)?),
+            Self::Blackhole => Err(ServerError::NotFound),
+        }
+    }
+
+    pub(crate) fn put_content_addressed_file(
+        &self,
+        key: &ObjectKey,
+        path: &Path,
+        integrity: &ObjectIntegrity,
+    ) -> Result<PutOutcome, ServerError> {
+        match self {
+            Self::Local(store) => Ok(store.put_temporary_file_if_absent(key, path, integrity)?),
+            Self::S3(store) => Ok(store.put_content_addressed_file(key, path, integrity)?),
+            Self::Blackhole => Ok(PutOutcome::Inserted),
         }
     }
 

--- a/crates/server/src/oci_adapter.rs
+++ b/crates/server/src/oci_adapter.rs
@@ -1,0 +1,558 @@
+use std::{
+    ffi::OsStr,
+    fs::{File, OpenOptions},
+    io::Read,
+    num::{NonZeroU64, NonZeroUsize},
+    path::{Path, PathBuf},
+    sync::LazyLock,
+};
+
+use blake3::Hasher as Blake3Hasher;
+use getrandom::fill as getrandom_fill;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use shardline_storage::ObjectIntegrity;
+use shardline_storage::{ObjectKey, ObjectPrefix};
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::{Mutex, MutexGuard};
+use tokio::task::spawn_blocking;
+
+use crate::{
+    ServerError,
+    clock::unix_now_seconds_checked,
+    local_fs::write_file_atomically,
+    protocol_support::{
+        object_key, parse_sha256_digest, scope_namespace, stable_hex_id,
+        validate_oci_repository_name, validate_oci_repository_scope, validate_oci_tag,
+        validate_upload_session_id,
+    },
+};
+use shardline_protocol::RepositoryScope;
+
+const OCI_UPLOAD_DIR: &str = "oci-uploads";
+static OCI_UPLOAD_SESSION_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+pub(crate) struct OciUploadSessionLock {
+    _process_guard: MutexGuard<'static, ()>,
+    _file_lock: OciFileLock,
+}
+
+struct OciFileLock {
+    file: File,
+}
+
+impl Drop for OciFileLock {
+    fn drop(&mut self) {
+        let _ignored = self.file.unlock();
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct OciUploadSession {
+    pub(crate) repository: String,
+    #[serde(default = "global_scope_namespace")]
+    pub(crate) scope_namespace: String,
+    pub(crate) created_at_unix_seconds: u64,
+    pub(crate) last_touched_unix_seconds: u64,
+}
+
+fn global_scope_namespace() -> String {
+    "global".to_owned()
+}
+
+pub(crate) fn validate_repository(repository: &str) -> Result<(), ServerError> {
+    validate_oci_repository_name(repository)
+}
+
+pub(crate) fn parse_reference(reference: &str) -> Result<OciReference, ServerError> {
+    if reference.starts_with("sha256:") {
+        return Ok(OciReference::Digest(parse_sha256_digest(reference)?));
+    }
+    validate_oci_tag(reference)?;
+    Ok(OciReference::Tag(reference.to_owned()))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum OciReference {
+    Digest(String),
+    Tag(String),
+}
+
+pub(crate) fn oci_blob_key(
+    repository: &str,
+    digest_hex: &str,
+    repository_scope: Option<&RepositoryScope>,
+) -> Result<ObjectKey, ServerError> {
+    validate_repository(repository)?;
+    validate_oci_repository_scope(repository, repository_scope)?;
+    object_key(&format!(
+        "protocols/oci/{}/repos/{}/blobs/{}",
+        scope_namespace(repository_scope),
+        stable_hex_id(repository),
+        digest_hex
+    ))
+}
+
+pub(crate) fn oci_manifest_key(
+    repository: &str,
+    digest_hex: &str,
+    repository_scope: Option<&RepositoryScope>,
+) -> Result<ObjectKey, ServerError> {
+    validate_repository(repository)?;
+    validate_oci_repository_scope(repository, repository_scope)?;
+    object_key(&format!(
+        "protocols/oci/{}/repos/{}/manifests/{}",
+        scope_namespace(repository_scope),
+        stable_hex_id(repository),
+        digest_hex
+    ))
+}
+
+pub(crate) fn oci_manifest_media_type_key(
+    repository: &str,
+    digest_hex: &str,
+    repository_scope: Option<&RepositoryScope>,
+) -> Result<ObjectKey, ServerError> {
+    validate_repository(repository)?;
+    validate_oci_repository_scope(repository, repository_scope)?;
+    object_key(&format!(
+        "protocols/oci/{}/repos/{}/manifest-media-types/{}",
+        scope_namespace(repository_scope),
+        stable_hex_id(repository),
+        digest_hex
+    ))
+}
+
+pub(crate) fn oci_tag_key(
+    repository: &str,
+    tag: &str,
+    repository_scope: Option<&RepositoryScope>,
+) -> Result<ObjectKey, ServerError> {
+    validate_repository(repository)?;
+    validate_oci_repository_scope(repository, repository_scope)?;
+    validate_oci_tag(tag)?;
+    object_key(&format!(
+        "protocols/oci/{}/repos/{}/tags/{}",
+        scope_namespace(repository_scope),
+        stable_hex_id(repository),
+        tag
+    ))
+}
+
+pub(crate) fn oci_tag_prefix(
+    repository: &str,
+    repository_scope: Option<&RepositoryScope>,
+) -> Result<ObjectPrefix, ServerError> {
+    validate_repository(repository)?;
+    validate_oci_repository_scope(repository, repository_scope)?;
+    ObjectPrefix::parse(&format!(
+        "protocols/oci/{}/repos/{}/tags/",
+        scope_namespace(repository_scope),
+        stable_hex_id(repository)
+    ))
+    .map_err(ServerError::from)
+}
+
+pub(crate) fn oci_tag_target_key(
+    repository: &str,
+    digest_hex: &str,
+    tag: &str,
+    repository_scope: Option<&RepositoryScope>,
+) -> Result<ObjectKey, ServerError> {
+    validate_repository(repository)?;
+    validate_oci_repository_scope(repository, repository_scope)?;
+    parse_sha256_digest(&format!("sha256:{digest_hex}"))?;
+    validate_oci_tag(tag)?;
+    object_key(&format!(
+        "protocols/oci/{}/repos/{}/tag-targets/{}/{}",
+        scope_namespace(repository_scope),
+        stable_hex_id(repository),
+        digest_hex,
+        tag
+    ))
+}
+
+pub(crate) fn oci_tag_target_prefix(
+    repository: &str,
+    digest_hex: &str,
+    repository_scope: Option<&RepositoryScope>,
+) -> Result<ObjectPrefix, ServerError> {
+    validate_repository(repository)?;
+    validate_oci_repository_scope(repository, repository_scope)?;
+    parse_sha256_digest(&format!("sha256:{digest_hex}"))?;
+    ObjectPrefix::parse(&format!(
+        "protocols/oci/{}/repos/{}/tag-targets/{}/",
+        scope_namespace(repository_scope),
+        stable_hex_id(repository),
+        digest_hex
+    ))
+    .map_err(ServerError::from)
+}
+
+pub(crate) fn oci_blob_location(repository: &str, digest_hex: &str) -> String {
+    format!("/v2/{repository}/blobs/sha256:{digest_hex}")
+}
+
+pub(crate) fn oci_manifest_location(repository: &str, reference: &str) -> String {
+    format!("/v2/{repository}/manifests/{reference}")
+}
+
+pub(crate) fn upload_session_location(repository: &str, session_id: &str) -> String {
+    format!("/v2/{repository}/blobs/uploads/{session_id}")
+}
+
+pub(crate) fn new_upload_session_id() -> String {
+    let mut bytes = [0_u8; 16];
+    if getrandom_fill(&mut bytes).is_ok() {
+        return hex::encode(bytes);
+    }
+
+    let fallback = format!(
+        "{}:{}:{}",
+        std::process::id(),
+        std::thread::current().name().unwrap_or("unnamed"),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0_u128, |duration| duration.as_nanos())
+    );
+    let digest = Sha256::digest(fallback.as_bytes());
+    let mut encoded = hex::encode(digest);
+    encoded.truncate(32);
+    encoded
+}
+
+pub(crate) async fn lock_upload_sessions(root: &Path) -> Result<OciUploadSessionLock, ServerError> {
+    let process_guard = OCI_UPLOAD_SESSION_LOCK.lock().await;
+    let file_lock = acquire_upload_session_file_lock(upload_session_lock_path(root)).await?;
+    Ok(OciUploadSessionLock {
+        _process_guard: process_guard,
+        _file_lock: file_lock,
+    })
+}
+
+fn upload_dir(root: &Path) -> PathBuf {
+    root.join(OCI_UPLOAD_DIR)
+}
+
+fn upload_session_lock_path(root: &Path) -> PathBuf {
+    upload_dir(root).join(".sessions.lock")
+}
+
+fn upload_metadata_path(root: &Path, session_id: &str) -> PathBuf {
+    upload_dir(root).join(format!("{session_id}.json"))
+}
+
+fn upload_body_path(root: &Path, session_id: &str) -> PathBuf {
+    upload_dir(root).join(format!("{session_id}.bin"))
+}
+
+pub(crate) async fn create_upload_session(
+    root: &Path,
+    repository: &str,
+    repository_scope: Option<&RepositoryScope>,
+    ttl_seconds: NonZeroU64,
+    max_active_sessions: NonZeroUsize,
+) -> Result<String, ServerError> {
+    let _lock = lock_upload_sessions(root).await?;
+    validate_repository(repository)?;
+    validate_oci_repository_scope(repository, repository_scope)?;
+    let now_unix_seconds = unix_now_seconds_checked()?;
+    purge_expired_upload_sessions(root, ttl_seconds, now_unix_seconds).await?;
+    let active_sessions = count_active_upload_sessions(root).await?;
+    if active_sessions >= max_active_sessions.get() {
+        return Err(ServerError::TooManyUploadSessions);
+    }
+    let session_id = new_upload_session_id();
+    let upload_dir = upload_dir(root);
+    fs::create_dir_all(&upload_dir).await?;
+    let metadata = serde_json::to_vec(&OciUploadSession {
+        repository: repository.to_owned(),
+        scope_namespace: scope_namespace(repository_scope),
+        created_at_unix_seconds: now_unix_seconds,
+        last_touched_unix_seconds: now_unix_seconds,
+    })?;
+    fs::write(upload_body_path(root, &session_id), []).await?;
+    if let Err(error) = write_upload_metadata(root, &session_id, metadata).await {
+        delete_upload_session(root, &session_id).await?;
+        return Err(error);
+    }
+    Ok(session_id)
+}
+
+pub(crate) async fn read_upload_session(
+    root: &Path,
+    session_id: &str,
+    ttl_seconds: NonZeroU64,
+) -> Result<OciUploadSession, ServerError> {
+    validate_upload_session_id(session_id)?;
+    let bytes = fs::read(upload_metadata_path(root, session_id))
+        .await
+        .map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                ServerError::NotFound
+            } else {
+                ServerError::Io(error)
+            }
+        })?;
+    let session: OciUploadSession = serde_json::from_slice(&bytes)?;
+    let now_unix_seconds = unix_now_seconds_checked()?;
+    if upload_session_expired(&session, ttl_seconds, now_unix_seconds) {
+        delete_upload_session(root, session_id).await?;
+        return Err(ServerError::NotFound);
+    }
+    if fs::metadata(upload_body_path(root, session_id))
+        .await
+        .is_err()
+    {
+        delete_upload_session(root, session_id).await?;
+        return Err(ServerError::NotFound);
+    }
+    Ok(session)
+}
+
+pub(crate) async fn append_upload_bytes(
+    root: &Path,
+    session_id: &str,
+    bytes: &[u8],
+) -> Result<u64, ServerError> {
+    validate_upload_session_id(session_id)?;
+    let path = upload_body_path(root, session_id);
+    let mut file = fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .await
+        .map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                ServerError::NotFound
+            } else {
+                ServerError::Io(error)
+            }
+        })?;
+    file.write_all(bytes).await?;
+    let metadata = file.metadata().await?;
+    Ok(metadata.len())
+}
+
+pub(crate) async fn upload_length(root: &Path, session_id: &str) -> Result<u64, ServerError> {
+    validate_upload_session_id(session_id)?;
+    let metadata = fs::metadata(upload_body_path(root, session_id))
+        .await
+        .map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                ServerError::NotFound
+            } else {
+                ServerError::Io(error)
+            }
+        })?;
+    Ok(metadata.len())
+}
+
+pub(crate) fn upload_body_path_for_session(
+    root: &Path,
+    session_id: &str,
+) -> Result<PathBuf, ServerError> {
+    validate_upload_session_id(session_id)?;
+    Ok(upload_body_path(root, session_id))
+}
+
+pub(crate) async fn upload_body_integrity(
+    root: &Path,
+    session_id: &str,
+) -> Result<(String, ObjectIntegrity), ServerError> {
+    validate_upload_session_id(session_id)?;
+    let path = upload_body_path(root, session_id);
+    spawn_blocking(move || {
+        let mut file = File::open(&path)?;
+        let mut sha256 = Sha256::new();
+        let mut blake3 = Blake3Hasher::new();
+        let mut buffer = [0_u8; 256 * 1024];
+        let mut total_length = 0_u64;
+        loop {
+            let read = file.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            let slice = buffer.get(..read).ok_or(ServerError::Overflow)?;
+            sha256.update(slice);
+            blake3.update(slice);
+            total_length = total_length
+                .checked_add(u64::try_from(read).map_err(|_error| ServerError::Overflow)?)
+                .ok_or(ServerError::Overflow)?;
+        }
+        let sha256_hex = hex::encode(sha256.finalize());
+        let blake3_hash =
+            shardline_protocol::ShardlineHash::from_bytes(*blake3.finalize().as_bytes());
+        Ok::<_, ServerError>((sha256_hex, ObjectIntegrity::new(blake3_hash, total_length)))
+    })
+    .await
+    .map_err(ServerError::BlockingTask)?
+}
+
+pub(crate) async fn delete_upload_session(
+    root: &Path,
+    session_id: &str,
+) -> Result<(), ServerError> {
+    validate_upload_session_id(session_id)?;
+    let metadata_path = upload_metadata_path(root, session_id);
+    let body_path = upload_body_path(root, session_id);
+    match fs::remove_file(body_path).await {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(ServerError::Io(error)),
+    }
+    match fs::remove_file(metadata_path).await {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(ServerError::Io(error)),
+    }
+    Ok(())
+}
+
+pub(crate) async fn touch_upload_session(
+    root: &Path,
+    session_id: &str,
+    mut session: OciUploadSession,
+) -> Result<(), ServerError> {
+    validate_upload_session_id(session_id)?;
+    session.last_touched_unix_seconds = unix_now_seconds_checked()?;
+    let bytes = serde_json::to_vec(&session)?;
+    write_upload_metadata(root, session_id, bytes).await
+}
+
+const fn upload_session_expired(
+    session: &OciUploadSession,
+    ttl_seconds: NonZeroU64,
+    now_unix_seconds: u64,
+) -> bool {
+    session
+        .last_touched_unix_seconds
+        .saturating_add(ttl_seconds.get())
+        <= now_unix_seconds
+}
+
+async fn count_active_upload_sessions(root: &Path) -> Result<usize, ServerError> {
+    let upload_dir = upload_dir(root);
+    let mut entries = match fs::read_dir(upload_dir).await {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(error) => return Err(ServerError::Io(error)),
+    };
+    let mut active_sessions = 0_usize;
+    while let Some(entry) = entries.next_entry().await? {
+        if entry.path().extension() == Some(OsStr::new("json")) {
+            active_sessions = active_sessions.saturating_add(1);
+        }
+    }
+    Ok(active_sessions)
+}
+
+async fn acquire_upload_session_file_lock(path: PathBuf) -> Result<OciFileLock, ServerError> {
+    spawn_blocking(move || {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(path)?;
+        file.lock()?;
+        Ok(OciFileLock { file })
+    })
+    .await
+    .map_err(ServerError::BlockingTask)?
+}
+
+pub(crate) async fn purge_expired_upload_sessions(
+    root: &Path,
+    ttl_seconds: NonZeroU64,
+    now_unix_seconds: u64,
+) -> Result<(), ServerError> {
+    let upload_dir = upload_dir(root);
+    let mut entries = match fs::read_dir(upload_dir).await {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(ServerError::Io(error)),
+    };
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        match path.extension() {
+            Some(extension) if extension == OsStr::new("json") => {}
+            Some(extension) if extension == OsStr::new("bin") => {
+                let Some(stem) = path.file_stem().and_then(OsStr::to_str) else {
+                    continue;
+                };
+                if validate_upload_session_id(stem).is_err() {
+                    continue;
+                }
+                if fs::metadata(upload_metadata_path(root, stem))
+                    .await
+                    .is_err()
+                {
+                    let _deleted = fs::remove_file(&path).await;
+                }
+                continue;
+            }
+            _ => continue,
+        }
+        let Some(stem) = path.file_stem().and_then(OsStr::to_str) else {
+            continue;
+        };
+        if validate_upload_session_id(stem).is_err() {
+            continue;
+        }
+        let bytes = match fs::read(&path).await {
+            Ok(bytes) => bytes,
+            Err(_error) => {
+                delete_upload_session(root, stem).await?;
+                continue;
+            }
+        };
+        let session: OciUploadSession = match serde_json::from_slice(&bytes) {
+            Ok(session) => session,
+            Err(_error) => {
+                delete_upload_session(root, stem).await?;
+                continue;
+            }
+        };
+        if upload_session_expired(&session, ttl_seconds, now_unix_seconds)
+            || fs::metadata(upload_body_path(root, stem)).await.is_err()
+        {
+            delete_upload_session(root, stem).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn write_upload_metadata(
+    root: &Path,
+    session_id: &str,
+    bytes: Vec<u8>,
+) -> Result<(), ServerError> {
+    validate_upload_session_id(session_id)?;
+    let root = root.to_path_buf();
+    let path = upload_metadata_path(&root, session_id);
+    spawn_blocking(move || write_file_atomically(&root, &path, &bytes))
+        .await
+        .map_err(ServerError::BlockingTask)?
+        .map_err(ServerError::Io)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::new_upload_session_id;
+
+    #[test]
+    fn upload_session_ids_are_hex_and_not_reused_back_to_back() {
+        let first = new_upload_session_id();
+        let second = new_upload_session_id();
+
+        assert_eq!(first.len(), 32);
+        assert_eq!(second.len(), 32);
+        assert!(first.bytes().all(|byte| byte.is_ascii_hexdigit()));
+        assert!(second.bytes().all(|byte| byte.is_ascii_hexdigit()));
+        assert_ne!(first, second);
+    }
+}

--- a/crates/server/src/postgres_backend.rs
+++ b/crates/server/src/postgres_backend.rs
@@ -23,6 +23,7 @@ use crate::{
     },
     object_store::{ServerObjectStore, read_full_object, reconstruct_file_record_bytes},
     overflow::{checked_add, checked_increment},
+    protocol_support::shared_sha256_object_key,
     record_store::parse_stored_file_record_bytes,
     upload_ingest::{FileUploadIngestor, RequestBodyReader},
     validation::{ensure_directory, validate_content_hash, validate_identifier},
@@ -246,6 +247,29 @@ impl PostgresBackend {
             .put_if_absent(object_key, ObjectBody::from_vec(bytes), &integrity)
     }
 
+    pub(crate) fn put_sha256_addressed_object_bytes_if_absent(
+        &self,
+        object_key: &ObjectKey,
+        digest_hex: &str,
+        bytes: Vec<u8>,
+    ) -> Result<PutOutcome, ServerError> {
+        let canonical_key = shared_sha256_object_key(digest_hex)?;
+        let integrity = ObjectIntegrity::new(
+            shardline_protocol::ShardlineHash::from_bytes(*blake3::hash(&bytes).as_bytes()),
+            u64::try_from(bytes.len())?,
+        );
+        let canonical_outcome = self.object_store().put_if_absent(
+            &canonical_key,
+            ObjectBody::from_vec(bytes),
+            &integrity,
+        )?;
+        if canonical_key == *object_key {
+            return Ok(canonical_outcome);
+        }
+        self.object_store()
+            .copy_if_absent(&canonical_key, object_key)
+    }
+
     pub(crate) fn copy_object_if_absent(
         &self,
         source: &ObjectKey,
@@ -267,14 +291,22 @@ impl PostgresBackend {
             .put_overwrite(object_key, ObjectBody::from_vec(bytes), &integrity)
     }
 
-    pub(crate) fn put_content_addressed_object_file(
+    pub(crate) fn put_sha256_addressed_object_file(
         &self,
         object_key: &ObjectKey,
+        digest_hex: &str,
         path: &std::path::Path,
         integrity: &ObjectIntegrity,
     ) -> Result<PutOutcome, ServerError> {
+        let canonical_key = shared_sha256_object_key(digest_hex)?;
+        let canonical_outcome =
+            self.object_store()
+                .put_content_addressed_file(&canonical_key, path, integrity)?;
+        if canonical_key == *object_key {
+            return Ok(canonical_outcome);
+        }
         self.object_store()
-            .put_content_addressed_file(object_key, path, integrity)
+            .copy_if_absent(&canonical_key, object_key)
     }
 
     /// Stores a raw xorb body under its content hash.

--- a/crates/server/src/postgres_backend.rs
+++ b/crates/server/src/postgres_backend.rs
@@ -6,7 +6,9 @@ use shardline_index::{
     RepositoryRecordScope,
 };
 use shardline_protocol::{ByteRange, RepositoryScope};
-use shardline_storage::{ObjectKey, ObjectPrefix};
+use shardline_storage::{
+    DeleteOutcome, ObjectBody, ObjectIntegrity, ObjectKey, ObjectMetadata, ObjectPrefix, PutOutcome,
+};
 use sqlx::{PgPool, postgres::PgPoolOptions, query_scalar};
 use tokio::task;
 
@@ -231,6 +233,50 @@ impl PostgresBackend {
         Ok(response)
     }
 
+    pub(crate) fn put_object_bytes_if_absent(
+        &self,
+        object_key: &ObjectKey,
+        bytes: Vec<u8>,
+    ) -> Result<PutOutcome, ServerError> {
+        let integrity = ObjectIntegrity::new(
+            shardline_protocol::ShardlineHash::from_bytes(*blake3::hash(&bytes).as_bytes()),
+            u64::try_from(bytes.len())?,
+        );
+        self.object_store()
+            .put_if_absent(object_key, ObjectBody::from_vec(bytes), &integrity)
+    }
+
+    pub(crate) fn copy_object_if_absent(
+        &self,
+        source: &ObjectKey,
+        destination: &ObjectKey,
+    ) -> Result<PutOutcome, ServerError> {
+        self.object_store().copy_if_absent(source, destination)
+    }
+
+    pub(crate) fn put_object_bytes_overwrite(
+        &self,
+        object_key: &ObjectKey,
+        bytes: Vec<u8>,
+    ) -> Result<(), ServerError> {
+        let integrity = ObjectIntegrity::new(
+            shardline_protocol::ShardlineHash::from_bytes(*blake3::hash(&bytes).as_bytes()),
+            u64::try_from(bytes.len())?,
+        );
+        self.object_store()
+            .put_overwrite(object_key, ObjectBody::from_vec(bytes), &integrity)
+    }
+
+    pub(crate) fn put_content_addressed_object_file(
+        &self,
+        object_key: &ObjectKey,
+        path: &std::path::Path,
+        integrity: &ObjectIntegrity,
+    ) -> Result<PutOutcome, ServerError> {
+        self.object_store()
+            .put_content_addressed_file(object_key, path, integrity)
+    }
+
     /// Stores a raw xorb body under its content hash.
     ///
     /// # Errors
@@ -368,6 +414,71 @@ impl PostgresBackend {
         })
         .await
         .map_err(ServerError::BlockingTask)?
+    }
+
+    pub(crate) async fn object_length(&self, object_key: &ObjectKey) -> Result<u64, ServerError> {
+        let metadata = self.object_store().metadata(object_key)?;
+        let Some(metadata) = metadata else {
+            return Err(ServerError::NotFound);
+        };
+        Ok(metadata.length())
+    }
+
+    pub(crate) async fn read_object(&self, object_key: &ObjectKey) -> Result<Vec<u8>, ServerError> {
+        let object_store = self.object_store();
+        let metadata = object_store.metadata(object_key)?;
+        let Some(metadata) = metadata else {
+            return Err(ServerError::NotFound);
+        };
+        let object_key = object_key.clone();
+        task::spawn_blocking(move || {
+            read_full_object(&object_store, &object_key, metadata.length())
+        })
+        .await
+        .map_err(ServerError::BlockingTask)?
+    }
+
+    pub(crate) async fn read_object_stream(
+        &self,
+        object_key: &ObjectKey,
+        total_length: u64,
+        range: Option<ByteRange>,
+    ) -> Result<ServerByteStream, ServerError> {
+        let object_store = self.object_store();
+        if let Some(range) = range {
+            return object_byte_range_stream(object_store, object_key.clone(), total_length, range)
+                .await;
+        }
+
+        object_byte_stream(object_store, object_key.clone(), total_length).await
+    }
+
+    pub(crate) fn visit_object_prefix<Visitor>(
+        &self,
+        prefix: &ObjectPrefix,
+        visitor: Visitor,
+    ) -> Result<(), ServerError>
+    where
+        Visitor: FnMut(ObjectMetadata) -> Result<(), ServerError>,
+    {
+        self.object_store().visit_prefix(prefix, visitor)
+    }
+
+    pub(crate) fn list_object_flat_namespace_page(
+        &self,
+        prefix: &ObjectPrefix,
+        start_after: Option<&ObjectKey>,
+        limit: usize,
+    ) -> Result<Vec<ObjectMetadata>, ServerError> {
+        self.object_store()
+            .list_flat_namespace_page(prefix, start_after, limit)
+    }
+
+    pub(crate) async fn delete_object_if_present(
+        &self,
+        object_key: &ObjectKey,
+    ) -> Result<DeleteOutcome, ServerError> {
+        self.object_store().delete_if_present(object_key)
     }
 
     /// Loads the stored byte length for a chunk object.

--- a/crates/server/src/protocol_support.rs
+++ b/crates/server/src/protocol_support.rs
@@ -1,0 +1,215 @@
+use sha2::{Digest, Sha256};
+use shardline_protocol::RepositoryScope;
+use shardline_storage::ObjectKey;
+
+use crate::{ServerError, validation::validate_content_hash};
+
+const MAX_UPLOAD_SESSION_ID_BYTES: usize = 64;
+
+pub(crate) fn parse_sha256_digest(value: &str) -> Result<String, ServerError> {
+    let Some(hash_hex) = value.strip_prefix("sha256:") else {
+        return Err(ServerError::InvalidDigest);
+    };
+    validate_content_hash(hash_hex).map_err(|_error| ServerError::InvalidDigest)?;
+    Ok(hash_hex.to_owned())
+}
+
+pub(crate) fn scope_namespace(repository_scope: Option<&RepositoryScope>) -> String {
+    repository_scope.map_or_else(
+        || "global".to_owned(),
+        |scope| {
+            let mut hasher = Sha256::new();
+            hasher.update(scope.provider().as_str().as_bytes());
+            hasher.update([0]);
+            hasher.update(scope.owner().as_bytes());
+            hasher.update([0]);
+            hasher.update(scope.name().as_bytes());
+            hasher.update([0]);
+            if let Some(revision) = scope.revision() {
+                hasher.update(revision.as_bytes());
+            }
+            hex::encode(hasher.finalize())
+        },
+    )
+}
+
+pub(crate) fn stable_hex_id(value: &str) -> String {
+    hex::encode(Sha256::digest(value.as_bytes()))
+}
+
+pub(crate) fn object_key(value: &str) -> Result<ObjectKey, ServerError> {
+    ObjectKey::parse(value).map_err(|_error| ServerError::InvalidContentHash)
+}
+
+pub(crate) fn validate_oci_repository_name(value: &str) -> Result<(), ServerError> {
+    if value.is_empty() || value.starts_with('/') || value.ends_with('/') || value.contains('\\') {
+        return Err(ServerError::InvalidRepositoryName);
+    }
+
+    for segment in value.split('/') {
+        if segment.is_empty()
+            || segment == "."
+            || segment == ".."
+            || !segment.bytes().all(|byte| {
+                byte.is_ascii_lowercase()
+                    || byte.is_ascii_digit()
+                    || matches!(byte, b'.' | b'_' | b'-')
+            })
+        {
+            return Err(ServerError::InvalidRepositoryName);
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn validate_oci_repository_scope(
+    value: &str,
+    repository_scope: Option<&RepositoryScope>,
+) -> Result<(), ServerError> {
+    let Some(repository_scope) = repository_scope else {
+        return Ok(());
+    };
+
+    let expected_root = format!(
+        "{}/{}",
+        repository_scope.owner().to_ascii_lowercase(),
+        repository_scope.name().to_ascii_lowercase()
+    );
+    if value == expected_root
+        || value
+            .strip_prefix(&expected_root)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+    {
+        return Ok(());
+    }
+
+    Err(ServerError::NotFound)
+}
+
+pub(crate) fn validate_oci_tag(value: &str) -> Result<(), ServerError> {
+    let mut bytes = value.bytes();
+    let Some(first) = bytes.next() else {
+        return Err(ServerError::InvalidManifestReference);
+    };
+    if !(first.is_ascii_alphanumeric() || first == b'_') {
+        return Err(ServerError::InvalidManifestReference);
+    }
+    if value.len() > 128
+        || !bytes.all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.' | b'-'))
+    {
+        return Err(ServerError::InvalidManifestReference);
+    }
+
+    Ok(())
+}
+
+pub(crate) fn validate_upload_session_id(value: &str) -> Result<(), ServerError> {
+    if value.is_empty()
+        || value.len() > MAX_UPLOAD_SESSION_ID_BYTES
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() || byte == b'-')
+    {
+        return Err(ServerError::InvalidUploadSession);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        MAX_UPLOAD_SESSION_ID_BYTES, parse_sha256_digest, validate_oci_repository_name,
+        validate_oci_repository_scope, validate_oci_tag, validate_upload_session_id,
+    };
+    use crate::ServerError;
+    use shardline_protocol::{RepositoryProvider, RepositoryScope};
+
+    #[test]
+    fn sha256_digest_parser_requires_prefixed_lowercase_hex() {
+        let digest = parse_sha256_digest(
+            "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        );
+        assert!(digest.is_ok());
+        assert_eq!(
+            digest.unwrap_or_default(),
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        );
+        assert!(matches!(
+            parse_sha256_digest("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+            Err(ServerError::InvalidDigest)
+        ));
+        assert!(matches!(
+            parse_sha256_digest(
+                "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg"
+            ),
+            Err(ServerError::InvalidDigest)
+        ));
+    }
+
+    #[test]
+    fn oci_repository_validator_rejects_traversal_and_uppercase() {
+        assert!(validate_oci_repository_name("team/assets").is_ok());
+        assert!(matches!(
+            validate_oci_repository_name("../assets"),
+            Err(ServerError::InvalidRepositoryName)
+        ));
+        assert!(matches!(
+            validate_oci_repository_name("Team/assets"),
+            Err(ServerError::InvalidRepositoryName)
+        ));
+        assert!(matches!(
+            validate_oci_repository_name("team//assets"),
+            Err(ServerError::InvalidRepositoryName)
+        ));
+    }
+
+    #[test]
+    fn oci_tag_validator_enforces_allowed_characters() {
+        assert!(validate_oci_tag("v1").is_ok());
+        assert!(validate_oci_tag("_debug.2026-04-23").is_ok());
+        assert!(matches!(
+            validate_oci_tag("bad/tag"),
+            Err(ServerError::InvalidManifestReference)
+        ));
+        assert!(matches!(
+            validate_oci_tag("-bad"),
+            Err(ServerError::InvalidManifestReference)
+        ));
+    }
+
+    #[test]
+    fn upload_session_validator_accepts_hex_and_hyphen_only() {
+        assert!(validate_upload_session_id("0000000000000001").is_ok());
+        assert!(validate_upload_session_id("dead-beef").is_ok());
+        assert!(matches!(
+            validate_upload_session_id("session_1"),
+            Err(ServerError::InvalidUploadSession)
+        ));
+        assert!(matches!(
+            validate_upload_session_id(&"a".repeat(MAX_UPLOAD_SESSION_ID_BYTES + 1)),
+            Err(ServerError::InvalidUploadSession)
+        ));
+    }
+
+    #[test]
+    fn oci_repository_scope_validator_accepts_bound_roots_and_nested_namespaces() {
+        let scope = RepositoryScope::new(RepositoryProvider::GitHub, "team", "assets", None);
+        assert!(scope.is_ok());
+        let Ok(scope) = scope else {
+            return;
+        };
+
+        assert!(validate_oci_repository_scope("team/assets", Some(&scope)).is_ok());
+        assert!(validate_oci_repository_scope("team/assets/cache", Some(&scope)).is_ok());
+        assert!(matches!(
+            validate_oci_repository_scope("team/other", Some(&scope)),
+            Err(ServerError::NotFound)
+        ));
+        assert!(matches!(
+            validate_oci_repository_scope("other/assets", Some(&scope)),
+            Err(ServerError::NotFound)
+        ));
+    }
+}

--- a/crates/server/src/protocol_support.rs
+++ b/crates/server/src/protocol_support.rs
@@ -41,6 +41,11 @@ pub(crate) fn object_key(value: &str) -> Result<ObjectKey, ServerError> {
     ObjectKey::parse(value).map_err(|_error| ServerError::InvalidContentHash)
 }
 
+pub(crate) fn shared_sha256_object_key(digest_hex: &str) -> Result<ObjectKey, ServerError> {
+    validate_content_hash(digest_hex)?;
+    object_key(&format!("protocols/shared/sha256/{digest_hex}"))
+}
+
 pub(crate) fn validate_oci_repository_name(value: &str) -> Result<(), ServerError> {
     if value.is_empty() || value.starts_with('/') || value.ends_with('/') || value.contains('\\') {
         return Err(ServerError::InvalidRepositoryName);
@@ -120,8 +125,9 @@ pub(crate) fn validate_upload_session_id(value: &str) -> Result<(), ServerError>
 #[cfg(test)]
 mod tests {
     use super::{
-        MAX_UPLOAD_SESSION_ID_BYTES, parse_sha256_digest, validate_oci_repository_name,
-        validate_oci_repository_scope, validate_oci_tag, validate_upload_session_id,
+        MAX_UPLOAD_SESSION_ID_BYTES, parse_sha256_digest, shared_sha256_object_key,
+        validate_oci_repository_name, validate_oci_repository_scope, validate_oci_tag,
+        validate_upload_session_id,
     };
     use crate::ServerError;
     use shardline_protocol::{RepositoryProvider, RepositoryScope};
@@ -211,5 +217,20 @@ mod tests {
             validate_oci_repository_scope("other/assets", Some(&scope)),
             Err(ServerError::NotFound)
         ));
+    }
+
+    #[test]
+    fn shared_sha256_key_uses_stable_shared_namespace() {
+        let key = shared_sha256_object_key(
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        );
+        assert!(key.is_ok());
+        let Ok(key) = key else {
+            return;
+        };
+        assert_eq!(
+            key.as_str(),
+            "protocols/shared/sha256/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        );
     }
 }

--- a/crates/server/src/provider_events/tests.rs
+++ b/crates/server/src/provider_events/tests.rs
@@ -8,12 +8,10 @@ use serde_json::to_vec;
 use shardline_index::{
     AsyncIndexStore, DedupeShardMapping, FileChunkRecord, FileId, FileReconstruction, FileRecord,
     IndexStore, IndexStoreFuture, LocalIndexStore, LocalIndexStoreError, ProviderRepositoryState,
-    QuarantineCandidate, RecordStore, RetentionHold, WebhookDelivery, XorbId,
+    QuarantineCandidate, RecordStore, RetentionHold, WebhookDelivery, XorbId, parse_xet_hash_hex,
+    xet_hash_hex_string,
 };
-use shardline_protocol::{
-    RepositoryProvider, RepositoryScope, ShardlineHash, try_for_each_serialized_xorb_chunk,
-    validate_serialized_xorb,
-};
+use shardline_protocol::{RepositoryProvider, RepositoryScope, ShardlineHash};
 use shardline_storage::ObjectKey;
 use shardline_vcs::{
     ProviderKind, RepositoryRef, RepositoryWebhookEvent, RepositoryWebhookEventKind, RevisionRef,
@@ -31,6 +29,7 @@ use crate::{
     object_store::ServerObjectStore,
     record_store::LocalRecordStore,
     test_invariant_error::ServerTestInvariantError,
+    try_for_each_serialized_xorb_chunk, validate_serialized_xorb,
     xet_adapter::{normalize_serialized_xorb, store_uploaded_xorb, xorb_object_key},
 };
 
@@ -431,7 +430,7 @@ async fn exercise_repository_deleted_holds_native_xet_xorb_and_unpacked_chunks()
     let serialized =
         SerializedXorbObject::from_xorb_with_compression(raw_xorb, CompressionScheme::LZ4, false)?;
     let xorb_hash = serialized.hash.hex();
-    let expected_xorb_hash = ShardlineHash::parse_api_hex(&xorb_hash)?;
+    let expected_xorb_hash = parse_xet_hash_hex(&xorb_hash)?;
     let normalized_xorb =
         normalize_serialized_xorb(expected_xorb_hash, &serialized.serialized_data)?;
     let mut reader = Cursor::new(normalized_xorb.as_slice());
@@ -439,7 +438,7 @@ async fn exercise_repository_deleted_holds_native_xet_xorb_and_unpacked_chunks()
     let range_end = u32::try_from(validated.chunks().len())?;
     let mut chunk_hashes = Vec::new();
     try_for_each_serialized_xorb_chunk(&mut reader, &validated, |decoded_chunk| {
-        chunk_hashes.push(decoded_chunk.descriptor().hash().api_hex_string());
+        chunk_hashes.push(xet_hash_hex_string(decoded_chunk.descriptor().hash()));
         Ok::<(), ServerError>(())
     })?;
     let upload = store_uploaded_xorb(&object_store, &xorb_hash, &serialized.serialized_data)?;

--- a/crates/server/src/rebuild.rs
+++ b/crates/server/src/rebuild.rs
@@ -9,9 +9,8 @@ mod candidates;
 use serde_json::to_vec;
 use shardline_index::{
     AsyncIndexStore, DedupeShardMapping, FileId, LocalIndexStore, PostgresIndexStore,
-    PostgresRecordStore, RecordStore,
+    PostgresRecordStore, RecordStore, parse_xet_hash_hex, xet_hash_hex_string,
 };
-use shardline_protocol::ShardlineHash;
 use shardline_storage::ObjectPrefix;
 use thiserror::Error;
 
@@ -346,9 +345,9 @@ where
     records
         .into_iter()
         .filter_map(|candidate| {
-            ShardlineHash::parse_api_hex(&candidate.record.file_id)
+            parse_xet_hash_hex(&candidate.record.file_id)
                 .ok()
-                .map(|hash| hash.api_hex_string())
+                .map(xet_hash_hex_string)
         })
         .collect::<HashSet<_>>()
 }
@@ -372,7 +371,7 @@ where
         .map_err(Into::into)?;
     for file_id in existing_file_ids {
         report.scanned_reconstructions = checked_increment(report.scanned_reconstructions)?;
-        let file_id_hex = file_id.hash().api_hex_string();
+        let file_id_hex = xet_hash_hex_string(file_id.hash());
         if desired_reconstructions.contains(&file_id_hex) {
             report.unchanged_reconstructions = checked_increment(report.unchanged_reconstructions)?;
             continue;
@@ -436,10 +435,8 @@ where
         };
 
         for chunk_hash_hex in chunk_hashes {
-            let mapping = DedupeShardMapping::new(
-                ShardlineHash::parse_api_hex(&chunk_hash_hex)?,
-                shard_key.clone(),
-            );
+            let mapping =
+                DedupeShardMapping::new(parse_xet_hash_hex(&chunk_hash_hex)?, shard_key.clone());
             match desired.get(&chunk_hash_hex) {
                 Some(existing)
                     if existing.shard_object_key().as_str()
@@ -459,7 +456,7 @@ where
     let mut existing = HashMap::new();
     index_store
         .visit_dedupe_shard_mappings(|mapping| {
-            existing.insert(mapping.chunk_hash().api_hex_string(), mapping);
+            existing.insert(xet_hash_hex_string(mapping.chunk_hash()), mapping);
             Ok::<(), ServerError>(())
         })
         .await?;
@@ -488,7 +485,7 @@ where
             continue;
         }
 
-        let chunk_hash = ShardlineHash::parse_api_hex(&chunk_hash_hex)?;
+        let chunk_hash = parse_xet_hash_hex(&chunk_hash_hex)?;
         let _deleted = index_store
             .delete_dedupe_shard_mapping(&chunk_hash)
             .await

--- a/crates/server/src/rebuild/tests.rs
+++ b/crates/server/src/rebuild/tests.rs
@@ -5,7 +5,7 @@ use rusqlite::{Connection, params};
 use serde_json::{from_slice, to_vec};
 use shardline_index::{
     FileChunkRecord, FileId, FileReconstruction, FileRecord, IndexStore, LocalIndexStore,
-    ReconstructionTerm, RecordStore, StoredObjectId,
+    ReconstructionTerm, RecordStore, StoredObjectId, parse_xet_hash_hex, xet_hash_hex_string,
 };
 use shardline_protocol::{ChunkRange, RepositoryProvider, RepositoryScope, ShardlineHash};
 use tokio::{fs, time::sleep};
@@ -126,12 +126,12 @@ async fn index_rebuild_reaches_a_fixed_point_on_second_run() {
     let record_store = LocalRecordStore::open(storage.path().to_path_buf());
     let record = FileRecord {
         file_id: "asset.bin".to_owned(),
-        content_hash: ShardlineHash::from_bytes([71; 32]).api_hex_string(),
+        content_hash: xet_hash_hex_string(ShardlineHash::from_bytes([71; 32])),
         total_bytes: 4,
         chunk_size: 4,
         repository_scope: None,
         chunks: vec![FileChunkRecord {
-            hash: ShardlineHash::from_bytes([72; 32]).api_hex_string(),
+            hash: xet_hash_hex_string(ShardlineHash::from_bytes([72; 32])),
             offset: 0,
             length: 4,
             range_start: 0,
@@ -260,8 +260,8 @@ async fn index_rebuild_preserves_reconstruction_rows_backed_by_version_records()
     let file_hash = ShardlineHash::from_bytes([33; 32]);
     let file_id = FileId::new(file_hash);
     let record = FileRecord {
-        file_id: file_hash.api_hex_string(),
-        content_hash: ShardlineHash::from_bytes([34; 32]).api_hex_string(),
+        file_id: xet_hash_hex_string(file_hash),
+        content_hash: xet_hash_hex_string(ShardlineHash::from_bytes([34; 32])),
         total_bytes: 0,
         chunk_size: 0,
         repository_scope: None,
@@ -602,7 +602,7 @@ async fn index_rebuild_restores_dedupe_shard_mapping_from_retained_shard_objects
     assert!(uploaded_shard.is_ok());
 
     let index_store = LocalIndexStore::open(storage.path().to_path_buf());
-    let chunk_hash = ShardlineHash::parse_api_hex(&xorb_hash);
+    let chunk_hash = parse_xet_hash_hex(&xorb_hash);
     assert!(chunk_hash.is_ok());
     let Ok(chunk_hash) = chunk_hash else {
         return;
@@ -660,7 +660,7 @@ async fn index_rebuild_does_not_mutate_dedupe_mappings_when_retained_shard_is_co
     assert!(uploaded_shard.is_ok());
 
     let index_store = LocalIndexStore::open(storage.path().to_path_buf());
-    let chunk_hash = ShardlineHash::parse_api_hex(&xorb_hash);
+    let chunk_hash = parse_xet_hash_hex(&xorb_hash);
     assert!(chunk_hash.is_ok());
     let Ok(chunk_hash) = chunk_hash else {
         return;

--- a/crates/server/src/server_frontend/dispatch.rs
+++ b/crates/server/src/server_frontend/dispatch.rs
@@ -15,6 +15,7 @@ pub(crate) fn optional_chunk_container_keys(
             ServerFrontend::Xet => {
                 xet::push_optional_chunk_container_key(&mut object_keys, chunk_hash)?
             }
+            ServerFrontend::Lfs | ServerFrontend::BazelHttp | ServerFrontend::Oci => {}
         }
     }
 
@@ -43,6 +44,7 @@ pub(crate) fn managed_protocol_object_identity(
                     return Ok(Some(hash));
                 }
             }
+            ServerFrontend::Lfs | ServerFrontend::BazelHttp | ServerFrontend::Oci => {}
         }
     }
 
@@ -69,6 +71,7 @@ where
                     );
                 }
             }
+            ServerFrontend::Lfs | ServerFrontend::BazelHttp | ServerFrontend::Oci => {}
         }
     }
 

--- a/crates/server/src/server_frontend/kind.rs
+++ b/crates/server/src/server_frontend/kind.rs
@@ -3,8 +3,14 @@ use thiserror::Error;
 /// Runtime protocol frontend selection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ServerFrontend {
-    /// Xet-compatible CAS frontend.
+    /// Validated Xet-compatible CAS frontend.
     Xet,
+    /// Git LFS batch and object-transfer frontend.
+    Lfs,
+    /// Bazel-compatible HTTP remote-cache frontend.
+    BazelHttp,
+    /// OCI Distribution frontend.
+    Oci,
 }
 
 impl ServerFrontend {
@@ -17,6 +23,9 @@ impl ServerFrontend {
     pub fn parse(value: &str) -> Result<Self, ServerFrontendParseError> {
         match value {
             "xet" => Ok(Self::Xet),
+            "lfs" => Ok(Self::Lfs),
+            "bazel-http" => Ok(Self::BazelHttp),
+            "oci" => Ok(Self::Oci),
             _ => Err(ServerFrontendParseError),
         }
     }
@@ -26,6 +35,9 @@ impl ServerFrontend {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Xet => "xet",
+            Self::Lfs => "lfs",
+            Self::BazelHttp => "bazel-http",
+            Self::Oci => "oci",
         }
     }
 }

--- a/crates/server/src/server_frontend/tests.rs
+++ b/crates/server/src/server_frontend/tests.rs
@@ -3,10 +3,19 @@ use super::ServerFrontend;
 #[test]
 fn parses_supported_frontends() {
     assert_eq!(ServerFrontend::parse("xet"), Ok(ServerFrontend::Xet));
-    assert!(ServerFrontend::parse("lfs").is_err());
+    assert_eq!(ServerFrontend::parse("lfs"), Ok(ServerFrontend::Lfs));
+    assert_eq!(
+        ServerFrontend::parse("bazel-http"),
+        Ok(ServerFrontend::BazelHttp)
+    );
+    assert_eq!(ServerFrontend::parse("oci"), Ok(ServerFrontend::Oci));
+    assert!(ServerFrontend::parse("nope").is_err());
 }
 
 #[test]
 fn frontend_tokens_are_stable() {
     assert_eq!(ServerFrontend::Xet.as_str(), "xet");
+    assert_eq!(ServerFrontend::Lfs.as_str(), "lfs");
+    assert_eq!(ServerFrontend::BazelHttp.as_str(), "bazel-http");
+    assert_eq!(ServerFrontend::Oci.as_str(), "oci");
 }

--- a/crates/server/src/server_frontend/xet.rs
+++ b/crates/server/src/server_frontend/xet.rs
@@ -1,9 +1,6 @@
 use std::io::Cursor;
 
-use shardline_index::FileChunkRecord;
-use shardline_protocol::{
-    ShardlineHash, try_for_each_serialized_xorb_chunk, validate_serialized_xorb,
-};
+use shardline_index::{FileChunkRecord, parse_xet_hash_hex};
 use shardline_storage::ObjectKey;
 
 use crate::{
@@ -11,6 +8,7 @@ use crate::{
     object_store::{ServerObjectStore, read_full_object},
     xet_adapter::{
         map_xorb_visit_error, shard_hash_from_object_key_if_present,
+        try_for_each_serialized_xorb_chunk, validate_serialized_xorb,
         visit_stored_xorb_chunk_hashes, xorb_hash_from_object_key_if_present, xorb_object_key,
     },
 };
@@ -72,7 +70,7 @@ pub(super) fn append_referenced_term_bytes(
         return Err(ServerError::MissingReferencedXorb);
     };
     let xorb_bytes = read_full_object(object_store, &xorb_key, metadata.length())?;
-    let expected_hash = ShardlineHash::parse_api_hex(&term.hash)?;
+    let expected_hash = parse_xet_hash_hex(&term.hash)?;
     let mut reader = Cursor::new(xorb_bytes);
     let validated = validate_serialized_xorb(&mut reader, expected_hash)?;
     let range_start = usize::try_from(term.range_start)?;

--- a/crates/server/src/storage_migration.rs
+++ b/crates/server/src/storage_migration.rs
@@ -1,7 +1,7 @@
 use std::{io::Cursor, path::PathBuf};
 
 use serde::Serialize;
-use shardline_protocol::{ShardlineHash, validate_serialized_xorb};
+use shardline_index::{parse_xet_hash_hex, xet_hash_hex_string};
 use shardline_storage::{
     ObjectBody, ObjectIntegrity, ObjectKey, ObjectPrefix, PutOutcome, S3ObjectStoreConfig,
 };
@@ -13,7 +13,10 @@ use crate::{
     local_backend::chunk_hash,
     object_store::{ServerObjectStore, read_full_object},
     overflow::checked_add,
-    xet_adapter::{shard_hash_from_object_key_if_present, xorb_hash_from_object_key_if_present},
+    xet_adapter::{
+        shard_hash_from_object_key_if_present, validate_serialized_xorb,
+        xorb_hash_from_object_key_if_present,
+    },
 };
 
 /// Object-storage endpoint used by storage migration.
@@ -163,12 +166,12 @@ fn validate_source_object_matches_content_addressed_key(
     bytes: &[u8],
 ) -> Result<(), ServerError> {
     if let Some(expected_hash) = chunk_hash_from_chunk_object_key_if_present(key)? {
-        let observed_hash = chunk_hash(bytes).api_hex_string();
+        let observed_hash = xet_hash_hex_string(chunk_hash(bytes));
         ensure_observed_hash_matches_key(key, expected_hash, &observed_hash)?;
     }
 
     if let Some(expected_hash) = xorb_hash_from_object_key_if_present(key)? {
-        let expected_hash = ShardlineHash::parse_api_hex(expected_hash)?;
+        let expected_hash = parse_xet_hash_hex(expected_hash)?;
         let mut cursor = Cursor::new(bytes);
         validate_serialized_xorb(&mut cursor, expected_hash)?;
     }

--- a/crates/server/src/test_fixtures.rs
+++ b/crates/server/src/test_fixtures.rs
@@ -1,3 +1,4 @@
+use shardline_index::xet_hash_hex_string;
 use std::io::{self, Cursor};
 
 use axum::body::Bytes;
@@ -17,7 +18,7 @@ use xet_core_structures::{
 
 pub(crate) fn xet_hash_hex(hash: &MerkleHash) -> String {
     let bytes: [u8; 32] = hash.as_bytes().try_into().unwrap_or([0; 32]);
-    ShardlineHash::from_bytes(bytes).api_hex_string()
+    xet_hash_hex_string(ShardlineHash::from_bytes(bytes))
 }
 
 pub(crate) fn single_chunk_xorb(bytes: &[u8]) -> (Bytes, String) {

--- a/crates/server/src/upload_ingest.rs
+++ b/crates/server/src/upload_ingest.rs
@@ -647,6 +647,7 @@ mod tests {
     use std::num::NonZeroUsize;
 
     use axum::body::Bytes;
+    use shardline_index::xet_hash_hex_string;
 
     use super::FileUploadIngestor;
     use crate::{
@@ -841,8 +842,8 @@ mod tests {
         assert_eq!(response.inserted_chunks, 0);
         assert_eq!(response.reused_chunks, 2);
         assert_eq!(response.stored_bytes, 0);
-        let first_chunk = chunk_hash(b"abcd").api_hex_string();
-        let second_chunk = chunk_hash(b"efgh").api_hex_string();
+        let first_chunk = xet_hash_hex_string(chunk_hash(b"abcd"));
+        let second_chunk = xet_hash_hex_string(chunk_hash(b"efgh"));
         let first_key = chunk_object_key(&first_chunk);
         let second_key = chunk_object_key(&second_chunk);
         assert!(first_key.is_ok());

--- a/crates/server/src/xet_adapter/frontend.rs
+++ b/crates/server/src/xet_adapter/frontend.rs
@@ -1,4 +1,4 @@
-use shardline_protocol::ShardlineHash;
+use shardline_index::parse_xet_hash_hex;
 
 use crate::ServerError;
 
@@ -9,7 +9,7 @@ pub(crate) const XET_WRITE_TOKEN_ROUTE: &str =
     "/api/{provider}/{owner}/{repo}/xet-write-token/{rev}";
 
 pub(crate) fn validate_hash_path(value: &str) -> Result<(), ServerError> {
-    ShardlineHash::parse_api_hex(value)?;
+    parse_xet_hash_hex(value)?;
     Ok(())
 }
 

--- a/crates/server/src/xet_adapter/mod.rs
+++ b/crates/server/src/xet_adapter/mod.rs
@@ -2,6 +2,7 @@ mod frontend;
 mod ingest;
 mod reconstruction;
 mod shard_store;
+mod xorb;
 mod xorb_store;
 mod xorb_visit;
 
@@ -18,6 +19,10 @@ pub(crate) use shard_store::shard_object_key;
 pub(crate) use shard_store::{
     dedupe_shard_mapping, parse_uploaded_shard, resolve_dedupe_shard_object,
     retained_shard_chunk_hashes, shard_hash_from_object_key_if_present,
+};
+pub use xorb::{
+    DecodedXorbChunk, ValidatedXorb, ValidatedXorbChunk, XorbParseError, XorbVisitError,
+    decode_serialized_xorb_chunks, try_for_each_serialized_xorb_chunk, validate_serialized_xorb,
 };
 pub(crate) use xorb_store::{
     normalize_serialized_xorb, store_uploaded_xorb, visit_stored_xorb_chunk_hashes,

--- a/crates/server/src/xet_adapter/shard_store.rs
+++ b/crates/server/src/xet_adapter/shard_store.rs
@@ -5,10 +5,10 @@ use std::{
 };
 
 use axum::body::Bytes;
-use shardline_index::{AsyncIndexStore, DedupeShardMapping, FileChunkRecord, FileRecord};
-use shardline_protocol::{
-    RepositoryScope, ShardlineHash, ValidatedXorbChunk, validate_serialized_xorb,
+use shardline_index::{
+    AsyncIndexStore, DedupeShardMapping, FileChunkRecord, FileRecord, parse_xet_hash_hex,
 };
+use shardline_protocol::RepositoryScope;
 use shardline_storage::{ObjectBody, ObjectIntegrity, ObjectKey, ObjectKeyError, PutOutcome};
 use xet_core_structures::{
     merklehash::{MerkleHash, compute_data_hash},
@@ -33,7 +33,7 @@ use crate::{
     validation::validate_content_hash,
 };
 
-use super::xorb_object_key;
+use super::{ValidatedXorbChunk, validate_serialized_xorb, xorb_object_key};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ParsedShardUpload {
@@ -82,7 +82,7 @@ where
     IndexAdapter: AsyncIndexStore,
     IndexAdapter::Error: Into<ServerError>,
 {
-    let chunk_hash = ShardlineHash::parse_api_hex(chunk_hash_hex)?;
+    let chunk_hash = parse_xet_hash_hex(chunk_hash_hex)?;
     let Some(mapping) = index_store
         .dedupe_shard_mapping(&chunk_hash)
         .await
@@ -488,7 +488,7 @@ fn load_xorb_range_info(
         return Err(ServerError::MissingReferencedXorb);
     };
     let bytes = read_full_object(object_store, &key, metadata.length())?;
-    let expected_hash = ShardlineHash::parse_api_hex(hash_hex)?;
+    let expected_hash = parse_xet_hash_hex(hash_hex)?;
     let mut reader = Cursor::new(bytes);
     let validated = validate_serialized_xorb(&mut reader, expected_hash)?;
     let packed_chunk_ends = validated
@@ -503,7 +503,7 @@ pub(crate) fn dedupe_shard_mapping(
     chunk_hash_hex: &str,
     shard_key: &ObjectKey,
 ) -> Result<DedupeShardMapping, ServerError> {
-    let chunk_hash = ShardlineHash::parse_api_hex(chunk_hash_hex)?;
+    let chunk_hash = parse_xet_hash_hex(chunk_hash_hex)?;
     Ok(DedupeShardMapping::new(chunk_hash, shard_key.clone()))
 }
 

--- a/crates/server/src/xet_adapter/xorb.rs
+++ b/crates/server/src/xet_adapter/xorb.rs
@@ -4,14 +4,13 @@ use std::{
     num::TryFromIntError,
 };
 
+use shardline_protocol::ShardlineHash;
 use thiserror::Error;
 use xet_core_structures::{
     error::CoreError,
     merklehash::{MerkleHash, compute_data_hash},
     xorb_object::{XorbObject, deserialize_chunk},
 };
-
-use crate::ShardlineHash;
 
 /// Validated metadata for one chunk inside a serialized xorb.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -449,7 +448,7 @@ mod tests {
         decode_serialized_xorb_chunks, merkle_hash_to_shardline_hash,
         try_for_each_serialized_xorb_chunk, validate_serialized_xorb,
     };
-    use crate::ShardlineHash;
+    use shardline_protocol::ShardlineHash;
 
     #[test]
     fn validate_serialized_xorb_reports_chunk_metadata_and_decodes_bytes() {

--- a/crates/server/src/xet_adapter/xorb_store.rs
+++ b/crates/server/src/xet_adapter/xorb_store.rs
@@ -1,8 +1,7 @@
 use std::{borrow::Cow, io::Cursor};
 
-use shardline_protocol::{
-    ShardlineHash, ValidatedXorb, try_for_each_serialized_xorb_chunk, validate_serialized_xorb,
-};
+use shardline_index::{parse_xet_hash_hex, xet_hash_hex_string};
+use shardline_protocol::ShardlineHash;
 use shardline_storage::{ObjectBody, ObjectIntegrity, ObjectKey, ObjectKeyError, PutOutcome};
 use xet_core_structures::xorb_object::reconstruct_xorb_with_footer;
 
@@ -14,7 +13,10 @@ use crate::{
     validation::validate_content_hash,
 };
 
-use super::map_xorb_visit_error;
+use super::{
+    ValidatedXorb, map_xorb_visit_error, try_for_each_serialized_xorb_chunk,
+    validate_serialized_xorb,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct StoredXorbUpload {
@@ -78,12 +80,12 @@ where
     let Some(xorb_hash_hex) = xorb_hash_from_object_key_if_present(object_key)? else {
         return Ok(());
     };
-    let expected_hash = ShardlineHash::parse_api_hex(xorb_hash_hex)?;
+    let expected_hash = parse_xet_hash_hex(xorb_hash_hex)?;
     let xorb_bytes = read_full_object(object_store, object_key, metadata.length())?;
     let mut cursor = Cursor::new(xorb_bytes);
     let validated = validate_serialized_xorb(&mut cursor, expected_hash)?;
     try_for_each_serialized_xorb_chunk(&mut cursor, &validated, |decoded_chunk| {
-        visitor(decoded_chunk.descriptor().hash().api_hex_string())
+        visitor(xet_hash_hex_string(decoded_chunk.descriptor().hash()))
     })
     .map_err(map_xorb_visit_error)
 }
@@ -93,7 +95,7 @@ pub(crate) fn store_uploaded_xorb(
     expected_hash: &str,
     uploaded_bytes: &[u8],
 ) -> Result<StoredXorbUpload, ServerError> {
-    let expected_hash_value = ShardlineHash::parse_api_hex(expected_hash)?;
+    let expected_hash_value = parse_xet_hash_hex(expected_hash)?;
     let (canonical_bytes, validated) =
         canonicalize_uploaded_xorb(expected_hash_value, uploaded_bytes)?;
     let canonical_length = u64::try_from(canonical_bytes.len())?;
@@ -102,7 +104,7 @@ pub(crate) fn store_uploaded_xorb(
     let mut stored_bytes = 0_u64;
 
     try_for_each_serialized_xorb_chunk(&mut cursor, &validated, |decoded_chunk| {
-        let chunk_hash_hex = decoded_chunk.descriptor().hash().api_hex_string();
+        let chunk_hash_hex = xet_hash_hex_string(decoded_chunk.descriptor().hash());
         let chunk_length = u64::try_from(decoded_chunk.data().len())?;
         unpacked_length = unpacked_length
             .checked_add(chunk_length)
@@ -171,7 +173,7 @@ pub(crate) fn normalize_serialized_xorb(
     let mut normalized = Vec::with_capacity(bytes.len());
     let (_xorb, computed_hash) = reconstruct_xorb_with_footer(&mut normalized, bytes)
         .map_err(|_error| ServerError::InvalidSerializedXorb)?;
-    let computed_hash = ShardlineHash::parse_api_hex(&computed_hash.hex())?;
+    let computed_hash = parse_xet_hash_hex(&computed_hash.hex())?;
     if computed_hash != expected_hash {
         return Err(ServerError::XorbHashMismatch);
     }
@@ -192,14 +194,15 @@ const fn map_object_key_error(error: ObjectKeyError) -> ServerError {
 mod tests {
     use std::{borrow::Cow, io::Cursor};
 
-    use shardline_protocol::{ShardlineHash, validate_serialized_xorb};
+    use shardline_index::parse_xet_hash_hex;
+    use shardline_protocol::ShardlineHash;
     use xet_core_structures::xorb_object::{
         CompressionScheme, SerializedXorbObject,
         xorb_format_test_utils::{ChunkSize, build_raw_xorb},
     };
 
     use super::{
-        canonicalize_uploaded_xorb, normalize_serialized_xorb,
+        canonicalize_uploaded_xorb, normalize_serialized_xorb, validate_serialized_xorb,
         xorb_hash_from_object_key_if_present, xorb_object_key,
     };
     use crate::ServerError;
@@ -214,7 +217,7 @@ mod tests {
             return;
         };
         assert!(serialized.footer_start.is_none());
-        let expected_hash = ShardlineHash::parse_api_hex(&serialized.hash.hex());
+        let expected_hash = parse_xet_hash_hex(&serialized.hash.hex());
         assert!(expected_hash.is_ok());
         let Ok(expected_hash) = expected_hash else {
             return;
@@ -255,7 +258,7 @@ mod tests {
         let Ok(serialized) = serialized else {
             return;
         };
-        let expected_hash = ShardlineHash::parse_api_hex(&serialized.hash.hex());
+        let expected_hash = parse_xet_hash_hex(&serialized.hash.hex());
         assert!(expected_hash.is_ok());
         let Ok(expected_hash) = expected_hash else {
             return;
@@ -284,7 +287,7 @@ mod tests {
         let Ok(serialized) = serialized else {
             return;
         };
-        let expected_hash = ShardlineHash::parse_api_hex(&serialized.hash.hex());
+        let expected_hash = parse_xet_hash_hex(&serialized.hash.hex());
         assert!(expected_hash.is_ok());
         let Ok(expected_hash) = expected_hash else {
             return;

--- a/crates/server/src/xet_adapter/xorb_visit.rs
+++ b/crates/server/src/xet_adapter/xorb_visit.rs
@@ -1,6 +1,6 @@
-use shardline_protocol::XorbVisitError;
-
 use crate::ServerError;
+
+use super::XorbVisitError;
 
 pub(crate) fn map_xorb_visit_error(error: XorbVisitError<ServerError>) -> ServerError {
     match error {

--- a/crates/server/tests/git_xet_push_e2e.rs
+++ b/crates/server/tests/git_xet_push_e2e.rs
@@ -30,14 +30,13 @@ use serde_json::{Value, from_slice, json, to_vec};
 use sha2::{Digest, Sha256};
 use shardline_index::{
     FileChunkRecord, FileRecord, LocalRecordStore, RecordStore, RepositoryRecordScope,
+    parse_xet_hash_hex,
 };
-use shardline_protocol::{
-    RepositoryProvider, ShardlineHash, TokenScope, try_for_each_serialized_xorb_chunk,
-    validate_serialized_xorb,
-};
+use shardline_protocol::{RepositoryProvider, TokenScope};
 use shardline_server::{
     FileReconstructionResponse, ProviderTokenIssueRequest, ProviderTokenIssueResponse,
-    ServerConfig, ServerStatsResponse, serve_with_listener,
+    ServerConfig, ServerStatsResponse, serve_with_listener, try_for_each_serialized_xorb_chunk,
+    validate_serialized_xorb,
 };
 use support::ServerE2eInvariantError;
 use tokio::{net::TcpListener, spawn, task::spawn_blocking, time::sleep};
@@ -1245,7 +1244,7 @@ async fn append_record_term_through_cas(
     output: &mut Vec<u8>,
 ) -> Result<(), TestError> {
     let xorb_bytes = read_full_xorb_through_cas(state, token, &term.hash).await?;
-    let expected_hash = ShardlineHash::parse_api_hex(&term.hash)?;
+    let expected_hash = parse_xet_hash_hex(&term.hash)?;
     let mut reader = Cursor::new(xorb_bytes);
     let validated = validate_serialized_xorb(&mut reader, expected_hash)?;
     let range_start = usize::try_from(term.range_start)?;

--- a/crates/server/tests/live_provider_bridge_e2e.rs
+++ b/crates/server/tests/live_provider_bridge_e2e.rs
@@ -29,13 +29,12 @@ use reqwest::{Client, header::RANGE};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, from_slice, json, to_vec};
 use sha2::{Digest, Sha256};
-use shardline_index::{FileChunkRecord, FileRecord};
-use shardline_protocol::{
-    ShardlineHash, TokenScope, try_for_each_serialized_xorb_chunk, validate_serialized_xorb,
-};
+use shardline_index::{FileChunkRecord, FileRecord, parse_xet_hash_hex};
+use shardline_protocol::TokenScope;
 use shardline_server::{
     FileReconstructionResponse, ProviderTokenIssueRequest, ProviderTokenIssueResponse,
-    ServerConfig, ServerStatsResponse, serve_with_listener,
+    ServerConfig, ServerStatsResponse, serve_with_listener, try_for_each_serialized_xorb_chunk,
+    validate_serialized_xorb,
 };
 use support::ServerE2eInvariantError;
 use tokio::{net::TcpListener, spawn, time::sleep};
@@ -839,7 +838,7 @@ async fn append_record_term_through_shardline(
     output: &mut Vec<u8>,
 ) -> Result<(), TestError> {
     let xorb_bytes = read_full_xorb_through_shardline(state, token, &term.hash).await?;
-    let expected_hash = ShardlineHash::parse_api_hex(&term.hash)?;
+    let expected_hash = parse_xet_hash_hex(&term.hash)?;
     let mut reader = Cursor::new(xorb_bytes);
     let validated = validate_serialized_xorb(&mut reader, expected_hash)?;
     let range_start = usize::try_from(term.range_start)?;

--- a/crates/server/tests/native_protocol_frontends_e2e.rs
+++ b/crates/server/tests/native_protocol_frontends_e2e.rs
@@ -1,0 +1,2018 @@
+#![allow(
+    clippy::indexing_slicing,
+    clippy::nonminimal_bool,
+    clippy::shadow_unrelated,
+    clippy::too_many_arguments
+)]
+
+mod support;
+
+use std::{
+    error::Error,
+    fs::{create_dir_all, read, write as write_file},
+    io::{Error as IoError, Write},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    num::NonZeroUsize,
+    path::Path,
+    process::{Command, Output, Stdio},
+    time::Duration,
+};
+
+use reqwest::Client;
+use serde_json::{Value, json, to_vec};
+use sha2::{Digest, Sha256};
+use shardline_protocol::{
+    RepositoryProvider, RepositoryScope, TokenClaims, TokenScope, TokenSigner,
+};
+use shardline_server::{ServerConfig, ServerError, ServerFrontend, serve_with_listener};
+use support::ServerE2eInvariantError;
+use tokio::{net::TcpListener, spawn, task::JoinHandle, time::sleep};
+
+type TestError = Box<dyn Error + Send + Sync>;
+
+struct FrontendRuntime {
+    _storage: tempfile::TempDir,
+    base_url: String,
+    host_port: String,
+    server: JoinHandle<Result<(), ServerError>>,
+}
+
+impl FrontendRuntime {
+    fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    fn host_port(&self) -> &str {
+        &self.host_port
+    }
+}
+
+impl Drop for FrontendRuntime {
+    fn drop(&mut self) {
+        self.server.abort();
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn native_git_lfs_push_and_pull_flow_works_against_shardline_lfs_frontend() {
+    if !(command_available("git") && command_available("git-lfs")) {
+        return;
+    }
+
+    let result = exercise_native_git_lfs_flow().await;
+    let error = result.as_ref().err().map(ToString::to_string);
+    assert!(result.is_ok(), "native git-lfs e2e failed: {error:?}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn native_git_lfs_pull_and_fetch_all_work_against_shardline_lfs_frontend() {
+    if !(command_available("git") && command_available("git-lfs")) {
+        return;
+    }
+
+    let result = exercise_native_git_lfs_pull_and_fetch_all_flow().await;
+    let error = result.as_ref().err().map(ToString::to_string);
+    assert!(
+        result.is_ok(),
+        "native git-lfs pull/fetch-all e2e failed: {error:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn native_bazel_remote_cache_flow_works_against_shardline_http_cache_frontend() {
+    if bazel_program().is_none() {
+        return;
+    }
+
+    let result = exercise_native_bazel_http_cache_flow().await;
+    let error = result.as_ref().err().map(ToString::to_string);
+    assert!(
+        result.is_ok(),
+        "native bazel remote cache e2e failed: {error:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn native_bazel_remote_cache_toplevel_download_flow_works_against_shardline_http_cache_frontend()
+ {
+    if bazel_program().is_none() {
+        return;
+    }
+
+    let result = exercise_native_bazel_http_cache_toplevel_flow().await;
+    let error = result.as_ref().err().map(ToString::to_string);
+    assert!(
+        result.is_ok(),
+        "native bazel toplevel remote cache e2e failed: {error:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn native_skopeo_push_pull_and_tag_listing_work_against_shardline_oci_frontend() {
+    if !(command_available("skopeo") && command_available("tar")) {
+        return;
+    }
+
+    let result = exercise_native_oci_registry_flow().await;
+    let error = result.as_ref().err().map(ToString::to_string);
+    assert!(result.is_ok(), "native oci registry e2e failed: {error:?}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn native_skopeo_digest_reference_and_multi_tag_flow_work_against_shardline_oci_frontend() {
+    if !(command_available("skopeo") && command_available("tar")) {
+        return;
+    }
+
+    let result = exercise_native_oci_digest_and_multi_tag_flow().await;
+    let error = result.as_ref().err().map(ToString::to_string);
+    assert!(
+        result.is_ok(),
+        "native oci digest/multi-tag e2e failed: {error:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn native_skopeo_registry_to_registry_copy_works_against_shardline_oci_frontend() {
+    if !(command_available("skopeo") && command_available("tar")) {
+        return;
+    }
+
+    let result = exercise_native_oci_registry_to_registry_copy_flow().await;
+    let error = result.as_ref().err().map(ToString::to_string);
+    assert!(
+        result.is_ok(),
+        "native oci registry-to-registry copy e2e failed: {error:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn native_skopeo_multiarch_index_flow_works_against_shardline_oci_frontend() {
+    if !(command_available("skopeo") && command_available("tar")) {
+        return;
+    }
+
+    let result = exercise_native_oci_multiarch_index_flow().await;
+    let error = result.as_ref().err().map(ToString::to_string);
+    assert!(
+        result.is_ok(),
+        "native oci multiarch index e2e failed: {error:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn native_skopeo_docker_schema2_flow_works_against_shardline_oci_frontend() {
+    if !(command_available("skopeo") && command_available("tar")) {
+        return;
+    }
+
+    let result = exercise_native_oci_docker_schema2_flow().await;
+    let error = result.as_ref().err().map(ToString::to_string);
+    assert!(
+        result.is_ok(),
+        "native oci docker schema2 e2e failed: {error:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn native_skopeo_creds_token_service_flow_works_against_shardline_oci_frontend() {
+    if !(command_available("skopeo") && command_available("tar")) {
+        return;
+    }
+
+    let result = exercise_native_oci_token_service_flow().await;
+    let error = result.as_ref().err().map(ToString::to_string);
+    assert!(
+        result.is_ok(),
+        "native oci token-service e2e failed: {error:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn native_helm_oci_chart_push_and_pull_work_against_shardline_oci_frontend() {
+    if !command_available("helm") {
+        return;
+    }
+
+    let result = exercise_native_helm_oci_chart_flow().await;
+    let error = result.as_ref().err().map(ToString::to_string);
+    assert!(result.is_ok(), "native helm oci e2e failed: {error:?}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn native_podman_pull_and_push_work_against_shardline_oci_frontend() {
+    if !(command_available("podman") && command_available("skopeo") && command_available("tar")) {
+        return;
+    }
+
+    let result = exercise_native_podman_oci_flow().await;
+    let error = result.as_ref().err().map(ToString::to_string);
+    assert!(result.is_ok(), "native podman oci e2e failed: {error:?}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn native_docker_pull_and_push_work_against_shardline_oci_frontend() {
+    if !(command_available("docker") && command_available("skopeo") && command_available("tar")) {
+        return;
+    }
+
+    let result = exercise_native_docker_oci_flow().await;
+    let error = result.as_ref().err().map(ToString::to_string);
+    assert!(result.is_ok(), "native docker oci e2e failed: {error:?}");
+}
+
+async fn exercise_native_git_lfs_flow() -> Result<(), TestError> {
+    let runtime = start_runtime(&[ServerFrontend::Lfs]).await?;
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+
+    let remote_root = tempfile::tempdir()?;
+    let worktree = tempfile::tempdir()?;
+    let clone = tempfile::tempdir()?;
+    let git_home = tempfile::tempdir()?;
+    let remote_repo_path = remote_root.path().join("origin.git");
+    let remote_repo_path_string = remote_repo_path.to_string_lossy().to_string();
+    let original_bytes = seeded_bytes(256 * 1024, 41);
+    let original_path = worktree.path().join("asset.bin");
+
+    run_command_checked(
+        Command::new("git")
+            .arg("init")
+            .arg("--bare")
+            .arg(&remote_repo_path),
+        "git init --bare",
+    )?;
+
+    run_git_with_home(worktree.path(), git_home.path(), &["init"])?;
+    run_git_with_home(
+        worktree.path(),
+        git_home.path(),
+        &["config", "user.name", "Shardline Test"],
+    )?;
+    run_git_with_home(
+        worktree.path(),
+        git_home.path(),
+        &["config", "user.email", "shardline@example.invalid"],
+    )?;
+    run_git_with_home(
+        worktree.path(),
+        git_home.path(),
+        &["remote", "add", "origin", &remote_repo_path_string],
+    )?;
+    run_git_with_home_and_env(
+        worktree.path(),
+        git_home.path(),
+        &[],
+        "git-lfs",
+        &["install", "--local"],
+    )?;
+    run_git_with_home_and_env(
+        worktree.path(),
+        git_home.path(),
+        &[],
+        "git-lfs",
+        &["track", "*.bin"],
+    )?;
+    run_git_with_home(
+        worktree.path(),
+        git_home.path(),
+        &[
+            "config",
+            "lfs.url",
+            &format!("{}/v1/lfs", runtime.base_url()),
+        ],
+    )?;
+    run_git_with_home(
+        worktree.path(),
+        git_home.path(),
+        &["config", "lfs.locksverify", "false"],
+    )?;
+    run_git_with_home(
+        worktree.path(),
+        git_home.path(),
+        &[
+            "config",
+            "http.extraHeader",
+            &format!("Authorization: Bearer {write_token}"),
+        ],
+    )?;
+
+    write_file(&original_path, &original_bytes)?;
+    run_git_with_home(
+        worktree.path(),
+        git_home.path(),
+        &["add", ".gitattributes", "asset.bin"],
+    )?;
+    run_git_with_home(
+        worktree.path(),
+        git_home.path(),
+        &["commit", "-m", "add lfs asset"],
+    )?;
+    run_git_with_home(worktree.path(), git_home.path(), &["branch", "-M", "main"])?;
+    run_git_with_home(
+        worktree.path(),
+        git_home.path(),
+        &["push", "-u", "origin", "main"],
+    )?;
+    run_git_with_home_and_env(
+        worktree.path(),
+        git_home.path(),
+        &[],
+        "git-lfs",
+        &["push", "origin", "main"],
+    )?;
+
+    let mut clone_command = Command::new("git");
+    prepare_command(&mut clone_command, git_home.path())
+        .env("GIT_LFS_SKIP_SMUDGE", "1")
+        .arg("clone")
+        .arg("--branch")
+        .arg("main")
+        .arg(&remote_repo_path)
+        .arg(clone.path());
+    run_command_checked(&mut clone_command, "git clone")?;
+
+    run_git_with_home(
+        clone.path(),
+        git_home.path(),
+        &[
+            "config",
+            "lfs.url",
+            &format!("{}/v1/lfs", runtime.base_url()),
+        ],
+    )?;
+    run_git_with_home(
+        clone.path(),
+        git_home.path(),
+        &["config", "lfs.locksverify", "false"],
+    )?;
+    run_git_with_home(
+        clone.path(),
+        git_home.path(),
+        &[
+            "config",
+            "http.extraHeader",
+            &format!("Authorization: Bearer {read_token}"),
+        ],
+    )?;
+    run_git_with_home_and_env(
+        clone.path(),
+        git_home.path(),
+        &[],
+        "git-lfs",
+        &["install", "--local"],
+    )?;
+    run_git_with_home_and_env(
+        clone.path(),
+        git_home.path(),
+        &[("GIT_ATTR_SOURCE", "HEAD")],
+        "git-lfs",
+        &["fetch", "origin", "main"],
+    )?;
+    run_git_with_home_and_env(
+        clone.path(),
+        git_home.path(),
+        &[("GIT_ATTR_SOURCE", "HEAD")],
+        "git-lfs",
+        &["checkout", "asset.bin"],
+    )?;
+
+    let cloned_bytes = read(clone.path().join("asset.bin"))?;
+    if cloned_bytes != original_bytes {
+        return Err(
+            ServerE2eInvariantError::new("git-lfs pulled bytes did not match source").into(),
+        );
+    }
+
+    Ok(())
+}
+
+async fn exercise_native_git_lfs_pull_and_fetch_all_flow() -> Result<(), TestError> {
+    let runtime = start_runtime(&[ServerFrontend::Lfs]).await?;
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+
+    let remote_root = tempfile::tempdir()?;
+    let worktree = tempfile::tempdir()?;
+    let clone = tempfile::tempdir()?;
+    let git_home = tempfile::tempdir()?;
+    let remote_repo_path = remote_root.path().join("origin.git");
+    let remote_repo_path_string = remote_repo_path.to_string_lossy().to_string();
+    let original_bytes = seeded_bytes(128 * 1024, 77);
+
+    run_command_checked(
+        Command::new("git")
+            .arg("init")
+            .arg("--bare")
+            .arg(&remote_repo_path),
+        "git init --bare",
+    )?;
+
+    run_git_with_home(worktree.path(), git_home.path(), &["init"])?;
+    run_git_with_home(
+        worktree.path(),
+        git_home.path(),
+        &["config", "user.name", "Shardline Test"],
+    )?;
+    run_git_with_home(
+        worktree.path(),
+        git_home.path(),
+        &["config", "user.email", "shardline@example.invalid"],
+    )?;
+    run_git_with_home(
+        worktree.path(),
+        git_home.path(),
+        &["remote", "add", "origin", &remote_repo_path_string],
+    )?;
+    run_git_with_home_and_env(
+        worktree.path(),
+        git_home.path(),
+        &[],
+        "git-lfs",
+        &["install", "--local"],
+    )?;
+    run_git_with_home_and_env(
+        worktree.path(),
+        git_home.path(),
+        &[],
+        "git-lfs",
+        &["track", "*.bin"],
+    )?;
+    configure_lfs_client_repo(
+        worktree.path(),
+        git_home.path(),
+        runtime.base_url(),
+        &write_token,
+    )?;
+
+    write_file(worktree.path().join("asset.bin"), &original_bytes)?;
+    run_git_with_home(
+        worktree.path(),
+        git_home.path(),
+        &["add", ".gitattributes", "asset.bin"],
+    )?;
+    run_git_with_home(
+        worktree.path(),
+        git_home.path(),
+        &["commit", "-m", "add lfs asset"],
+    )?;
+    run_git_with_home(worktree.path(), git_home.path(), &["branch", "-M", "main"])?;
+    run_git_with_home(
+        worktree.path(),
+        git_home.path(),
+        &["push", "-u", "origin", "main"],
+    )?;
+    run_git_with_home_and_env(
+        worktree.path(),
+        git_home.path(),
+        &[],
+        "git-lfs",
+        &["push", "--all", "origin"],
+    )?;
+
+    let mut clone_command = Command::new("git");
+    prepare_command(&mut clone_command, git_home.path())
+        .env("GIT_LFS_SKIP_SMUDGE", "1")
+        .arg("-c")
+        .arg(format!("lfs.url={}/v1/lfs", runtime.base_url()))
+        .arg("-c")
+        .arg("lfs.locksverify=false")
+        .arg("-c")
+        .arg(format!(
+            "http.extraHeader=Authorization: Bearer {read_token}"
+        ))
+        .arg("clone")
+        .arg("--branch")
+        .arg("main")
+        .arg(&remote_repo_path)
+        .arg(clone.path());
+    run_command_checked(&mut clone_command, "git clone for lfs pull/fetch-all")?;
+
+    configure_lfs_client_repo(
+        clone.path(),
+        git_home.path(),
+        runtime.base_url(),
+        &read_token,
+    )?;
+    run_git_with_home_and_env(
+        clone.path(),
+        git_home.path(),
+        &[],
+        "git-lfs",
+        &["install", "--local"],
+    )?;
+    run_git_with_home_and_env(
+        clone.path(),
+        git_home.path(),
+        &[("GIT_ATTR_SOURCE", "HEAD")],
+        "git-lfs",
+        &["pull", "origin"],
+    )?;
+    let cloned_bytes = read(clone.path().join("asset.bin"))?;
+    if cloned_bytes != original_bytes {
+        return Err(ServerE2eInvariantError::new("git-lfs pull bytes did not match source").into());
+    }
+    run_git_with_home_and_env(
+        clone.path(),
+        git_home.path(),
+        &[("GIT_ATTR_SOURCE", "HEAD")],
+        "git-lfs",
+        &["fetch", "--all", "origin"],
+    )?;
+    let ls_files =
+        run_git_with_home_and_env(clone.path(), git_home.path(), &[], "git-lfs", &["ls-files"])?;
+    if !String::from_utf8_lossy(&ls_files.stdout).contains("asset.bin") {
+        return Err(ServerE2eInvariantError::new("git-lfs ls-files did not list asset.bin").into());
+    }
+
+    Ok(())
+}
+
+async fn exercise_native_bazel_http_cache_flow() -> Result<(), TestError> {
+    let runtime = start_runtime(&[ServerFrontend::BazelHttp]).await?;
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+    let workspace = tempfile::tempdir()?;
+    let bazel_home = tempfile::tempdir()?;
+    let output_base_one = tempfile::tempdir()?;
+    let output_base_two = tempfile::tempdir()?;
+    let bazel = bazel_program().ok_or_else(|| {
+        ServerE2eInvariantError::new("bazel or bazelisk is required for native bazel e2e")
+    })?;
+
+    write_file(
+        workspace.path().join("MODULE.bazel"),
+        "module(name = \"cachetest\")\n",
+    )?;
+    write_file(
+        workspace.path().join("BUILD.bazel"),
+        concat!(
+            "genrule(\n",
+            "    name = \"copy\",\n",
+            "    srcs = [\"input.txt\"],\n",
+            "    outs = [\"out.txt\"],\n",
+            "    cmd = \"cat $(location input.txt) > $@\",\n",
+            ")\n",
+        ),
+    )?;
+    write_file(workspace.path().join("input.txt"), "hello bazel cache\n")?;
+
+    let first_build = run_bazel_build(
+        bazel,
+        workspace.path(),
+        bazel_home.path(),
+        output_base_one.path(),
+        runtime.base_url(),
+        &write_token,
+        true,
+    )?;
+    if !first_build.status.success() {
+        return Err(command_error("initial bazel build", &first_build).into());
+    }
+
+    let built = read(workspace.path().join("bazel-bin").join("out.txt"))?;
+    if built != b"hello bazel cache\n" {
+        return Err(
+            ServerE2eInvariantError::new("initial bazel build produced wrong bytes").into(),
+        );
+    }
+
+    let second_build = run_bazel_build(
+        bazel,
+        workspace.path(),
+        bazel_home.path(),
+        output_base_two.path(),
+        runtime.base_url(),
+        &read_token,
+        false,
+    )?;
+    if !second_build.status.success() {
+        return Err(command_error("second bazel build", &second_build).into());
+    }
+    let combined_output = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&second_build.stdout),
+        String::from_utf8_lossy(&second_build.stderr)
+    );
+    if !combined_output.contains("remote cache hit") {
+        return Err(ServerE2eInvariantError::new(format!(
+            "expected bazel remote cache hit in output\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&second_build.stdout),
+            String::from_utf8_lossy(&second_build.stderr)
+        ))
+        .into());
+    }
+
+    let rebuilt = read(workspace.path().join("bazel-bin").join("out.txt"))?;
+    if rebuilt != b"hello bazel cache\n" {
+        return Err(ServerE2eInvariantError::new("cached bazel build produced wrong bytes").into());
+    }
+
+    Ok(())
+}
+
+async fn exercise_native_bazel_http_cache_toplevel_flow() -> Result<(), TestError> {
+    let runtime = start_runtime(&[ServerFrontend::BazelHttp]).await?;
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+    let workspace = tempfile::tempdir()?;
+    let bazel_home = tempfile::tempdir()?;
+    let output_base_one = tempfile::tempdir()?;
+    let output_base_two = tempfile::tempdir()?;
+    let bazel = bazel_program().ok_or_else(|| {
+        ServerE2eInvariantError::new("bazel or bazelisk is required for native bazel e2e")
+    })?;
+
+    write_file(
+        workspace.path().join("MODULE.bazel"),
+        "module(name = \"cachetest\")\n",
+    )?;
+    write_file(
+        workspace.path().join("BUILD.bazel"),
+        concat!(
+            "genrule(\n",
+            "    name = \"copy\",\n",
+            "    srcs = [\"input.txt\"],\n",
+            "    outs = [\"out.txt\"],\n",
+            "    cmd = \"cat $(location input.txt) > $@\",\n",
+            ")\n",
+        ),
+    )?;
+    write_file(workspace.path().join("input.txt"), "hello bazel toplevel\n")?;
+
+    let first_build = run_bazel_build_with_download_mode(
+        bazel,
+        workspace.path(),
+        bazel_home.path(),
+        output_base_one.path(),
+        runtime.base_url(),
+        &write_token,
+        true,
+        "toplevel",
+    )?;
+    if !first_build.status.success() {
+        return Err(command_error("initial bazel toplevel build", &first_build).into());
+    }
+
+    let second_build = run_bazel_build_with_download_mode(
+        bazel,
+        workspace.path(),
+        bazel_home.path(),
+        output_base_two.path(),
+        runtime.base_url(),
+        &read_token,
+        false,
+        "toplevel",
+    )?;
+    if !second_build.status.success() {
+        return Err(command_error("second bazel toplevel build", &second_build).into());
+    }
+
+    let combined_output = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&second_build.stdout),
+        String::from_utf8_lossy(&second_build.stderr)
+    );
+    if !combined_output.contains("remote cache hit") {
+        return Err(ServerE2eInvariantError::new(format!(
+            "expected bazel remote cache hit in toplevel mode\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&second_build.stdout),
+            String::from_utf8_lossy(&second_build.stderr)
+        ))
+        .into());
+    }
+    let rebuilt = read(workspace.path().join("bazel-bin").join("out.txt"))?;
+    if rebuilt != b"hello bazel toplevel\n" {
+        return Err(
+            ServerE2eInvariantError::new("toplevel bazel build produced wrong bytes").into(),
+        );
+    }
+
+    Ok(())
+}
+
+async fn exercise_native_oci_registry_flow() -> Result<(), TestError> {
+    let runtime = start_runtime(&[ServerFrontend::Oci]).await?;
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+    let source_layout = tempfile::tempdir()?;
+    let pulled_layout = tempfile::tempdir()?;
+    let image_ref = format!("docker://{}/team/assets:v1", runtime.host_port());
+    let repository_ref = format!("docker://{}/team/assets", runtime.host_port());
+    let _layout =
+        create_oci_image_layout(source_layout.path(), "v1", "hello from shardline oci\n")?;
+
+    run_command_checked(
+        Command::new("skopeo")
+            .arg("copy")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--dest-tls-verify=false")
+            .arg("--dest-registry-token")
+            .arg(&write_token)
+            .arg(format!("oci:{}:v1", source_layout.path().display()))
+            .arg(&image_ref),
+        "skopeo copy oci -> registry",
+    )?;
+
+    let tags = run_command_checked(
+        Command::new("skopeo")
+            .arg("list-tags")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--tls-verify=false")
+            .arg("--registry-token")
+            .arg(&read_token)
+            .arg(&repository_ref),
+        "skopeo list-tags",
+    )?;
+    let tags = serde_json::from_slice::<Value>(&tags.stdout)?;
+    if !tags["Tags"]
+        .as_array()
+        .is_some_and(|tags| tags.iter().any(|tag| tag == "v1"))
+    {
+        return Err(ServerE2eInvariantError::new("oci tag listing did not include v1").into());
+    }
+
+    let manifest = run_command_checked(
+        Command::new("skopeo")
+            .arg("inspect")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--tls-verify=false")
+            .arg("--registry-token")
+            .arg(&read_token)
+            .arg("--raw")
+            .arg(&image_ref),
+        "skopeo inspect --raw",
+    )?;
+    let manifest = serde_json::from_slice::<Value>(&manifest.stdout)?;
+    if manifest["config"]["digest"].as_str().is_none() {
+        return Err(
+            ServerE2eInvariantError::new("oci manifest was missing a config digest").into(),
+        );
+    }
+    if !manifest["layers"]
+        .as_array()
+        .is_some_and(|layers| !layers.is_empty())
+    {
+        return Err(ServerE2eInvariantError::new("oci manifest did not contain any layers").into());
+    }
+
+    run_command_checked(
+        Command::new("skopeo")
+            .arg("copy")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--src-tls-verify=false")
+            .arg("--src-registry-token")
+            .arg(&read_token)
+            .arg(&image_ref)
+            .arg(format!("oci:{}:mirror", pulled_layout.path().display())),
+        "skopeo copy registry -> oci",
+    )?;
+
+    let pulled_index = read(pulled_layout.path().join("index.json"))?;
+    let pulled_index = serde_json::from_slice::<Value>(&pulled_index)?;
+    if !pulled_index["manifests"]
+        .as_array()
+        .is_some_and(|entries| !entries.is_empty())
+    {
+        return Err(ServerE2eInvariantError::new(
+            "pulled oci layout did not contain an index manifest",
+        )
+        .into());
+    }
+    let pulled_blobs = std::fs::read_dir(pulled_layout.path().join("blobs").join("sha256"))?
+        .filter_map(Result::ok)
+        .count();
+    if pulled_blobs == 0 {
+        return Err(
+            ServerE2eInvariantError::new("pulled oci layout did not contain any blobs").into(),
+        );
+    }
+
+    Ok(())
+}
+
+async fn exercise_native_oci_digest_and_multi_tag_flow() -> Result<(), TestError> {
+    let runtime = start_runtime(&[ServerFrontend::Oci]).await?;
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+    let source_layout = tempfile::tempdir()?;
+    let digest_layout = tempfile::tempdir()?;
+    let repository_ref = format!("docker://{}/team/assets", runtime.host_port());
+    let v1_ref = format!("{repository_ref}:v1");
+    let stable_ref = format!("{repository_ref}:stable");
+
+    let _layout =
+        create_oci_image_layout(source_layout.path(), "v1", "hello from shardline oci\n")?;
+    run_command_checked(
+        Command::new("skopeo")
+            .arg("copy")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--dest-tls-verify=false")
+            .arg("--dest-registry-token")
+            .arg(&write_token)
+            .arg(format!("oci:{}:v1", source_layout.path().display()))
+            .arg(&v1_ref),
+        "skopeo copy oci -> registry v1",
+    )?;
+    run_command_checked(
+        Command::new("skopeo")
+            .arg("copy")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--dest-tls-verify=false")
+            .arg("--dest-registry-token")
+            .arg(&write_token)
+            .arg(format!("oci:{}:v1", source_layout.path().display()))
+            .arg(&stable_ref),
+        "skopeo copy oci -> registry stable",
+    )?;
+
+    let tags = run_command_checked(
+        Command::new("skopeo")
+            .arg("list-tags")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--tls-verify=false")
+            .arg("--registry-token")
+            .arg(&read_token)
+            .arg(&repository_ref),
+        "skopeo list-tags multi-tag",
+    )?;
+    let tags = serde_json::from_slice::<Value>(&tags.stdout)?;
+    let tags = tags["Tags"].as_array().ok_or_else(|| {
+        ServerE2eInvariantError::new("oci tag listing did not contain a tag array")
+    })?;
+    if !(tags.iter().any(|tag| tag == "v1") && tags.iter().any(|tag| tag == "stable")) {
+        return Err(ServerE2eInvariantError::new(
+            "oci tag listing did not include both v1 and stable",
+        )
+        .into());
+    }
+
+    let inspect = run_command_checked(
+        Command::new("skopeo")
+            .arg("inspect")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--tls-verify=false")
+            .arg("--registry-token")
+            .arg(&read_token)
+            .arg(&v1_ref),
+        "skopeo inspect digest",
+    )?;
+    let inspect = serde_json::from_slice::<Value>(&inspect.stdout)?;
+    let digest = inspect["Digest"]
+        .as_str()
+        .ok_or_else(|| ServerE2eInvariantError::new("skopeo inspect did not return a digest"))?;
+
+    let config = run_command_checked(
+        Command::new("skopeo")
+            .arg("inspect")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--tls-verify=false")
+            .arg("--registry-token")
+            .arg(&read_token)
+            .arg("--config")
+            .arg(&stable_ref),
+        "skopeo inspect --config",
+    )?;
+    let config = serde_json::from_slice::<Value>(&config.stdout)?;
+    if config["architecture"].as_str().is_none() || config["rootfs"].is_null() {
+        return Err(ServerE2eInvariantError::new(
+            "skopeo inspect --config returned an unexpected payload",
+        )
+        .into());
+    }
+
+    run_command_checked(
+        Command::new("skopeo")
+            .arg("copy")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--src-tls-verify=false")
+            .arg("--src-registry-token")
+            .arg(&read_token)
+            .arg(format!("{repository_ref}@{digest}"))
+            .arg(format!("oci:{}:bydigest", digest_layout.path().display())),
+        "skopeo copy by digest",
+    )?;
+    let digest_index = read(digest_layout.path().join("index.json"))?;
+    let digest_index = serde_json::from_slice::<Value>(&digest_index)?;
+    if !digest_index["manifests"]
+        .as_array()
+        .is_some_and(|entries| !entries.is_empty())
+    {
+        return Err(ServerE2eInvariantError::new(
+            "digest-addressed skopeo copy did not produce an OCI index",
+        )
+        .into());
+    }
+
+    Ok(())
+}
+
+async fn exercise_native_oci_registry_to_registry_copy_flow() -> Result<(), TestError> {
+    let runtime = start_runtime(&[ServerFrontend::Oci]).await?;
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+    let source_layout = tempfile::tempdir()?;
+    let source_repo = format!("docker://{}/team/assets/source", runtime.host_port());
+    let source_ref = format!("{source_repo}:v1");
+    let target_repo = format!("docker://{}/team/assets/mirror", runtime.host_port());
+    let target_ref = format!("{target_repo}:v1");
+
+    let _layout =
+        create_oci_image_layout(source_layout.path(), "v1", "registry to registry copy\n")?;
+    run_command_checked(
+        Command::new("skopeo")
+            .arg("copy")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--dest-tls-verify=false")
+            .arg("--dest-registry-token")
+            .arg(&write_token)
+            .arg(format!("oci:{}:v1", source_layout.path().display()))
+            .arg(&source_ref),
+        "skopeo seed registry source",
+    )?;
+
+    run_command_checked(
+        Command::new("skopeo")
+            .arg("copy")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--src-tls-verify=false")
+            .arg("--src-registry-token")
+            .arg(&read_token)
+            .arg("--dest-tls-verify=false")
+            .arg("--dest-registry-token")
+            .arg(&write_token)
+            .arg(&source_ref)
+            .arg(&target_ref),
+        "skopeo copy registry -> registry",
+    )?;
+
+    let tags = run_command_checked(
+        Command::new("skopeo")
+            .arg("list-tags")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--tls-verify=false")
+            .arg("--registry-token")
+            .arg(&read_token)
+            .arg(&target_repo),
+        "skopeo list-tags registry mirror",
+    )?;
+    let tags = serde_json::from_slice::<Value>(&tags.stdout)?;
+    if !tags["Tags"]
+        .as_array()
+        .is_some_and(|tags| tags.iter().any(|tag| tag == "v1"))
+    {
+        return Err(ServerE2eInvariantError::new(
+            "oci registry mirror tag listing did not include v1",
+        )
+        .into());
+    }
+
+    let manifest = run_command_checked(
+        Command::new("skopeo")
+            .arg("inspect")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--tls-verify=false")
+            .arg("--registry-token")
+            .arg(&read_token)
+            .arg("--raw")
+            .arg(&target_ref),
+        "skopeo inspect --raw registry mirror",
+    )?;
+    let manifest = serde_json::from_slice::<Value>(&manifest.stdout)?;
+    if manifest["config"]["digest"].as_str().is_none() {
+        return Err(ServerE2eInvariantError::new(
+            "oci registry mirror manifest was missing a config digest",
+        )
+        .into());
+    }
+
+    Ok(())
+}
+
+async fn exercise_native_oci_multiarch_index_flow() -> Result<(), TestError> {
+    let runtime = start_runtime(&[ServerFrontend::Oci]).await?;
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+    let source_layout = tempfile::tempdir()?;
+    let pulled_layout = tempfile::tempdir()?;
+    let image_ref = format!("docker://{}/team/assets:multi", runtime.host_port());
+
+    create_oci_multiarch_layout(source_layout.path(), "multi")?;
+    run_command_checked(
+        Command::new("skopeo")
+            .arg("copy")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--all")
+            .arg("--dest-tls-verify=false")
+            .arg("--dest-registry-token")
+            .arg(&write_token)
+            .arg(format!("oci:{}:multi", source_layout.path().display()))
+            .arg(&image_ref),
+        "skopeo copy multiarch oci -> registry",
+    )?;
+
+    let raw = run_command_checked(
+        Command::new("skopeo")
+            .arg("inspect")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--tls-verify=false")
+            .arg("--registry-token")
+            .arg(&read_token)
+            .arg("--raw")
+            .arg(&image_ref),
+        "skopeo inspect --raw multiarch",
+    )?;
+    let raw = serde_json::from_slice::<Value>(&raw.stdout)?;
+    if raw["mediaType"] != "application/vnd.oci.image.index.v1+json" {
+        return Err(ServerE2eInvariantError::new(
+            "multiarch registry payload was not an OCI image index",
+        )
+        .into());
+    }
+    if !raw["manifests"]
+        .as_array()
+        .is_some_and(|entries| entries.len() == 2)
+    {
+        return Err(ServerE2eInvariantError::new(
+            "multiarch registry payload did not contain two manifests",
+        )
+        .into());
+    }
+
+    run_command_checked(
+        Command::new("skopeo")
+            .arg("copy")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--all")
+            .arg("--src-tls-verify=false")
+            .arg("--src-registry-token")
+            .arg(&read_token)
+            .arg(&image_ref)
+            .arg(format!("oci:{}:mirror", pulled_layout.path().display())),
+        "skopeo copy multiarch registry -> oci",
+    )?;
+    let pulled_index = read(pulled_layout.path().join("index.json"))?;
+    let pulled_index = serde_json::from_slice::<Value>(&pulled_index)?;
+    if !pulled_index["manifests"]
+        .as_array()
+        .is_some_and(|entries| entries.len() == 1)
+    {
+        return Err(ServerE2eInvariantError::new(
+            "pulled multiarch OCI layout did not expose a named index entry",
+        )
+        .into());
+    }
+    let pulled_blobs = std::fs::read_dir(pulled_layout.path().join("blobs").join("sha256"))?
+        .filter_map(Result::ok)
+        .count();
+    if pulled_blobs < 5 {
+        return Err(ServerE2eInvariantError::new(
+            "pulled multiarch OCI layout did not contain enough blobs",
+        )
+        .into());
+    }
+
+    Ok(())
+}
+
+async fn exercise_native_oci_docker_schema2_flow() -> Result<(), TestError> {
+    let runtime = start_runtime(&[ServerFrontend::Oci]).await?;
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+    let source_layout = tempfile::tempdir()?;
+    let image_ref = format!("docker://{}/team/assets:v2s2", runtime.host_port());
+    let _layout =
+        create_oci_image_layout(source_layout.path(), "v1", "docker schema2 compatibility\n")?;
+
+    run_command_checked(
+        Command::new("skopeo")
+            .arg("copy")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--format")
+            .arg("v2s2")
+            .arg("--dest-tls-verify=false")
+            .arg("--dest-registry-token")
+            .arg(&write_token)
+            .arg(format!("oci:{}:v1", source_layout.path().display()))
+            .arg(&image_ref),
+        "skopeo copy docker schema2 oci -> registry",
+    )?;
+
+    let raw = run_command_checked(
+        Command::new("skopeo")
+            .arg("inspect")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--tls-verify=false")
+            .arg("--registry-token")
+            .arg(&read_token)
+            .arg("--raw")
+            .arg(&image_ref),
+        "skopeo inspect --raw docker schema2",
+    )?;
+    let raw = serde_json::from_slice::<Value>(&raw.stdout)?;
+    if raw["schemaVersion"].as_u64() != Some(2) {
+        return Err(ServerE2eInvariantError::new(
+            "docker schema2 payload did not expose schemaVersion 2",
+        )
+        .into());
+    }
+    if raw["config"]["digest"].as_str().is_none() {
+        return Err(ServerE2eInvariantError::new(
+            "docker schema2 payload was missing a config digest",
+        )
+        .into());
+    }
+
+    let manifest = Client::new()
+        .get(format!(
+            "{}/v2/team/assets/manifests/v2s2",
+            runtime.base_url()
+        ))
+        .bearer_auth(&read_token)
+        .send()
+        .await?;
+    if manifest.status() != reqwest::StatusCode::OK {
+        return Err(ServerE2eInvariantError::new("docker schema2 manifest fetch failed").into());
+    }
+    if manifest
+        .headers()
+        .get("content-type")
+        .and_then(|value| value.to_str().ok())
+        != Some("application/vnd.docker.distribution.manifest.v2+json")
+    {
+        return Err(ServerE2eInvariantError::new(
+            "docker schema2 manifest did not preserve the docker media type",
+        )
+        .into());
+    }
+
+    Ok(())
+}
+
+async fn exercise_native_oci_token_service_flow() -> Result<(), TestError> {
+    let runtime = start_runtime(&[ServerFrontend::Oci]).await?;
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+    let source_layout = tempfile::tempdir()?;
+    let image_ref = format!("docker://{}/team/assets:creds", runtime.host_port());
+    let repository_ref = format!("docker://{}/team/assets", runtime.host_port());
+    let _layout = create_oci_image_layout(source_layout.path(), "v1", "oci creds flow\n")?;
+
+    run_command_checked(
+        Command::new("skopeo")
+            .arg("copy")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--dest-tls-verify=false")
+            .arg("--dest-creds")
+            .arg(format!("stexs:{write_token}"))
+            .arg(format!("oci:{}:v1", source_layout.path().display()))
+            .arg(&image_ref),
+        "skopeo copy via creds token service",
+    )?;
+
+    let tags = run_command_checked(
+        Command::new("skopeo")
+            .arg("list-tags")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--tls-verify=false")
+            .arg("--creds")
+            .arg(format!("stexs:{read_token}"))
+            .arg(&repository_ref),
+        "skopeo list-tags via creds token service",
+    )?;
+    let tags = serde_json::from_slice::<Value>(&tags.stdout)?;
+    if !tags["Tags"]
+        .as_array()
+        .is_some_and(|tags| tags.iter().any(|tag| tag == "creds"))
+    {
+        return Err(ServerE2eInvariantError::new(
+            "oci token-service tag listing did not include creds",
+        )
+        .into());
+    }
+
+    let manifest = run_command_checked(
+        Command::new("skopeo")
+            .arg("inspect")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--tls-verify=false")
+            .arg("--creds")
+            .arg(format!("stexs:{read_token}"))
+            .arg("--raw")
+            .arg(&image_ref),
+        "skopeo inspect --raw via creds token service",
+    )?;
+    let manifest = serde_json::from_slice::<Value>(&manifest.stdout)?;
+    if manifest["config"]["digest"].as_str().is_none() {
+        return Err(ServerE2eInvariantError::new(
+            "oci token-service manifest was missing a config digest",
+        )
+        .into());
+    }
+
+    Ok(())
+}
+
+async fn exercise_native_helm_oci_chart_flow() -> Result<(), TestError> {
+    let runtime = start_runtime(&[ServerFrontend::Oci]).await?;
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+    let workdir = tempfile::tempdir()?;
+    let helm_home = tempfile::tempdir()?;
+    let package_dir = workdir.path().join("package");
+    let pull_dir = workdir.path().join("pull");
+    let chart_dir = workdir.path().join("chart");
+    create_dir_all(&package_dir)?;
+    create_dir_all(&pull_dir)?;
+    create_dir_all(chart_dir.join("templates"))?;
+
+    write_file(
+        chart_dir.join("Chart.yaml"),
+        r#"apiVersion: v2
+name: stexs-chart
+description: Shardline helm chart e2e
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+"#,
+    )?;
+    write_file(
+        chart_dir.join("values.yaml"),
+        "replicaCount: 1\nimage:\n  repository: stexs/example\n  tag: latest\n",
+    )?;
+    write_file(
+        chart_dir.join("templates").join("configmap.yaml"),
+        r#"apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}
+data:
+  replicaCount: "{{ .Values.replicaCount }}"
+"#,
+    )?;
+
+    let mut package_command = Command::new("helm");
+    prepare_helm_command(&mut package_command, helm_home.path())
+        .arg("package")
+        .arg(&chart_dir)
+        .arg("--destination")
+        .arg(&package_dir);
+    run_command_checked(&mut package_command, "helm package")?;
+
+    let chart_package = package_dir.join("stexs-chart-0.1.0.tgz");
+    if !chart_package.exists() {
+        return Err(
+            ServerE2eInvariantError::new("helm package did not produce a chart tarball").into(),
+        );
+    }
+
+    let mut push_command = Command::new("helm");
+    prepare_helm_command(&mut push_command, helm_home.path())
+        .arg("push")
+        .arg(&chart_package)
+        .arg(format!("oci://{}/team/assets/charts", runtime.host_port()))
+        .arg("--plain-http")
+        .arg("--username")
+        .arg("stexs")
+        .arg("--password")
+        .arg(&write_token);
+    run_command_checked(&mut push_command, "helm push oci chart")?;
+
+    let mut pull_command = Command::new("helm");
+    prepare_helm_command(&mut pull_command, helm_home.path())
+        .arg("pull")
+        .arg(format!(
+            "oci://{}/team/assets/charts/stexs-chart",
+            runtime.host_port()
+        ))
+        .arg("--version")
+        .arg("0.1.0")
+        .arg("--plain-http")
+        .arg("--username")
+        .arg("stexs")
+        .arg("--password")
+        .arg(&read_token)
+        .arg("--destination")
+        .arg(&pull_dir);
+    run_command_checked(&mut pull_command, "helm pull oci chart")?;
+
+    let pulled_chart = pull_dir.join("stexs-chart-0.1.0.tgz");
+    if !pulled_chart.exists() {
+        return Err(
+            ServerE2eInvariantError::new("helm pull did not produce a chart tarball").into(),
+        );
+    }
+
+    let mut show_command = Command::new("helm");
+    prepare_helm_command(&mut show_command, helm_home.path())
+        .arg("show")
+        .arg("chart")
+        .arg(format!(
+            "oci://{}/team/assets/charts/stexs-chart",
+            runtime.host_port()
+        ))
+        .arg("--version")
+        .arg("0.1.0")
+        .arg("--plain-http")
+        .arg("--username")
+        .arg("stexs")
+        .arg("--password")
+        .arg(&read_token);
+    let chart_metadata = run_command_checked(&mut show_command, "helm show chart")?;
+    let chart_metadata = String::from_utf8(chart_metadata.stdout)?;
+    if !chart_metadata.contains("name: stexs-chart") || !chart_metadata.contains("version: 0.1.0") {
+        return Err(
+            ServerE2eInvariantError::new("helm show chart returned unexpected metadata").into(),
+        );
+    }
+
+    Ok(())
+}
+
+async fn exercise_native_podman_oci_flow() -> Result<(), TestError> {
+    let runtime = start_runtime(&[ServerFrontend::Oci]).await?;
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+    let source_layout = tempfile::tempdir()?;
+    let client_home = tempfile::tempdir()?;
+    let runtime_dir = client_home.path().join("run");
+    let auth_file = client_home.path().join("auth.json");
+    create_dir_all(&runtime_dir)?;
+
+    let seeded_ref = format!("{}/team/assets:podman-seed", runtime.host_port());
+    let copied_ref = format!("{}/team/assets:podman-copy", runtime.host_port());
+    let _layout = create_oci_image_layout(source_layout.path(), "v1", "podman registry flow\n")?;
+
+    run_command_checked(
+        Command::new("skopeo")
+            .arg("copy")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--dest-tls-verify=false")
+            .arg("--dest-creds")
+            .arg(format!("stexs:{write_token}"))
+            .arg(format!("oci:{}:v1", source_layout.path().display()))
+            .arg(format!("docker://{seeded_ref}")),
+        "skopeo seed podman registry image",
+    )?;
+
+    let mut login = Command::new("podman");
+    prepare_podman_command(&mut login, client_home.path(), &runtime_dir, &auth_file)
+        .arg("login")
+        .arg("--tls-verify=false")
+        .arg("--username")
+        .arg("stexs")
+        .arg("--password-stdin")
+        .arg(runtime.host_port());
+    run_command_with_stdin_checked(&mut login, read_token.as_bytes(), "podman login")?;
+
+    let mut pull = Command::new("podman");
+    prepare_podman_command(&mut pull, client_home.path(), &runtime_dir, &auth_file)
+        .arg("pull")
+        .arg("--tls-verify=false")
+        .arg(&seeded_ref);
+    run_command_checked(&mut pull, "podman pull")?;
+
+    let mut tag = Command::new("podman");
+    prepare_podman_command(&mut tag, client_home.path(), &runtime_dir, &auth_file)
+        .arg("tag")
+        .arg(&seeded_ref)
+        .arg(&copied_ref);
+    run_command_checked(&mut tag, "podman tag")?;
+
+    let mut push = Command::new("podman");
+    prepare_podman_command(&mut push, client_home.path(), &runtime_dir, &auth_file)
+        .arg("push")
+        .arg("--tls-verify=false")
+        .arg("--creds")
+        .arg(format!("stexs:{write_token}"))
+        .arg(&copied_ref);
+    run_command_checked(&mut push, "podman push")?;
+
+    let tags = run_command_checked(
+        Command::new("skopeo")
+            .arg("list-tags")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--tls-verify=false")
+            .arg("--creds")
+            .arg(format!("stexs:{read_token}"))
+            .arg(format!("docker://{}/team/assets", runtime.host_port())),
+        "skopeo list-tags after podman push",
+    )?;
+    let tags = serde_json::from_slice::<Value>(&tags.stdout)?;
+    if !tags["Tags"]
+        .as_array()
+        .is_some_and(|tags| tags.iter().any(|tag| tag == "podman-copy"))
+    {
+        return Err(ServerE2eInvariantError::new(
+            "podman push did not create the expected registry tag",
+        )
+        .into());
+    }
+
+    Ok(())
+}
+
+async fn exercise_native_docker_oci_flow() -> Result<(), TestError> {
+    let runtime = start_runtime(&[ServerFrontend::Oci]).await?;
+    let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
+    let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
+    let source_layout = tempfile::tempdir()?;
+    let docker_home = tempfile::tempdir()?;
+    let docker_config = docker_home.path().join(".docker");
+    create_dir_all(&docker_config)?;
+
+    let seeded_ref = format!("{}/team/assets:docker-seed", runtime.host_port());
+    let copied_ref = format!("{}/team/assets:docker-copy", runtime.host_port());
+    let _layout = create_oci_image_layout(source_layout.path(), "v1", "docker registry flow\n")?;
+
+    run_command_checked(
+        Command::new("skopeo")
+            .arg("copy")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--dest-tls-verify=false")
+            .arg("--dest-creds")
+            .arg(format!("stexs:{write_token}"))
+            .arg(format!("oci:{}:v1", source_layout.path().display()))
+            .arg(format!("docker://{seeded_ref}")),
+        "skopeo seed docker registry image",
+    )?;
+
+    let mut login = Command::new("docker");
+    prepare_docker_command(&mut login, docker_home.path(), &docker_config)
+        .arg("login")
+        .arg("--username")
+        .arg("stexs")
+        .arg("--password-stdin")
+        .arg(runtime.host_port());
+    run_command_with_stdin_checked(&mut login, write_token.as_bytes(), "docker login")?;
+
+    let mut pull = Command::new("docker");
+    prepare_docker_command(&mut pull, docker_home.path(), &docker_config)
+        .arg("pull")
+        .arg(&seeded_ref);
+    run_command_checked(&mut pull, "docker pull")?;
+
+    let mut tag = Command::new("docker");
+    prepare_docker_command(&mut tag, docker_home.path(), &docker_config)
+        .arg("tag")
+        .arg(&seeded_ref)
+        .arg(&copied_ref);
+    run_command_checked(&mut tag, "docker tag")?;
+
+    let mut push = Command::new("docker");
+    prepare_docker_command(&mut push, docker_home.path(), &docker_config)
+        .arg("push")
+        .arg(&copied_ref);
+    run_command_checked(&mut push, "docker push")?;
+
+    let tags = run_command_checked(
+        Command::new("skopeo")
+            .arg("list-tags")
+            .arg("--retry-times")
+            .arg("1")
+            .arg("--tls-verify=false")
+            .arg("--creds")
+            .arg(format!("stexs:{read_token}"))
+            .arg(format!("docker://{}/team/assets", runtime.host_port())),
+        "skopeo list-tags after docker push",
+    )?;
+    let tags = serde_json::from_slice::<Value>(&tags.stdout)?;
+    if !tags["Tags"]
+        .as_array()
+        .is_some_and(|tags| tags.iter().any(|tag| tag == "docker-copy"))
+    {
+        return Err(ServerE2eInvariantError::new(
+            "docker push did not create the expected registry tag",
+        )
+        .into());
+    }
+
+    let mut cleanup_seed = Command::new("docker");
+    let _cleanup_seed = run_command(
+        prepare_docker_command(&mut cleanup_seed, docker_home.path(), &docker_config)
+            .arg("image")
+            .arg("rm")
+            .arg("-f")
+            .arg(&seeded_ref),
+    );
+    let mut cleanup_copy = Command::new("docker");
+    let _cleanup_copy = run_command(
+        prepare_docker_command(&mut cleanup_copy, docker_home.path(), &docker_config)
+            .arg("image")
+            .arg("rm")
+            .arg("-f")
+            .arg(&copied_ref),
+    );
+
+    Ok(())
+}
+
+async fn start_runtime(frontends: &[ServerFrontend]) -> Result<FrontendRuntime, TestError> {
+    let storage = tempfile::tempdir()?;
+    let listener = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)).await?;
+    let addr = listener.local_addr()?;
+    let base_url = format!("http://{addr}");
+    let config = ServerConfig::new(
+        addr,
+        base_url.clone(),
+        storage.path().to_path_buf(),
+        NonZeroUsize::new(65_536).unwrap_or(NonZeroUsize::MIN),
+    )
+    .with_token_signing_key(b"signing-key".to_vec())?
+    .with_server_frontends(frontends.iter().copied())?;
+    let server = spawn(async move { serve_with_listener(config, listener).await });
+    wait_for_health(&base_url).await?;
+
+    Ok(FrontendRuntime {
+        _storage: storage,
+        base_url,
+        host_port: addr.to_string(),
+        server,
+    })
+}
+
+fn scoped_token(scope: TokenScope, owner: &str, repo: &str) -> Result<String, TestError> {
+    let signer = TokenSigner::new(b"signing-key")?;
+    let repository = RepositoryScope::new(RepositoryProvider::GitHub, owner, repo, Some("main"))?;
+    let claims = TokenClaims::new("local", "native-client", scope, repository, u64::MAX)?;
+    Ok(signer.sign(&claims)?)
+}
+
+async fn wait_for_health(base_url: &str) -> Result<(), TestError> {
+    let client = Client::new();
+    for _attempt in 0..50 {
+        let response = client.get(format!("{base_url}/healthz")).send().await;
+        if let Ok(response) = response
+            && response.status().is_success()
+        {
+            return Ok(());
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+
+    Err(ServerE2eInvariantError::new("server did not become healthy").into())
+}
+
+fn command_available(program: &str) -> bool {
+    Command::new(program)
+        .arg("--version")
+        .output()
+        .is_ok_and(|output| output.status.success())
+}
+
+fn bazel_program() -> Option<&'static str> {
+    if command_available("bazel") {
+        return Some("bazel");
+    }
+    if command_available("bazelisk") {
+        return Some("bazelisk");
+    }
+
+    None
+}
+
+fn prepare_helm_command<'command>(
+    command: &'command mut Command,
+    home: &Path,
+) -> &'command mut Command {
+    let config_home = home.join(".config");
+    let cache_home = home.join(".cache");
+    let data_home = home.join(".local").join("share");
+    command
+        .env("HOME", home)
+        .env("HELM_CONFIG_HOME", &config_home)
+        .env("HELM_CACHE_HOME", &cache_home)
+        .env("HELM_DATA_HOME", &data_home)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .env("XDG_CACHE_HOME", &cache_home)
+        .env("XDG_DATA_HOME", &data_home)
+}
+
+fn prepare_podman_command<'command>(
+    command: &'command mut Command,
+    home: &Path,
+    runtime_dir: &Path,
+    auth_file: &Path,
+) -> &'command mut Command {
+    command
+        .env("HOME", home)
+        .env("XDG_RUNTIME_DIR", runtime_dir)
+        .env("REGISTRY_AUTH_FILE", auth_file)
+}
+
+fn prepare_docker_command<'command>(
+    command: &'command mut Command,
+    home: &Path,
+    docker_config: &Path,
+) -> &'command mut Command {
+    command
+        .env("HOME", home)
+        .env("DOCKER_CONFIG", docker_config)
+}
+
+fn prepare_command<'command>(command: &'command mut Command, home: &Path) -> &'command mut Command {
+    command
+        .env("HOME", home)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_ASKPASS", "true")
+}
+
+fn run_git_with_home(repo: &Path, home: &Path, args: &[&str]) -> Result<Output, TestError> {
+    let mut command = Command::new("git");
+    prepare_command(&mut command, home)
+        .current_dir(repo)
+        .args(args);
+    let output = run_command(&mut command)?;
+    if output.status.success() {
+        return Ok(output);
+    }
+
+    Err(command_error("git command", &output).into())
+}
+
+fn run_git_with_home_and_env(
+    repo: &Path,
+    home: &Path,
+    envs: &[(&str, &str)],
+    program: &str,
+    args: &[&str],
+) -> Result<Output, TestError> {
+    let mut command = Command::new(program);
+    prepare_command(&mut command, home)
+        .current_dir(repo)
+        .args(args);
+    for &(key, value) in envs {
+        command.env(key, value);
+    }
+    let output = run_command(&mut command)?;
+    if output.status.success() {
+        return Ok(output);
+    }
+
+    Err(command_error(program, &output).into())
+}
+
+fn configure_lfs_client_repo(
+    repo: &Path,
+    home: &Path,
+    base_url: &str,
+    token: &str,
+) -> Result<(), TestError> {
+    run_git_with_home(
+        repo,
+        home,
+        &["config", "lfs.url", &format!("{base_url}/v1/lfs")],
+    )?;
+    run_git_with_home(repo, home, &["config", "lfs.locksverify", "false"])?;
+    run_git_with_home(
+        repo,
+        home,
+        &[
+            "config",
+            "http.extraHeader",
+            &format!("Authorization: Bearer {token}"),
+        ],
+    )?;
+    Ok(())
+}
+
+fn run_bazel_build(
+    program: &str,
+    workspace: &Path,
+    home: &Path,
+    output_base: &Path,
+    base_url: &str,
+    token: &str,
+    allow_uploads: bool,
+) -> Result<Output, TestError> {
+    run_bazel_build_with_download_mode(
+        program,
+        workspace,
+        home,
+        output_base,
+        base_url,
+        token,
+        allow_uploads,
+        "all",
+    )
+}
+
+fn run_bazel_build_with_download_mode(
+    program: &str,
+    workspace: &Path,
+    home: &Path,
+    output_base: &Path,
+    base_url: &str,
+    token: &str,
+    allow_uploads: bool,
+    download_mode: &str,
+) -> Result<Output, TestError> {
+    let mut command = Command::new(program);
+    command
+        .current_dir(workspace)
+        .env("HOME", home)
+        .arg("--batch")
+        .arg("--bazelrc=/dev/null")
+        .arg("--nohome_rc")
+        .arg("--nosystem_rc")
+        .arg("--noworkspace_rc")
+        .arg(format!("--output_base={}", output_base.display()))
+        .arg("build")
+        .arg("//:copy")
+        .arg("--show_result=0")
+        .arg("--noshow_progress")
+        .arg("--color=no")
+        .arg("--curses=no")
+        .arg(format!("--remote_download_outputs={download_mode}"))
+        .arg(format!("--remote_cache={base_url}/v1/bazel/cache"))
+        .arg(format!("--remote_header=Authorization=Bearer {token}"))
+        .arg(format!(
+            "--remote_cache_header=Authorization=Bearer {token}"
+        ))
+        .arg(format!(
+            "--remote_upload_local_results={}",
+            if allow_uploads { "true" } else { "false" }
+        ));
+    let output = run_command(&mut command)?;
+    Ok(output)
+}
+
+fn run_command(command: &mut Command) -> Result<Output, IoError> {
+    command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+}
+
+fn run_command_with_stdin(command: &mut Command, input: &[u8]) -> Result<Output, IoError> {
+    command.stdin(Stdio::piped());
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = command.spawn()?;
+    if let Some(stdin) = child.stdin.as_mut() {
+        stdin.write_all(input)?;
+        stdin.write_all(b"\n")?;
+    }
+    child.wait_with_output()
+}
+
+fn run_command_checked(command: &mut Command, description: &str) -> Result<Output, TestError> {
+    let output = run_command(command)?;
+    if output.status.success() {
+        return Ok(output);
+    }
+
+    Err(command_error(description, &output).into())
+}
+
+fn run_command_with_stdin_checked(
+    command: &mut Command,
+    input: &[u8],
+    description: &str,
+) -> Result<Output, TestError> {
+    let output = run_command_with_stdin(command, input)?;
+    if output.status.success() {
+        return Ok(output);
+    }
+
+    Err(command_error(description, &output).into())
+}
+
+fn command_error(description: &str, output: &Output) -> IoError {
+    ServerE2eInvariantError::new(format!(
+        "{description} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    ))
+    .into()
+}
+
+fn seeded_bytes(len: usize, seed: u8) -> Vec<u8> {
+    (0..len)
+        .map(|index| seed.wrapping_add((index % 251) as u8))
+        .collect()
+}
+
+struct OciLayoutSummary {
+    _config_digest: String,
+    _layer_digest: String,
+}
+
+fn create_oci_image_layout(
+    root: &Path,
+    tag: &str,
+    payload: &str,
+) -> Result<OciLayoutSummary, TestError> {
+    let blobs_root = root.join("blobs").join("sha256");
+    let layer_root = root.join("layer-root");
+    create_dir_all(&blobs_root)?;
+    create_dir_all(&layer_root)?;
+    write_file(
+        root.join("oci-layout"),
+        to_vec(&json!({ "imageLayoutVersion": "1.0.0" }))?,
+    )?;
+    write_file(layer_root.join("payload.txt"), payload)?;
+
+    run_command_checked(
+        Command::new("tar")
+            .arg("-C")
+            .arg(&layer_root)
+            .arg("-cf")
+            .arg(root.join("layer.tar"))
+            .arg("."),
+        "tar create layer",
+    )?;
+    let layer_bytes = read(root.join("layer.tar"))?;
+    let layer_digest = hex::encode(Sha256::digest(&layer_bytes));
+    write_file(blobs_root.join(&layer_digest), &layer_bytes)?;
+
+    let config_bytes = to_vec(&json!({
+        "architecture": "amd64",
+        "os": "linux",
+        "rootfs": {
+            "type": "layers",
+            "diff_ids": [format!("sha256:{layer_digest}")],
+        },
+        "config": {},
+    }))?;
+    let config_digest = hex::encode(Sha256::digest(&config_bytes));
+    write_file(blobs_root.join(&config_digest), &config_bytes)?;
+
+    let manifest_bytes = to_vec(&json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": format!("sha256:{config_digest}"),
+            "size": config_bytes.len(),
+        },
+        "layers": [{
+            "mediaType": "application/vnd.oci.image.layer.v1.tar",
+            "digest": format!("sha256:{layer_digest}"),
+            "size": layer_bytes.len(),
+        }],
+    }))?;
+    let manifest_digest = hex::encode(Sha256::digest(&manifest_bytes));
+    write_file(blobs_root.join(&manifest_digest), &manifest_bytes)?;
+
+    let index_bytes = to_vec(&json!({
+        "schemaVersion": 2,
+        "manifests": [{
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "digest": format!("sha256:{manifest_digest}"),
+            "size": manifest_bytes.len(),
+            "annotations": {
+                "org.opencontainers.image.ref.name": tag,
+            },
+        }],
+    }))?;
+    write_file(root.join("index.json"), &index_bytes)?;
+
+    Ok(OciLayoutSummary {
+        _config_digest: config_digest,
+        _layer_digest: layer_digest,
+    })
+}
+
+fn create_oci_multiarch_layout(root: &Path, tag: &str) -> Result<(), TestError> {
+    let blobs_root = root.join("blobs").join("sha256");
+    create_dir_all(&blobs_root)?;
+    write_file(
+        root.join("oci-layout"),
+        to_vec(&json!({ "imageLayoutVersion": "1.0.0" }))?,
+    )?;
+
+    let amd64 = create_oci_manifest_blob(root, "amd64", "linux", "hello amd64\n")?;
+    let arm64 = create_oci_manifest_blob(root, "arm64", "linux", "hello arm64\n")?;
+    let image_index = to_vec(&json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": [
+            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": format!("sha256:{}", amd64.manifest_digest),
+                "size": amd64.manifest_size,
+                "platform": {
+                    "architecture": "amd64",
+                    "os": "linux",
+                },
+            },
+            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": format!("sha256:{}", arm64.manifest_digest),
+                "size": arm64.manifest_size,
+                "platform": {
+                    "architecture": "arm64",
+                    "os": "linux",
+                },
+            }
+        ],
+    }))?;
+    let image_index_digest = hex::encode(Sha256::digest(&image_index));
+    write_file(blobs_root.join(&image_index_digest), &image_index)?;
+
+    let index_bytes = to_vec(&json!({
+        "schemaVersion": 2,
+        "manifests": [{
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+            "digest": format!("sha256:{image_index_digest}"),
+            "size": image_index.len(),
+            "annotations": {
+                "org.opencontainers.image.ref.name": tag,
+            },
+        }],
+    }))?;
+    write_file(root.join("index.json"), &index_bytes)?;
+    Ok(())
+}
+
+struct OciManifestBlobSummary {
+    manifest_digest: String,
+    manifest_size: usize,
+}
+
+fn create_oci_manifest_blob(
+    root: &Path,
+    architecture: &str,
+    os: &str,
+    payload: &str,
+) -> Result<OciManifestBlobSummary, TestError> {
+    let blobs_root = root.join("blobs").join("sha256");
+    let layer_root = root.join(format!("layer-root-{architecture}"));
+    create_dir_all(&blobs_root)?;
+    create_dir_all(&layer_root)?;
+    write_file(layer_root.join("payload.txt"), payload)?;
+
+    let layer_tar_path = root.join(format!("layer-{architecture}.tar"));
+    run_command_checked(
+        Command::new("tar")
+            .arg("-C")
+            .arg(&layer_root)
+            .arg("-cf")
+            .arg(&layer_tar_path)
+            .arg("."),
+        "tar create multiarch layer",
+    )?;
+    let layer_bytes = read(&layer_tar_path)?;
+    let layer_digest = hex::encode(Sha256::digest(&layer_bytes));
+    write_file(blobs_root.join(&layer_digest), &layer_bytes)?;
+
+    let config_bytes = to_vec(&json!({
+        "architecture": architecture,
+        "os": os,
+        "rootfs": {
+            "type": "layers",
+            "diff_ids": [format!("sha256:{layer_digest}")],
+        },
+        "config": {},
+    }))?;
+    let config_digest = hex::encode(Sha256::digest(&config_bytes));
+    write_file(blobs_root.join(&config_digest), &config_bytes)?;
+
+    let manifest_bytes = to_vec(&json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": format!("sha256:{config_digest}"),
+            "size": config_bytes.len(),
+        },
+        "layers": [{
+            "mediaType": "application/vnd.oci.image.layer.v1.tar",
+            "digest": format!("sha256:{layer_digest}"),
+            "size": layer_bytes.len(),
+        }],
+    }))?;
+    let manifest_digest = hex::encode(Sha256::digest(&manifest_bytes));
+    write_file(blobs_root.join(&manifest_digest), &manifest_bytes)?;
+
+    Ok(OciManifestBlobSummary {
+        manifest_digest,
+        manifest_size: manifest_bytes.len(),
+    })
+}

--- a/crates/server/tests/provider_token_flow.rs
+++ b/crates/server/tests/provider_token_flow.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use reqwest::{Client, StatusCode};
+use shardline_index::xet_hash_hex_string;
 use shardline_protocol::ShardlineHash;
 use shardline_server::{ServerConfig, serve_with_listener};
 use shardline_vcs::{
@@ -147,7 +148,7 @@ async fn exercise_provider_token_flow() -> Result<(), Box<dyn Error>> {
 
 fn xet_hash_hex(hash: &MerkleHash) -> String {
     let bytes: [u8; 32] = hash.as_bytes().try_into().unwrap_or([0; 32]);
-    ShardlineHash::from_bytes(bytes).api_hex_string()
+    xet_hash_hex_string(ShardlineHash::from_bytes(bytes))
 }
 
 fn single_chunk_xorb(bytes: &[u8]) -> (Vec<u8>, String) {

--- a/crates/server/tests/role_split_e2e.rs
+++ b/crates/server/tests/role_split_e2e.rs
@@ -22,7 +22,9 @@ use reqwest::Client;
 use shardline_protocol::{
     RepositoryProvider, RepositoryScope, TokenClaims, TokenScope, TokenSigner,
 };
-use shardline_server::{ReadyResponse, ServerConfig, ServerRole, serve_with_listener};
+use shardline_server::{
+    ReadyResponse, ServerConfig, ServerError, ServerFrontend, ServerRole, serve_with_listener,
+};
 use support::ServerE2eInvariantError;
 use tokio::{net::TcpListener, spawn, time::sleep};
 use xet_client::cas_client::auth::AuthConfig;
@@ -30,6 +32,24 @@ use xet_data::processing::{
     FileDownloadSession, FileUploadSession, Sha256Policy, XetFileInfo,
     configurations::TranslatorConfig,
 };
+
+struct FrontendRoleRuntime {
+    _storage: tempfile::TempDir,
+    base_url: String,
+    server: tokio::task::JoinHandle<Result<(), ServerError>>,
+}
+
+impl FrontendRoleRuntime {
+    fn base_url(&self) -> &str {
+        &self.base_url
+    }
+}
+
+impl Drop for FrontendRoleRuntime {
+    fn drop(&mut self) {
+        self.server.abort();
+    }
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn api_role_serves_control_plane_routes_only() {
@@ -72,6 +92,20 @@ async fn split_roles_support_native_xet_through_path_routed_proxy() {
         result.is_ok(),
         "split role native xet e2e failed: {error:?}"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn api_role_serves_oci_api_routes_but_not_oci_transfer_routes() {
+    let result = exercise_oci_role_surface(ServerRole::Api).await;
+    let error = result.as_ref().err().map(ToString::to_string);
+    assert!(result.is_ok(), "oci api role e2e failed: {error:?}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn transfer_role_serves_oci_transfer_routes_but_not_oci_api_routes() {
+    let result = exercise_oci_role_surface(ServerRole::Transfer).await;
+    let error = result.as_ref().err().map(ToString::to_string);
+    assert!(result.is_ok(), "oci transfer role e2e failed: {error:?}");
 }
 
 async fn exercise_role(
@@ -133,6 +167,118 @@ async fn wait_for_health(client: &Client, base_url: &str) -> Result<(), Box<dyn 
     }
 
     Err(ServerE2eInvariantError::new("server did not become healthy").into())
+}
+
+async fn start_frontend_role_runtime(
+    role: ServerRole,
+    frontends: &[ServerFrontend],
+) -> Result<FrontendRoleRuntime, Box<dyn Error>> {
+    let storage = tempfile::tempdir()?;
+    let listener = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)).await?;
+    let addr = listener.local_addr()?;
+    let base_url = format!("http://{addr}");
+    let config = ServerConfig::new(
+        addr,
+        base_url.clone(),
+        storage.path().to_path_buf(),
+        NonZeroUsize::new(4).ok_or("chunk size")?,
+    )
+    .with_server_role(role)
+    .with_token_signing_key(b"signing-key".to_vec())?
+    .with_server_frontends(frontends.iter().copied())?;
+    let server = spawn(async move { serve_with_listener(config, listener).await });
+    let client = Client::new();
+    wait_for_health(&client, &base_url).await?;
+    Ok(FrontendRoleRuntime {
+        _storage: storage,
+        base_url,
+        server,
+    })
+}
+
+async fn exercise_oci_role_surface(role: ServerRole) -> Result<(), Box<dyn Error>> {
+    let runtime = start_frontend_role_runtime(role, &[ServerFrontend::Oci]).await?;
+    let client = Client::new();
+    let write_token = bearer_token(
+        "operator-1",
+        TokenScope::Write,
+        RepositoryProvider::GitHub,
+        "team",
+        "assets",
+        Some("main"),
+    )?;
+
+    match role {
+        ServerRole::Api => {
+            let root = client
+                .get(format!("{}/v2/", runtime.base_url()))
+                .bearer_auth(&write_token)
+                .send()
+                .await?;
+            assert_eq!(root.status(), StatusCode::OK);
+
+            let token = client
+                .get(format!(
+                    "{}/v2/token?service=shardline&scope=repository:team/assets:pull",
+                    runtime.base_url()
+                ))
+                .bearer_auth(&write_token)
+                .send()
+                .await?;
+            assert_eq!(token.status(), StatusCode::OK);
+
+            let upload = client
+                .post(format!(
+                    "{}/v2/team/assets/blobs/uploads",
+                    runtime.base_url()
+                ))
+                .bearer_auth(&write_token)
+                .send()
+                .await?;
+            assert_eq!(upload.status(), StatusCode::NOT_FOUND);
+        }
+        ServerRole::Transfer => {
+            let root = client
+                .get(format!("{}/v2/", runtime.base_url()))
+                .bearer_auth(&write_token)
+                .send()
+                .await?;
+            assert_eq!(root.status(), StatusCode::NOT_FOUND);
+
+            let token = client
+                .get(format!(
+                    "{}/v2/token?service=shardline&scope=repository:team/assets:pull",
+                    runtime.base_url()
+                ))
+                .bearer_auth(&write_token)
+                .send()
+                .await?;
+            assert_eq!(token.status(), StatusCode::NOT_FOUND);
+
+            let upload = client
+                .post(format!(
+                    "{}/v2/team/assets/blobs/uploads",
+                    runtime.base_url()
+                ))
+                .bearer_auth(&write_token)
+                .send()
+                .await?;
+            assert_eq!(upload.status(), StatusCode::ACCEPTED);
+
+            let manifest = client
+                .get(format!(
+                    "{}/v2/team/assets/manifests/latest",
+                    runtime.base_url()
+                ))
+                .bearer_auth(&write_token)
+                .send()
+                .await?;
+            assert_eq!(manifest.status(), StatusCode::NOT_FOUND);
+        }
+        ServerRole::All => {}
+    }
+
+    Ok(())
 }
 
 #[derive(Debug, Clone)]

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -24,7 +24,13 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [dev-dependencies]
+hex.workspace = true
+sha2.workspace = true
 tempfile.workspace = true
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "s3_put_file_fixed"
+harness = false

--- a/crates/storage/benches/s3_put_file_fixed.rs
+++ b/crates/storage/benches/s3_put_file_fixed.rs
@@ -1,0 +1,203 @@
+use std::{
+    fs,
+    io::Read,
+    path::{Path, PathBuf},
+    process::ExitCode,
+    time::{Instant, SystemTime, UNIX_EPOCH},
+};
+
+use blake3::Hasher as Blake3Hasher;
+use sha2::{Digest, Sha256};
+use shardline_protocol::ShardlineHash;
+use shardline_storage::{
+    ObjectBody, ObjectIntegrity, ObjectKey, ObjectStore, S3ObjectStore, S3ObjectStoreConfig,
+};
+use tempfile::TempDir;
+
+const FILE_BYTES: usize = 32 * 1024 * 1024;
+const DEFAULT_ITERATIONS: usize = 8;
+
+struct Fixture {
+    _root: TempDir,
+    source_path: PathBuf,
+    store: S3ObjectStore,
+    run_prefix: String,
+}
+
+impl Fixture {
+    fn new() -> Result<Self, Box<dyn std::error::Error>> {
+        let endpoint = std::env::var("S3_BENCH_ENDPOINT")
+            .unwrap_or_else(|_error| "http://127.0.0.1:9010".to_owned());
+        let bucket =
+            std::env::var("S3_BENCH_BUCKET").unwrap_or_else(|_error| "shardline-bench".to_owned());
+        let access_key =
+            std::env::var("S3_BENCH_ACCESS_KEY").unwrap_or_else(|_error| "minio".to_owned());
+        let secret_key =
+            std::env::var("S3_BENCH_SECRET_KEY").unwrap_or_else(|_error| "minio123".to_owned());
+        let root = tempfile::tempdir()?;
+        let source_path = root.path().join("source.bin");
+        fs::write(&source_path, vec![0x5a; FILE_BYTES])?;
+        let store = S3ObjectStore::new(
+            S3ObjectStoreConfig::new(bucket, "us-east-1".to_owned())
+                .with_endpoint(Some(endpoint))
+                .with_allow_http(true)
+                .with_credentials(Some(access_key), Some(secret_key), None),
+        )?;
+        let run_prefix = format!(
+            "bench-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_or(0_u128, |duration| duration.as_nanos())
+        );
+        Ok(Self {
+            _root: root,
+            source_path,
+            store,
+            run_prefix,
+        })
+    }
+
+    fn object_key(
+        &self,
+        mode: &str,
+        iteration: usize,
+    ) -> Result<ObjectKey, Box<dyn std::error::Error>> {
+        Ok(ObjectKey::parse(&format!(
+            "protocol-bench/s3/{}/{mode}/{iteration:08}",
+            self.run_prefix
+        ))?)
+    }
+}
+
+fn main() -> ExitCode {
+    let mut mode = "direct";
+    let mut iterations = DEFAULT_ITERATIONS;
+    let mut args = std::env::args().skip(1);
+    while let Some(argument) = args.next() {
+        match argument.as_str() {
+            "old" | "generic" | "direct" => mode = Box::leak(argument.into_boxed_str()),
+            "--bench" => {}
+            "--iterations" => {
+                let Some(value) = args.next() else {
+                    eprintln!("missing value for --iterations");
+                    return ExitCode::FAILURE;
+                };
+                match value.parse::<usize>() {
+                    Ok(parsed) if parsed > 0 => iterations = parsed,
+                    _ => {
+                        eprintln!("invalid --iterations value: {value}");
+                        return ExitCode::FAILURE;
+                    }
+                }
+            }
+            _ => {
+                eprintln!(
+                    "usage: cargo bench --bench s3_put_file_fixed -- [old|generic|direct] [--iterations N]"
+                );
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+
+    let fixture = match Fixture::new() {
+        Ok(fixture) => fixture,
+        Err(error) => {
+            eprintln!("fixture setup failed: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let start = Instant::now();
+    for iteration in 0..iterations {
+        let key = match fixture.object_key(mode, iteration) {
+            Ok(key) => key,
+            Err(error) => {
+                eprintln!("object key failed: {error}");
+                return ExitCode::FAILURE;
+            }
+        };
+        let result = match mode {
+            "old" => old_finalize_s3(&fixture.store, &fixture.source_path, &key),
+            "generic" => generic_finalize_s3(&fixture.store, &fixture.source_path, &key),
+            "direct" => direct_finalize_s3(&fixture.store, &fixture.source_path, &key),
+            invalid => {
+                eprintln!("unsupported mode: {invalid}");
+                return ExitCode::FAILURE;
+            }
+        };
+        if let Err(error) = result {
+            eprintln!("{mode} finalize failed: {error}");
+            return ExitCode::FAILURE;
+        }
+    }
+    let elapsed = start.elapsed();
+    let elapsed_ms = elapsed.as_millis();
+    let elapsed_micros_remainder = elapsed.subsec_micros() % 1000;
+    println!(
+        "mode={mode} iterations={iterations} file_bytes={FILE_BYTES} elapsed_ms={elapsed_ms}.{elapsed_micros_remainder:03}"
+    );
+    ExitCode::SUCCESS
+}
+
+fn old_finalize_s3(
+    store: &S3ObjectStore,
+    path: &Path,
+    key: &ObjectKey,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let bytes = fs::read(path)?;
+    let _sha256_hex = hex::encode(Sha256::digest(&bytes));
+    let integrity = ObjectIntegrity::new(
+        ShardlineHash::from_bytes(*blake3::hash(&bytes).as_bytes()),
+        u64::try_from(bytes.len())?,
+    );
+    let _stored = store.put_if_absent(key, ObjectBody::from_vec(bytes), &integrity)?;
+    Ok(())
+}
+
+fn generic_finalize_s3(
+    store: &S3ObjectStore,
+    path: &Path,
+    key: &ObjectKey,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_sha256_hex, integrity) = stream_file_integrity(path)?;
+    let _stored = store.put_file_if_absent(key, path, &integrity)?;
+    Ok(())
+}
+
+fn direct_finalize_s3(
+    store: &S3ObjectStore,
+    path: &Path,
+    key: &ObjectKey,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_sha256_hex, integrity) = stream_file_integrity(path)?;
+    let _stored = store.put_content_addressed_file(key, path, &integrity)?;
+    Ok(())
+}
+
+fn stream_file_integrity(
+    path: &Path,
+) -> Result<(String, ObjectIntegrity), Box<dyn std::error::Error>> {
+    let mut file = fs::File::open(path)?;
+    let mut sha256 = Sha256::new();
+    let mut blake3 = Blake3Hasher::new();
+    let mut buffer = [0_u8; 256 * 1024];
+    let mut total_length = 0_u64;
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        let slice = buffer
+            .get(..read)
+            .ok_or("integrity buffer read exceeded allocated capacity")?;
+        sha256.update(slice);
+        blake3.update(slice);
+        total_length = total_length
+            .checked_add(u64::try_from(read)?)
+            .ok_or("overflow while summing file bytes")?;
+    }
+    let sha256_hex = hex::encode(sha256.finalize());
+    let blake3_hash = ShardlineHash::from_bytes(*blake3.finalize().as_bytes());
+    Ok((sha256_hex, ObjectIntegrity::new(blake3_hash, total_length)))
+}

--- a/crates/storage/src/local.rs
+++ b/crates/storage/src/local.rs
@@ -14,7 +14,10 @@ use crate::{
     DeleteOutcome, DirectoryPathError, ObjectBody, ObjectIntegrity, ObjectKey, ObjectMetadata,
     ObjectPrefix, ObjectStore, PutOutcome,
     ensure_directory_path_components_are_not_symlinked as ensure_directory_path_components_are_not_symlinked_shared,
-    local_fs::{PutBytesIfAbsentOutcome, hard_link_file_if_absent, put_bytes_if_absent},
+    local_fs::{
+        PutBytesIfAbsentOutcome, hard_link_file_if_absent, put_bytes_if_absent,
+        write_bytes_atomically,
+    },
 };
 const VERIFY_BUFFER_BYTES: usize = 256 * 1024;
 
@@ -92,6 +95,93 @@ impl LocalObjectStore {
         let path = self.key_path(key);
         ensure_parent_directories_are_not_symlinked(&self.root, &path)?;
         link_temporary_file_if_absent(&self.root, &path, temporary, integrity, None)
+    }
+
+    /// Copies an existing object to a new key if the destination is absent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LocalObjectStoreError`] when the source is missing, the destination
+    /// conflicts with different bytes, or installation fails.
+    pub fn copy_object_if_absent(
+        &self,
+        source: &ObjectKey,
+        destination: &ObjectKey,
+    ) -> Result<PutOutcome, LocalObjectStoreError> {
+        let source_path = self.key_path(source);
+        let destination_path = self.key_path(destination);
+        let _source = open_existing_object_file(&source_path)?;
+        ensure_parent_directories_are_not_symlinked(&self.root, &destination_path)?;
+        match hard_link_file_if_absent(&self.root, &destination_path, &source_path) {
+            Ok(()) => Ok(PutOutcome::Inserted),
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                let existing = open_existing_object_file(&destination_path)?;
+                let source_file = open_existing_object_file(&source_path)?;
+                ensure_files_match(existing, source_file)?;
+                Ok(PutOutcome::AlreadyExists)
+            }
+            Err(error) => Err(LocalObjectStoreError::Io(error)),
+        }
+    }
+
+    /// Stores bytes at a key, replacing any existing object atomically.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LocalObjectStoreError`] when integrity validation or filesystem
+    /// replacement fails.
+    pub fn put_overwrite(
+        &self,
+        key: &ObjectKey,
+        body: ObjectBody<'_>,
+        integrity: &ObjectIntegrity,
+    ) -> Result<(), LocalObjectStoreError> {
+        let bytes = body.into_bytes();
+        verify_integrity(&bytes, integrity)?;
+        let path = self.key_path(key);
+        ensure_parent_directories_are_not_symlinked(&self.root, &path)?;
+        write_bytes_atomically(&self.root, &path, &bytes).map_err(LocalObjectStoreError::Io)
+    }
+
+    /// Lists a bounded page of direct child objects under a flat namespace prefix.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LocalObjectStoreError`] when the namespace path cannot be read or a
+    /// listed child cannot be represented as a validated object key.
+    pub fn list_flat_namespace_page(
+        &self,
+        prefix: &ObjectPrefix,
+        start_after: Option<&ObjectKey>,
+        limit: usize,
+    ) -> Result<Vec<ObjectMetadata>, LocalObjectStoreError> {
+        let directory = self.root.join(prefix.as_str());
+        let Some(entries) = read_dir_if_exists(&directory)? else {
+            return Ok(Vec::new());
+        };
+        let mut children = Vec::new();
+        for entry in entries {
+            let entry = entry.map_err(LocalObjectStoreError::Io)?;
+            let file_type = entry.file_type().map_err(LocalObjectStoreError::Io)?;
+            if !file_type.is_file() {
+                continue;
+            }
+            let name = entry
+                .file_name()
+                .into_string()
+                .map_err(|_error| LocalObjectStoreError::InvalidStoredKey)?;
+            let key = ObjectKey::parse(&format!("{}{}", prefix.as_str(), name))
+                .map_err(|_error| LocalObjectStoreError::InvalidStoredKey)?;
+            if start_after.is_some_and(|offset| key.as_str() <= offset.as_str()) {
+                continue;
+            }
+            let metadata = fs::symlink_metadata(entry.path()).map_err(LocalObjectStoreError::Io)?;
+            ensure_regular_file_metadata(&metadata)?;
+            children.push(ObjectMetadata::new(key, metadata.len(), None));
+        }
+        children.sort_by(|left, right| left.key().as_str().cmp(right.key().as_str()));
+        children.truncate(limit);
+        Ok(children)
     }
 
     fn key_path(&self, key: &ObjectKey) -> PathBuf {

--- a/crates/storage/src/local_fs.rs
+++ b/crates/storage/src/local_fs.rs
@@ -142,6 +142,23 @@ pub(crate) fn put_bytes_if_absent(
     }
 }
 
+pub(crate) fn write_bytes_atomically(root: &Path, path: &Path, bytes: &[u8]) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        write_bytes_atomically_unix(root, path, bytes)
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = root;
+        let parent = path.parent().ok_or_else(invalid_local_path_error)?;
+        fs::create_dir_all(parent)?;
+        let temporary = write_temporary_file(path, bytes)?;
+        fs::rename(temporary, path)?;
+        Ok(())
+    }
+}
+
 #[cfg(unix)]
 fn hard_link_file_if_absent_unix(root: &Path, path: &Path, temporary: &Path) -> io::Result<()> {
     let anchored = open_anchored_target(root, path)?;
@@ -205,6 +222,27 @@ fn put_bytes_if_absent_unix(
 }
 
 #[cfg(unix)]
+fn write_bytes_atomically_unix(root: &Path, path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let anchored = open_anchored_target(root, path)?;
+    run_before_local_write_hook(&anchored.logical_path());
+    let final_path = anchored.final_path();
+    let temporary =
+        write_anchored_temporary_file_shared(&anchored, bytes, anchored_path_options().file_mode)?;
+    match fs::rename(&temporary, &final_path) {
+        Ok(()) => {}
+        Err(error) => {
+            remove_if_present(&temporary)?;
+            return Err(error);
+        }
+    }
+    if let Err(error) = ensure_parent_path_matches_anchor(&anchored) {
+        remove_if_present(&final_path)?;
+        return Err(error);
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
 fn open_anchored_target(root: &Path, path: &Path) -> io::Result<AnchoredTarget> {
     open_anchored_target_shared(
         root,
@@ -236,6 +274,27 @@ fn open_existing_regular_file(path: &Path) -> io::Result<File> {
         ));
     }
     Ok(file)
+}
+
+#[cfg(not(unix))]
+fn write_temporary_file(path: &Path, bytes: &[u8]) -> io::Result<std::path::PathBuf> {
+    let temporary = path.with_extension(format!("tmp-{}", std::process::id()));
+    match OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temporary)
+    {
+        Ok(mut file) => {
+            file.write_all(bytes)?;
+            file.flush()?;
+            Ok(temporary)
+        }
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+            fs::remove_file(&temporary)?;
+            write_temporary_file(path, bytes)
+        }
+        Err(error) => Err(error),
+    }
 }
 
 #[cfg(unix)]

--- a/crates/storage/src/s3.rs
+++ b/crates/storage/src/s3.rs
@@ -1,16 +1,31 @@
-use std::{fmt, future::Future, io::Error as IoError, ops::Range, pin::Pin, sync::Arc};
+use std::{
+    fmt,
+    fs::File,
+    future::Future,
+    io::{Error as IoError, Read},
+    ops::Range,
+    path::Path,
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use bytes::Bytes;
 use futures_util::{Stream, TryStreamExt};
 use object_store::{
-    Error as ExternalObjectStoreError, GetOptions, GetResult, ObjectStore as ExternalObjectStore,
-    ObjectStoreExt, PutMode,
-    aws::{AmazonS3, AmazonS3Builder, S3ConditionalPut},
+    CopyMode, CopyOptions, Error as ExternalObjectStoreError, GetOptions, GetResult,
+    ObjectStore as ExternalObjectStore, ObjectStoreExt, PutMode, WriteMultipart,
+    aws::{AmazonS3, AmazonS3Builder, S3ConditionalPut, S3CopyIfNotExists},
     path::Path as ObjectStorePath,
 };
 use shardline_protocol::{ByteRange, SecretString, ShardlineHash};
 use thiserror::Error;
 use tokio::{
+    fs::File as TokioFile,
+    io::AsyncReadExt,
     runtime::{Builder, Handle, Runtime},
     task::block_in_place,
 };
@@ -22,6 +37,9 @@ use crate::{
 
 /// Async byte stream returned from ranged S3 reads.
 pub type S3ByteStream = Pin<Box<dyn Stream<Item = Result<Bytes, S3ObjectStoreError>> + Send>>;
+const STREAM_UPLOAD_CHUNK_BYTES: usize = 8 * 1024 * 1024;
+const STREAM_COMPARE_CHUNK_BYTES: usize = 256 * 1024;
+static TEMP_UPLOAD_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// S3-compatible object store configuration.
 #[derive(Clone, PartialEq, Eq)]
@@ -177,6 +195,7 @@ impl S3ObjectStore {
             .with_region(config.region)
             .with_allow_http(config.allow_http)
             .with_virtual_hosted_style_request(config.virtual_hosted_style_request)
+            .with_copy_if_not_exists(S3CopyIfNotExists::Multipart)
             .with_conditional_put(S3ConditionalPut::ETagMatch);
 
         if let Some(endpoint) = config.endpoint {
@@ -278,6 +297,52 @@ impl S3ObjectStore {
         ObjectStorePath::parse(location).map_err(S3ObjectStoreError::Path)
     }
 
+    /// Lists a bounded page of direct child objects under a flat namespace prefix.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`S3ObjectStoreError`] when the underlying object-store listing fails or a
+    /// listed object cannot be represented as a validated direct child under `prefix`.
+    pub fn list_flat_namespace_page(
+        &self,
+        prefix: &ObjectPrefix,
+        start_after: Option<&ObjectKey>,
+        limit: usize,
+    ) -> Result<Vec<ObjectMetadata>, S3ObjectStoreError> {
+        let location = self.location_for_prefix(prefix)?;
+        let start_after = start_after
+            .map(|key| self.location_for_key(key))
+            .transpose()?;
+        self.block_on_result(async {
+            let mut listed = start_after.as_ref().map_or_else(
+                || self.inner.list(Some(&location)),
+                |start_after| self.inner.list_with_offset(Some(&location), start_after),
+            );
+            let mut metadata = Vec::with_capacity(limit);
+            while metadata.len() < limit {
+                let Some(entry) = listed
+                    .try_next()
+                    .await
+                    .map_err(S3ObjectStoreError::External)?
+                else {
+                    break;
+                };
+                let item = self.metadata_from_external(&entry)?;
+                if !item.key().as_str().starts_with(prefix.as_str()) {
+                    continue;
+                }
+                let Some(remainder) = item.key().as_str().strip_prefix(prefix.as_str()) else {
+                    continue;
+                };
+                if remainder.is_empty() || remainder.contains('/') {
+                    continue;
+                }
+                metadata.push(item);
+            }
+            Ok(metadata)
+        })
+    }
+
     /// Streams a validated byte range directly from S3-compatible storage.
     ///
     /// # Errors
@@ -318,6 +383,234 @@ impl S3ObjectStore {
         };
         let key = ObjectKey::parse(key).map_err(|_error| S3ObjectStoreError::InvalidListedKey)?;
         Ok(ObjectMetadata::new(key, metadata.size, None))
+    }
+
+    /// Stores bytes at a key, replacing any existing object.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`S3ObjectStoreError`] when integrity validation or the overwrite
+    /// operation fails.
+    pub fn put_overwrite(
+        &self,
+        key: &ObjectKey,
+        body: ObjectBody<'_>,
+        integrity: &ObjectIntegrity,
+    ) -> Result<(), S3ObjectStoreError> {
+        verify_integrity(body.as_slice(), integrity)?;
+        let location = self.location_for_key(key)?;
+        let bytes = body.into_bytes();
+        self.block_on(
+            self.inner
+                .put_opts(&location, bytes.into(), PutMode::Overwrite.into()),
+        )?;
+        Ok(())
+    }
+
+    /// Streams a caller-validated local file into S3-compatible storage if the destination
+    /// key is absent.
+    ///
+    /// # Errors
+    ///
+    /// Callers are expected to have already validated the file hash before invoking this
+    /// method. The S3 adapter rechecks file length up front and fully compares against an
+    /// existing destination object on conflict.
+    ///
+    /// Returns [`S3ObjectStoreError`] when the local file length does not match the
+    /// supplied integrity metadata, multipart upload fails, or an existing destination
+    /// object conflicts with the file contents.
+    pub fn put_file_if_absent(
+        &self,
+        key: &ObjectKey,
+        path: &Path,
+        integrity: &ObjectIntegrity,
+    ) -> Result<PutOutcome, S3ObjectStoreError> {
+        verify_file_length(path, integrity)?;
+        if let Some(existing) = self.metadata(key)? {
+            return existing_object_outcome_from_file(
+                self,
+                key,
+                existing.length(),
+                path,
+                integrity,
+            );
+        }
+
+        let location = self.location_for_key(key)?;
+        let temporary = temporary_upload_location(&self.key_prefix);
+        let upload_result = self.stream_file_to_location(&temporary, path);
+        if let Err(error) = upload_result {
+            self.delete_location_if_present(&temporary)?;
+            return Err(error);
+        }
+
+        let copy_result = self.block_on(self.inner.copy_opts(
+            &temporary,
+            &location,
+            CopyOptions::new().with_mode(CopyMode::Create),
+        ));
+        self.delete_location_if_present(&temporary)?;
+        match copy_result {
+            Ok(()) => Ok(PutOutcome::Inserted),
+            Err(S3ObjectStoreError::External(ExternalObjectStoreError::AlreadyExists {
+                ..
+            }))
+            | Err(S3ObjectStoreError::External(ExternalObjectStoreError::Precondition {
+                ..
+            })) => {
+                let existing_length = self
+                    .metadata(key)?
+                    .ok_or(S3ObjectStoreError::ExistingObjectConflict)?
+                    .length();
+                existing_object_outcome_from_file(self, key, existing_length, path, integrity)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Streams a caller-validated content-addressed local file directly to its final key.
+    ///
+    /// This path is intended for immutable digest-addressed objects, where concurrent
+    /// writers for the same key can only be writing the same bytes. It avoids the
+    /// temporary-object plus copy step used by [`Self::put_file_if_absent`].
+    ///
+    /// # Errors
+    ///
+    /// Callers are expected to have already validated the file hash before invoking this
+    /// method. The S3 adapter rechecks file length up front and fully compares against an
+    /// existing destination object on conflict.
+    ///
+    /// Returns [`S3ObjectStoreError`] when the local file length does not match the
+    /// supplied integrity metadata, an existing destination object conflicts with the
+    /// file contents, or the multipart upload fails.
+    pub fn put_content_addressed_file(
+        &self,
+        key: &ObjectKey,
+        path: &Path,
+        integrity: &ObjectIntegrity,
+    ) -> Result<PutOutcome, S3ObjectStoreError> {
+        verify_file_length(path, integrity)?;
+        if let Some(existing) = self.metadata(key)? {
+            return existing_object_outcome_from_file(
+                self,
+                key,
+                existing.length(),
+                path,
+                integrity,
+            );
+        }
+
+        let location = self.location_for_key(key)?;
+        self.stream_file_to_location(&location, path)?;
+        Ok(PutOutcome::Inserted)
+    }
+
+    /// Copies an existing object to a new key if the destination key is absent.
+    ///
+    /// This uses the S3-compatible provider's server-side copy path instead of reading
+    /// the full source object back into process memory.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`S3ObjectStoreError`] when the source is missing, the destination
+    /// conflicts with different bytes, or the underlying copy operation fails.
+    pub fn copy_object_if_absent(
+        &self,
+        source: &ObjectKey,
+        destination: &ObjectKey,
+    ) -> Result<PutOutcome, S3ObjectStoreError> {
+        if source == destination {
+            return if self.metadata(source)?.is_some() {
+                Ok(PutOutcome::AlreadyExists)
+            } else {
+                Err(S3ObjectStoreError::External(
+                    ExternalObjectStoreError::NotFound {
+                        path: source.as_str().to_owned(),
+                        source: Box::new(IoError::from(std::io::ErrorKind::NotFound)),
+                    },
+                ))
+            };
+        }
+
+        let Some(source_metadata) = self.metadata(source)? else {
+            return Err(S3ObjectStoreError::External(
+                ExternalObjectStoreError::NotFound {
+                    path: source.as_str().to_owned(),
+                    source: Box::new(IoError::from(std::io::ErrorKind::NotFound)),
+                },
+            ));
+        };
+
+        let source_location = self.location_for_key(source)?;
+        let destination_location = self.location_for_key(destination)?;
+        match self.block_on(self.inner.copy_opts(
+            &source_location,
+            &destination_location,
+            CopyOptions::new().with_mode(CopyMode::Create),
+        )) {
+            Ok(()) => Ok(PutOutcome::Inserted),
+            Err(S3ObjectStoreError::External(ExternalObjectStoreError::AlreadyExists {
+                ..
+            }))
+            | Err(S3ObjectStoreError::External(ExternalObjectStoreError::Precondition {
+                ..
+            })) => existing_copy_outcome(self, source, destination, source_metadata.length()),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn stream_file_to_location(
+        &self,
+        location: &ObjectStorePath,
+        path: &Path,
+    ) -> Result<(), S3ObjectStoreError> {
+        let store = self.inner.clone();
+        let location = location.clone();
+        let path = path.to_path_buf();
+        self.block_on_result(async move {
+            let upload = store.put_multipart(&location).await?;
+            let mut writer = WriteMultipart::new_with_chunk_size(upload, STREAM_UPLOAD_CHUNK_BYTES);
+            let mut file = TokioFile::open(&path)
+                .await
+                .map_err(S3ObjectStoreError::Io)?;
+            let mut buffer = vec![0_u8; STREAM_UPLOAD_CHUNK_BYTES];
+            loop {
+                let read = match file.read(&mut buffer).await {
+                    Ok(read) => read,
+                    Err(error) => {
+                        let _ignored = writer.abort().await;
+                        return Err(S3ObjectStoreError::Io(error));
+                    }
+                };
+                if read == 0 {
+                    break;
+                }
+                let chunk = buffer
+                    .get(..read)
+                    .ok_or(S3ObjectStoreError::IntegrityLengthMismatch)?;
+                writer.write(chunk);
+                if let Err(error) = writer.wait_for_capacity(4).await {
+                    let _ignored = writer.abort().await;
+                    return Err(S3ObjectStoreError::External(error));
+                }
+            }
+            writer
+                .finish()
+                .await
+                .map_err(S3ObjectStoreError::External)?;
+            Ok(())
+        })
+    }
+
+    fn delete_location_if_present(
+        &self,
+        location: &ObjectStorePath,
+    ) -> Result<(), S3ObjectStoreError> {
+        match self.block_on(self.inner.delete(location)) {
+            Ok(()) => Ok(()),
+            Err(S3ObjectStoreError::External(ExternalObjectStoreError::NotFound { .. })) => Ok(()),
+            Err(error) => Err(error),
+        }
     }
 }
 
@@ -583,6 +876,112 @@ fn existing_object_outcome(
     }
 
     Err(S3ObjectStoreError::ExistingObjectConflict)
+}
+
+fn existing_object_outcome_from_file(
+    store: &S3ObjectStore,
+    key: &ObjectKey,
+    existing_length: u64,
+    path: &Path,
+    integrity: &ObjectIntegrity,
+) -> Result<PutOutcome, S3ObjectStoreError> {
+    verify_file_length(path, integrity)?;
+    if existing_length != integrity.length() {
+        return Err(S3ObjectStoreError::ExistingObjectConflict);
+    }
+    let mut file = File::open(path).map_err(S3ObjectStoreError::Io)?;
+    let mut offset = 0_u64;
+    let mut buffer = vec![0_u8; STREAM_COMPARE_CHUNK_BYTES];
+    while offset < existing_length {
+        let remaining = existing_length
+            .checked_sub(offset)
+            .ok_or(S3ObjectStoreError::ExistingObjectConflict)?;
+        let to_read = usize::try_from(remaining.min(STREAM_COMPARE_CHUNK_BYTES as u64))
+            .map_err(|_error| S3ObjectStoreError::ExistingObjectConflict)?;
+        let chunk = buffer
+            .get_mut(..to_read)
+            .ok_or(S3ObjectStoreError::ExistingObjectConflict)?;
+        file.read_exact(chunk).map_err(S3ObjectStoreError::Io)?;
+        let end = offset
+            .checked_add(
+                u64::try_from(to_read)
+                    .map_err(|_error| S3ObjectStoreError::ExistingObjectConflict)?,
+            )
+            .and_then(|value| value.checked_sub(1))
+            .ok_or(S3ObjectStoreError::ExistingObjectConflict)?;
+        let range = ByteRange::new(offset, end)
+            .map_err(|_error| S3ObjectStoreError::ExistingObjectConflict)?;
+        let existing = store.read_range(key, range)?;
+        let expected = buffer
+            .get(..to_read)
+            .ok_or(S3ObjectStoreError::ExistingObjectConflict)?;
+        if existing.as_slice() != expected {
+            return Err(S3ObjectStoreError::ExistingObjectConflict);
+        }
+        offset = end.saturating_add(1);
+    }
+    Ok(PutOutcome::AlreadyExists)
+}
+
+fn existing_copy_outcome(
+    store: &S3ObjectStore,
+    source: &ObjectKey,
+    destination: &ObjectKey,
+    source_length: u64,
+) -> Result<PutOutcome, S3ObjectStoreError> {
+    let Some(destination_metadata) = store.metadata(destination)? else {
+        return Err(S3ObjectStoreError::ExistingObjectConflict);
+    };
+    if destination_metadata.length() != source_length {
+        return Err(S3ObjectStoreError::ExistingObjectConflict);
+    }
+    if source_length == 0 {
+        return Ok(PutOutcome::AlreadyExists);
+    }
+
+    let mut offset = 0_u64;
+    while offset < source_length {
+        let remaining = source_length
+            .checked_sub(offset)
+            .ok_or(S3ObjectStoreError::ExistingObjectConflict)?;
+        let to_read = remaining.min(STREAM_COMPARE_CHUNK_BYTES as u64);
+        let end = offset
+            .checked_add(to_read)
+            .and_then(|value| value.checked_sub(1))
+            .ok_or(S3ObjectStoreError::ExistingObjectConflict)?;
+        let range = ByteRange::new(offset, end)
+            .map_err(|_error| S3ObjectStoreError::ExistingObjectConflict)?;
+        let source_bytes = store.read_range(source, range)?;
+        let destination_bytes = store.read_range(destination, range)?;
+        if source_bytes != destination_bytes {
+            return Err(S3ObjectStoreError::ExistingObjectConflict);
+        }
+        offset = end.saturating_add(1);
+    }
+    Ok(PutOutcome::AlreadyExists)
+}
+
+fn verify_file_length(path: &Path, integrity: &ObjectIntegrity) -> Result<(), S3ObjectStoreError> {
+    let metadata = std::fs::metadata(path).map_err(S3ObjectStoreError::Io)?;
+    if metadata.len() != integrity.length() {
+        return Err(S3ObjectStoreError::IntegrityLengthMismatch);
+    }
+    Ok(())
+}
+
+fn temporary_upload_location(key_prefix: &Option<String>) -> ObjectStorePath {
+    let counter = TEMP_UPLOAD_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let unix_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0_u128, |duration| duration.as_nanos());
+    let relative = format!(
+        "__tmp/shardline-stream-upload/{unix_nanos}-{}-{counter}",
+        std::process::id()
+    );
+    let path = key_prefix
+        .as_ref()
+        .map_or_else(|| relative.clone(), |prefix| format!("{prefix}/{relative}"));
+    ObjectStorePath::from(path)
 }
 
 fn chunk_hash(bytes: &[u8]) -> ShardlineHash {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,15 +1,18 @@
 # Architecture
 
 Shardline is an open, self-hostable content-addressed storage backend with
-Xet-compatible protocol support.
+pluggable protocol frontends.
 It uses a protocol-neutral CAS coordinator with explicit frontend adapters.
 The runtime hosts an explicit frontend set.
-Today, the implemented frontend in that set is the Xet protocol: clients upload xorbs and shards, the
-server verifies and indexes them, and clients later request file reconstruction
-metadata to download only the byte ranges they need.
+Validated frontends in this repository today are Xet, Git LFS, Bazel HTTP remote
+cache, and OCI Distribution.
+They share the same storage, metadata, authorization, lifecycle, and operator
+surface while keeping protocol-specific request shaping and object handling in
+dedicated adapters.
 
 ## Goals
 
+- Speak one or more practical CAS-facing protocols behind a shared backend.
 - Speak the public Xet CAS API closely enough for existing Xet-compatible clients.
 - Reduce repeated upload and storage costs through chunk-level deduplication.
 - Support local and cloud object storage through explicit adapter contracts.
@@ -34,7 +37,7 @@ flowchart TD
     direction TD
     Client[Client]
     Router[Frontend router]
-    Frontends["<b>Frontend set</b><br/>Xet frontend<br/>Future frontends"]
+    Frontends["<b>Frontend set</b><br/>Xet<br/>Git LFS<br/>Bazel HTTP cache<br/>OCI Distribution"]
     Core["<b>Shared server core</b><br/>Auth and scope checks<br/>CAS coordinator<br/>Reconstruction planner<br/>Lifecycle and operator flows"]
     Adapters["<b>Adapters</b><br/>Index and record store<br/>Object store<br/>Reconstruction cache<br/>Provider adapters"]
   end
@@ -58,7 +61,7 @@ flowchart TD
 
 Read it as:
 
-- the router selects one enabled frontend
+- the router selects among the enabled frontends for each request
 - the shared core handles authorization, coordination, reconstruction, and operator
   workflows
 - adapters provide the durable storage, metadata, cache, and provider boundaries
@@ -95,20 +98,33 @@ back to durable metadata and repairs the cache lazily.
 
 ## Public API Surface
 
-The current production server exposes the Xet-compatible CAS API:
+The current production server exposes multiple protocol route families:
 
-- `GET /v1/reconstructions/{file_id}`
-- `GET /v1/chunks/default/{hash}`
-- `POST /v1/xorbs/default/{hash}`
-- `POST /v1/shards`
+- Xet:
+  `GET /v1/reconstructions/{file_id}`,
+  `GET /v1/chunks/default/{hash}`,
+  `POST /v1/xorbs/default/{hash}`,
+  `POST /v1/shards`
+- Git LFS:
+  `POST /v1/lfs/objects/batch`,
+  `GET|HEAD|PUT /v1/lfs/objects/{oid}`
+- Bazel HTTP remote cache:
+  `GET|PUT /v1/bazel/cache/ac/{hash}`,
+  `GET|PUT /v1/bazel/cache/cas/{hash}`
+- OCI Distribution:
+  `GET /v2/`,
+  blob upload and download routes,
+  manifest `PUT|GET|HEAD|DELETE`,
+  `GET /v2/{repository}/tags/list`,
+  `GET /v2/token`
 
 When provider-backed token issuance is enabled, the server also exposes:
 
 - `POST /v1/providers/{provider}/tokens`
 - `POST /v1/providers/{provider}/webhooks`
 
-For storage adapters that cannot issue native presigned URLs, the server also exposes a
-range-enforced transfer endpoint:
+For storage adapters that cannot issue native presigned URLs, the Xet frontend also
+exposes a range-enforced transfer endpoint:
 
 - `GET /transfer/xorb/{prefix}/{hash}`
 
@@ -116,6 +132,13 @@ The Xet-specific route constants, hash/path validation, transfer URL constructio
 reconstruction shaping, and protocol-object ingest flow are intentionally isolated
 inside the server's `xet_adapter` layer rather than spread through generic backend and
 routing code.
+
+Other frontends follow the same pattern:
+
+- protocol-specific route registration at the HTTP edge
+- protocol-specific object-key and request-shape logic inside a dedicated adapter
+- shared authorization, object storage, metadata, cache, fsck, repair, and GC
+  services in the core
 
 The transfer endpoint is an implementation detail.
 Reconstruction responses can point to native presigned object-store URLs when an adapter
@@ -170,10 +193,12 @@ flowchart TD
   linkStyle default stroke:#111827,stroke-width:1.5px;
 ```
 
-`api` serves control-plane endpoints such as reconstruction lookup, provider-backed
-token issuance, and shard registration.
-`transfer` serves the large request and response paths: chunk download, xorb upload, and
-xorb range transfer.
+`api` serves control-plane and metadata-oriented endpoints such as reconstruction
+lookup, provider-backed token issuance, webhook handling, LFS batch negotiation,
+and OCI tag, manifest, and token-service routes.
+`transfer` serves the large request and response paths such as chunk download,
+protocol object upload, blob transfer, cache object transfer, and Xet xorb range
+transfer.
 `all` keeps the single-node behavior and serves both route sets from one process.
 
 ## Source Layout
@@ -206,7 +231,8 @@ flowchart TD
 
 Crate responsibilities:
 
-- `protocol`: Xet protocol types, hashes, ranges, tokens, and protocol validation
+- `protocol`: shared protocol types, generic hashes, ranges, tokens, and small
+  security/time/text helpers
 - `server`: HTTP runtime, frontend hosting, migrations, repair, and GC
 - `cli`: operator entrypoint and command wiring
 - `cas`: protocol-neutral coordination and planning
@@ -228,22 +254,24 @@ should use named files directly; do not introduce `mod.rs` files.
 The server is async-first and streams large request and response bodies.
 It must not buffer full untrusted uploads or full reconstructed downloads in memory
 unless the body is already within an explicit small bound.
-Native Xet uploads do not use server-side `incoming` files or shard parsing workspaces
-on the data path.
-The coordinator consumes bounded request frames, validates protocol objects in memory
-under the configured request-size limit, then commits bytes through the selected
-object-storage adapter.
+The coordinator consumes bounded request frames, validates protocol objects under the
+configured request-size limits, then commits bytes through the selected object-storage
+adapter.
 
 Expected concurrency behavior:
 
-- native xorb and shard upload bodies are capped before Xet validation
-- native shard metadata sections are counted and bounded before per-section records are
+- frontend-specific upload bodies are capped before validation and commit
+- Xet shard metadata sections are counted and bounded before per-section records are
   materialized
+- Git LFS and Bazel HTTP object paths validate digest shape before storage access
+- OCI upload sessions, tag listing, token issuance, and manifest writes are bounded
+  by explicit limits before they reach durable state
 - object writes are idempotent by content hash
-- shard registration uses a transaction in the index store
+- protocol metadata registration uses transactional metadata updates where the
+  frontend requires it
 - reconstruction planning is read-heavy and avoids coarse locks
-- transfer responses stream reconstruction chunks and support range reads and
-  backpressure
+- transfer responses and registry/blob reads stream bytes and support range reads
+  and backpressure
 - local transfer reads use bounded async file buffers after metadata and authorization
   validation
 

--- a/docs/COMPATIBILITY_STATUS.md
+++ b/docs/COMPATIBILITY_STATUS.md
@@ -1,16 +1,24 @@
 # Compatibility Status
 
-Shardline targets the public Xet protocol and the operator workflows needed to run it in
-self-hosted deployments.
+Shardline has a CAS-agnostic runtime with explicit protocol frontends.
+The current compatibility contract is scoped to the protocol and operator
+workflows documented in this repository.
 
 ## 1.0.0 Contract
 
-Shardline `1.0.0` should be treated as a full drop-in Xet backend for the validated
-workflows covered by this repository.
+Shardline `1.0.0` should be treated as a content-addressed backend for the
+validated workflows covered by this repository.
 
 ## Validated Today
 
 - native Xet upload and download flows
+- Git LFS batch negotiation plus direct object upload, download, and metadata
+  lookup routes
+- Bazel HTTP remote-cache `ac` and `cas` read and write routes
+- OCI Distribution blob upload and download, manifest upload and lookup, and tag
+  listing routes
+- native external-client coverage for `git-lfs`, `bazel`/`bazelisk`, and `skopeo`
+  across multiple command-path variants in the repository test matrix
 - provider-issued repository-scoped tokens and provider webhook handling for GitHub,
   GitLab, Gitea, and the generic provider adapter
 - stock `git` + `git-lfs` + `git-xet` push, clone, fetch, pull, and historical checkout
@@ -19,21 +27,36 @@ workflows covered by this repository.
 - local SQLite + filesystem deployments and Postgres + S3-style durable deployments
 - operator workflows for migrations, fsck, lifecycle repair, index rebuild, backup,
   storage migration, retention holds, and garbage collection
-- fuzz coverage for protocol parsing, reconstruction, lifecycle repair, CLI parsing, and
-  local filesystem race boundaries
+- fuzz coverage for protocol parsing, protocol frontend selectors and validators,
+  reconstruction, lifecycle repair, CLI parsing, and local filesystem race boundaries
+
+## Validated Native Clients
+
+| Frontend | Native client coverage |
+| --- | --- |
+| Xet | native Xet upload and download flows, plus `git` + `git-lfs` + `git-xet` push, clone, fetch, pull, historical checkout, and sparse checkout coverage |
+| Git LFS | `git-lfs` push/pull plus separate `pull` and `fetch --all` flows |
+| Bazel HTTP remote cache | `bazel` and `bazelisk` remote-cache flows with `remote_download_outputs=all` and `remote_download_outputs=toplevel` |
+| OCI Distribution | `skopeo` push/pull/tag-list, digest-reference, multi-tag, registry-to-registry copy, multi-arch index, Docker schema2, and token-service credential flow; `helm` OCI chart push/pull; `podman` pull/push; `docker` login/pull/push |
+
+## Validated Route Surface
+
+- Git LFS:
+  batch negotiation plus direct object `GET`, `HEAD`, and `PUT`
+- Bazel HTTP remote cache:
+  `ac` and `cas` object `GET` and `PUT`
+- OCI Distribution:
+  blob `GET`, `HEAD`, upload, mount, and ranged read paths; manifest `PUT`, `GET`,
+  `HEAD`, and digest delete; tag listing with pagination; token-service flow at
+  `/v2/token`; upload cancellation and scoped upload-session handling
 
 ## Current Limits
 
-- Shardline does not claim blanket compatibility across every possible Git workflow,
-  deployment topology, provider setup, or client-version combination.
-- The public claim is intentionally scoped to the Xet-facing protocol and operator
-  surface documented in this repo.
+- Shardline does not claim blanket compatibility across every possible Git
+  workflow, container client, Bazel deployment, deployment topology, provider
+  setup, or client-version combination.
+- Xet and OCI currently have the deepest native-client coverage in this repository.
+- Git LFS, Bazel HTTP remote cache, and OCI Distribution claims are scoped to the
+  route behavior and client flows covered by the repository tests.
 - The first crates.io release still has to publish the internal crate graph in
   dependency order before publishing the `shardline` CLI crate.
-
-## Ongoing Ratchets
-
-- keep expanding protocol-conformance coverage as new native-client behavior is observed
-- keep extending the validated `git` + `git-lfs` + `git-xet` workflow matrix
-- keep adding provider webhook fixtures as new primary-source payload variants are seen
-- keep extending fuzzing, benchmark, and profiling coverage around new hot paths

--- a/docs/PROTOCOLS.md
+++ b/docs/PROTOCOLS.md
@@ -1,0 +1,107 @@
+# Protocol Frontends
+
+Shardline has a protocol-neutral CAS core and explicit frontend adapters.
+
+That means the storage, indexing, authorization, reconstruction, and operator
+workflows are shared, while each client-facing protocol lives behind a bounded
+frontend surface.
+
+## Supported Today
+
+- Xet
+- Git LFS
+- Bazel HTTP remote cache
+- OCI Distribution
+
+## Starting the Server
+
+Shardline enables protocol frontends through the `--frontends` CLI flag. The
+default is `xet`.
+
+Start all currently implemented frontends:
+
+```bash
+shardline serve --role all --frontends xet,lfs,bazel-http,oci
+```
+
+Start only the new non-Xet frontends:
+
+```bash
+shardline serve --role all --frontends lfs,bazel-http,oci
+```
+
+When bearer-token auth is enabled, all enabled frontends use the same
+repository-scoped token model. The environment override is
+`SHARDLINE_SERVER_FRONTENDS`, but the CLI flag is the primary operator-facing
+entry point.
+
+OCI-specific knobs:
+
+- `SHARDLINE_OCI_UPLOAD_SESSION_TTL_SECONDS`
+- `SHARDLINE_OCI_UPLOAD_MAX_ACTIVE_SESSIONS`
+- `SHARDLINE_OCI_REGISTRY_TOKEN_TTL_SECONDS`
+- `SHARDLINE_OCI_REGISTRY_TOKEN_MAX_IN_FLIGHT_REQUESTS`
+
+Current route families:
+
+- Xet: reconstructions, shard upload, xorb upload, chunk transfer, xorb transfer
+- Git LFS: `POST /v1/lfs/objects/batch`, `GET|HEAD|PUT /v1/lfs/objects/{oid}`
+- Bazel HTTP remote cache: `GET|PUT /v1/bazel/cache/ac/{hash}`,
+  `GET|PUT /v1/bazel/cache/cas/{hash}`
+- OCI Distribution: `GET /v2/`, blob upload and download routes, manifest
+  `PUT|GET|HEAD|DELETE`, `GET /v2/{repository}/tags/list`, and `GET /v2/token`
+
+## Client Entry Points
+
+- Xet:
+  native Xet CAS routes plus the provider-aware Git/LFS bridge documented elsewhere
+- Git LFS:
+  point the client at `.../v1/lfs` as the LFS URL
+- Bazel HTTP remote cache:
+  point Bazel at `.../v1/bazel/cache`
+- OCI Distribution:
+  use the server as a registry at `http(s)://<host>/v2/`
+  and authenticate either with direct bearer tokens or the registry token flow at
+  `GET /v2/token`
+
+## Quick Start By Frontend
+
+These are the shortest validated client entry points for the implemented
+frontends.
+
+Git LFS:
+
+```bash
+git config lfs.url http://127.0.0.1:8080/v1/lfs
+git config http.extraHeader "Authorization: Bearer $SHARDLINE_TOKEN"
+git lfs push origin main
+```
+
+Bazel HTTP remote cache:
+
+```bash
+bazel build //... \
+  --remote_cache=http://127.0.0.1:8080/v1/bazel/cache \
+  --remote_header=Authorization=Bearer\ $SHARDLINE_TOKEN
+```
+
+OCI Distribution:
+
+```bash
+skopeo login --username shardline --password "$SHARDLINE_TOKEN" http://127.0.0.1:8080
+skopeo copy oci:./artifact:latest docker://127.0.0.1:8080/team/assets:latest
+```
+
+For local plain-HTTP registries, OCI clients may require their own insecure-registry
+flags or local client configuration.
+
+## CAS-Based Interface Protocols
+
+These are the current CAS-facing protocols implemented in the server.
+
+| Protocol Name | Frontend Flag | Primary Use Case | Addressing Method | Transport Type | Typical Strength |
+| --- | --- | --- | --- | --- | --- |
+| Xet Protocol | `xet` | ML and large-file repositories | Pointer hashes | Custom and HTTP | Reconstruction-oriented large-file backend. |
+| Git LFS | `lfs` | Large file versioning in standard Git workflows | SHA-256 digest | HTTP and JSON | Native interoperability with standard Git LFS clients. |
+| Remote HTTP (Bazel) | `bazel-http` | Developer and CI remote caching | SHA-256 digest paths today | HTTP `GET` and `PUT` | Straightforward shared cache protocol for build artifacts. |
+| OCI Distribution | `oci` | Container images and OCI artifacts | SHA-256 digest | HTTP and REST | Standard registry protocol for Docker, Kubernetes, and OCI artifacts. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Shardline Docs
 
 Shardline is an open, self-hostable content-addressed storage backend with
-Xet-compatible protocol support.
+pluggable protocol frontends.
 
 Use this index to find the shortest path for your task. If you are new to the project,
 start with deployment, then read the protocol or operator docs that match your use case.
@@ -23,6 +23,7 @@ start with deployment, then read the protocol or operator docs that match your u
 
 ## Runtime And Contracts
 
+- [Protocol Frontends](PROTOCOLS.md)
 - [Xet Protocol Conformance](PROTOCOL_CONFORMANCE.md)
 - [Storage Adapters](STORAGE_ADAPTERS.md)
 - [Cache Adapters](CACHE_ADAPTERS.md)


### PR DESCRIPTION
## Description

Add first-class CAS protocol frontends for Git LFS, Bazel HTTP remote cache, and OCI Distribution, and harden the outside-facing server surface so the new protocols are validated end to end instead of remaining Xet-only concepts.

This also de-Xet-centers the front-facing docs, moves remaining Xet-only wire helpers out of the shared protocol crate, adds protocol-focused fuzzing and benchmark coverage, and now explicitly covers mixed-frontend coexistence on one runtime.

## Changes

- Added `lfs`, `bazel-http`, and `oci` frontends to the server router and CLI/frontend configuration surface.
- Implemented LFS, Bazel HTTP cache, and OCI route handlers, object-key helpers, token/query validation, and protocol-specific server behavior.
- Added native-client e2e coverage for `git-lfs`, `bazel`/`bazelisk`, `skopeo`, `helm`, `docker`, and `podman`.
- Added protocol HTTP regression tests, protocol fuzz targets, OCI fixed-work/criterion benches, and S3 fixed-work bench coverage.
- Hardened OCI auth, upload session isolation, pagination, manifest validation, delete semantics, token exchange, and multi-process/shared-root behavior.
- Optimized OCI tag listing, OCI finalize paths, and shared S3 copy/finalize paths with measured benchmark coverage.
- Moved Xet-only xorb/hash helpers out of `crates/protocol` into Xet-specific crates/modules and updated Xet consumers.
- Updated README and docs to describe current supported frontends and exact `--frontends` flag tokens without roadmap phrasing.
- Added a mixed `xet + lfs + bazel-http + oci` runtime test and introduced a shared canonical `sha256` storage path for the digest-addressed raw-object frontends.

For the mixed-frontend follow-up:
- `Git LFS`, `Bazel CAS`, `OCI blobs`, and digest-addressed `OCI manifests` now share a canonical object path under `protocols/shared/sha256/<digest>`.
- Protocol-specific keys alias that shared object instead of storing duplicate whole-file bytes under separate protocol silos.
- `Xet` is covered in the same mixed-runtime regression to prove coexistence on one server/root, but it still uses its native chunk/xorb/shard layout rather than the shared whole-blob path.

Affected crates:
- `cli`, `protocol`, `index`, `server`, `storage`, `fuzz`, `cas` tests

Cross-crate interaction changes:
- protocol routing now spans multiple first-class frontends
- storage/index/server now share OCI/tag/copy/finalize paths and shared digest-addressed object aliasing
- Xet-specific helpers were removed from the generic protocol crate

Migration or rollout requirements:
- none for existing Xet deployments
- new frontends are opt-in through `shardline serve --frontends ...`

## Motivation

Business or operator motivation:
- Let Shardline serve more standard artifact and cache workflows for BaaS/SaaS use cases, especially OCI registries, Git LFS assets, and Bazel remote caching.
- Remove front-facing Xet-only positioning now that the runtime supports broader CAS protocols.
- Avoid avoidable whole-blob duplication across the new digest-addressed frontends when the same artifact arrives through different protocols.

Technical motivation:
- Align the codebase with the CAS-agnostic architecture after the earlier merge.
- Close protocol-surface security gaps before exposing OCI/LFS/Bazel as supported frontends.
- Remove leftover Xet-only code from generic core crates.
- Prove that mixed frontend enablement is safe and does not create route/storage conflicts.

Alternative approaches considered:
- Limiting this branch to docs only: rejected because docs would overstate support without server/runtime/test coverage.
- Implementing REAPI or additional protocols in the same branch: rejected because OCI/LFS/Bazel were the highest-value and most tractable end-to-end set.
- Forcing Xet onto the same raw shared-blob path: rejected for this branch because Xet’s storage model is chunk/xorb/shard based, and a whole-blob bridge would add more complexity than value without workload evidence.

## Scope and impact

- Affected crates: `crates/cli`, `crates/protocol`, `crates/index`, `crates/server`, `crates/storage`, `crates/fuzz`, `crates/cas` tests.
- Protocol or API changes: adds `lfs`, `bazel-http`, and `oci` frontend flags and their HTTP surfaces; adds OCI token endpoint behavior and registry-compatible responses.
- Backward compatibility: existing Xet flows remain covered and passing; new protocol frontends are additive.
- Performance impact:
  - OCI deep tag-list path reduced from ~97-99 ms to ~19-20 ms in bench runs.
  - OCI local finalize and direct S3 finalize paths are faster and cheaper than the previous in-memory/temp-copy paths.
  - identical digest-addressed raw objects are no longer stored separately across LFS/Bazel CAS/OCI keys on the same backend root.
- Security impact: OCI upload sessions, scope checks, token exchange, upload limits, pagination, manifest validation, delete behavior, and auth challenges were audited and hardened; LFS transfer negotiation was tightened.
- Operational impact: operators can now enable explicit frontend mixes with `--frontends`; OCI token TTL/limits and related metrics are configurable.

## Testing

- [x] Unit tests
- [x] Integration tests
- [x] Manual verification
- [x] Performance checks (if applicable)
- [x] Security checks (if applicable)

Commands/results:

```bash
cargo fmt --all --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace --lib --tests
cargo audit
cargo test -p shardline-server --test native_protocol_frontends_e2e -- --nocapture
cargo test -p shardline-server --test native_xet_client_e2e -- --nocapture
cargo test -p shardline-server --test git_xet_push_e2e -- --nocapture
cargo test -p shardline-server --test role_split_e2e -- --nocapture
cargo test -p shardline-server protocol_frontends_http -- --nocapture
cargo bench -p shardline-protocol --bench protocol_core -- --noplot
cargo bench -p shardline-server --bench local_backend -- --noplot
cargo bench -p shardline-server --bench oci_tags -- --noplot
cargo bench -p shardline-server --bench oci_tags_fixed
cargo bench -p shardline-server --bench oci_finalize_fixed
cargo bench -p shardline-storage --bench s3_put_file_fixed
```

Additional coverage added in the follow-up commit:
- mixed `xet + lfs + bazel-http + oci` runtime regression proving coexistence on one server/root
- local-storage assertion that `lfs`, `bazel-http` CAS, and `oci` blob paths resolve to the same underlying inode for identical digest-addressed content

All commands above passed in the final pre-push sweeps for their respective changes.

## Related issues and documentation

- Fixes: n/a
- Related: CAS-agnostic frontend expansion and de-Xet-centering work
- Architecture docs: `docs/ARCHITECTURE.md`
- Protocol docs: `docs/PROTOCOLS.md`
- Security/invariants docs: protocol/security hardening is covered by route tests, fuzz targets, and the updated compatibility/docs set in this branch
- Operations/runbook updates: frontends are documented in `docs/PROTOCOLS.md` and compatibility coverage in `docs/COMPATIBILITY_STATUS.md`

## Reviewer checklist

- [x] Code follows project standards and crate-boundary constraints
- [x] Tests added or updated and passing
- [x] Documentation updated where behavior or config changed
- [x] No undocumented breaking change
- [x] Performance trade-offs documented where relevant
- [x] Security considerations addressed where relevant

## Additional notes

- This branch intentionally scopes protocol expansion to LFS, Bazel HTTP cache, and OCI rather than attempting every CAS-adjacent protocol listed in the docs.
- The repo has explicit bench targets; a literal `cargo bench --workspace` is not used because the fuzz crate would make that path non-finite.
- The shared canonical blob path currently covers the digest-addressed raw-object frontends. `Xet` is validated for coexistence in the same runtime, but not forced into the same raw whole-blob storage path.
