### PR TITLE
perf(server): stream digest uploads to s3 — removes local staging I/O

### DIFF
--- a/crates/server/src/app/protocol_routes.rs
+++ b/crates/server/src/app/protocol_routes.rs
@@ -136,16 +136,11 @@ pub(super) async fn bazel_put_cas(
         &hash,
         auth.as_ref().map(scope_from_auth),
     )?;
-    let mut body = RequestBodyReader::from_body(body, state.config.max_request_body_bytes())?;
-    let bytes = read_body_to_bytes(&mut body).await?;
-    let observed = hex::encode(Sha256::digest(&bytes));
-    if observed != hash {
-        return Err(ServerError::ExpectedBodyHashMismatch);
-    }
-    let _stored =
-        state
-            .backend
-            .put_sha256_addressed_object_bytes_if_absent(&object_key, &hash, bytes)?;
+    let body = RequestBodyReader::from_body(body, state.config.max_request_body_bytes())?;
+    let _stored = state
+        .backend
+        .put_sha256_addressed_object_stream_if_absent(&object_key, &hash, body)
+        .await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -305,16 +300,11 @@ pub(super) async fn lfs_put_object(
 ) -> Result<impl IntoResponse, ServerError> {
     let auth = authorize(&state, &headers, TokenScope::Write)?;
     let object_key = lfs_object_key(&oid, auth.as_ref().map(scope_from_auth))?;
-    let mut body = RequestBodyReader::from_body(body, state.config.max_request_body_bytes())?;
-    let bytes = read_body_to_bytes(&mut body).await?;
-    let observed = hex::encode(Sha256::digest(&bytes));
-    if observed != oid {
-        return Err(ServerError::ExpectedBodyHashMismatch);
-    }
-    let _stored =
-        state
-            .backend
-            .put_sha256_addressed_object_bytes_if_absent(&object_key, &oid, bytes)?;
+    let body = RequestBodyReader::from_body(body, state.config.max_request_body_bytes())?;
+    let _stored = state
+        .backend
+        .put_sha256_addressed_object_stream_if_absent(&object_key, &oid, body)
+        .await?;
     Ok(StatusCode::OK)
 }
 
@@ -701,19 +691,13 @@ async fn oci_post_blob_upload(
 
     if let Some(digest) = query.get("digest") {
         let digest_hex = parse_sha256_digest(digest)?;
-        let mut body = RequestBodyReader::from_body(body, state.config.max_request_body_bytes())?;
-        let bytes = read_body_to_bytes(&mut body).await?;
-        if !bytes.is_empty() {
-            let observed = hex::encode(Sha256::digest(&bytes));
-            if observed != digest_hex {
-                return Err(ServerError::ExpectedBodyHashMismatch);
-            }
+        let body = RequestBodyReader::from_body(body, state.config.max_request_body_bytes())?;
+        if body.expected_total_bytes() != Some(0) {
             let object_key = oci_blob_key(repository, &digest_hex, scope)?;
-            let _stored = state.backend.put_sha256_addressed_object_bytes_if_absent(
-                &object_key,
-                &digest_hex,
-                bytes,
-            )?;
+            let _stored = state
+                .backend
+                .put_sha256_addressed_object_stream_if_absent(&object_key, &digest_hex, body)
+                .await?;
             return oci_created_response(
                 &oci_blob_location(repository, &digest_hex),
                 Some(&digest_hex),

--- a/crates/server/src/backend.rs
+++ b/crates/server/src/backend.rs
@@ -6,8 +6,12 @@ use std::sync::{
 use std::{num::NonZeroUsize, path::PathBuf};
 
 use axum::body::Bytes;
-use shardline_protocol::{ByteRange, RepositoryScope};
-use shardline_storage::{DeleteOutcome, ObjectKey, ObjectMetadata, ObjectPrefix, PutOutcome};
+use sha2::{Digest, Sha256};
+use shardline_protocol::{ByteRange, RepositoryScope, ShardlineHash};
+use shardline_storage::{
+    BeginMultipartUploadResult, DeleteOutcome, ObjectBody, ObjectIntegrity, ObjectKey,
+    ObjectMetadata, ObjectPrefix, PutOutcome,
+};
 #[cfg(test)]
 use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
 
@@ -19,11 +23,13 @@ use crate::{
         FileReconstructionResponse, ServerStatsResponse, ShardUploadResponse, UploadFileResponse,
         XorbUploadResponse,
     },
-    object_store::object_store_from_config,
+    object_store::{ServerObjectStore, object_store_from_config},
+    overflow::checked_add,
+    protocol_support::shared_sha256_object_key,
     reconstruction_cache::{
         ReconstructionCacheBenchReport, benchmark_memory_reconstruction_cache_with_loader,
     },
-    upload_ingest::RequestBodyReader,
+    upload_ingest::{RequestBodyReader, read_body_to_bytes},
 };
 
 #[derive(Debug, Clone)]
@@ -105,6 +111,34 @@ impl ServerBackend {
                 backend
                     .upload_shard_stream(body, repository_scope, shard_metadata_limits)
                     .await
+            }
+        }
+    }
+
+    pub(crate) async fn put_sha256_addressed_object_stream_if_absent(
+        &self,
+        object_key: &ObjectKey,
+        digest_hex: &str,
+        body: RequestBodyReader,
+    ) -> Result<PutOutcome, ServerError> {
+        match self {
+            Self::Local(backend) => {
+                put_sha256_addressed_object_stream_if_absent_with_object_store(
+                    &backend.object_store(),
+                    object_key,
+                    digest_hex,
+                    body,
+                )
+                .await
+            }
+            Self::Postgres(backend) => {
+                put_sha256_addressed_object_stream_if_absent_with_object_store(
+                    &backend.object_store(),
+                    object_key,
+                    digest_hex,
+                    body,
+                )
+                .await
             }
         }
     }
@@ -388,6 +422,68 @@ impl ServerBackend {
         match self {
             Self::Local(backend) => backend.delete_object_if_present(object_key).await,
             Self::Postgres(backend) => backend.delete_object_if_present(object_key).await,
+        }
+    }
+}
+
+async fn put_sha256_addressed_object_stream_if_absent_with_object_store(
+    object_store: &ServerObjectStore,
+    object_key: &ObjectKey,
+    digest_hex: &str,
+    mut body: RequestBodyReader,
+) -> Result<PutOutcome, ServerError> {
+    let canonical_key = shared_sha256_object_key(digest_hex)?;
+    match object_store {
+        ServerObjectStore::S3(store) => {
+            let canonical_outcome =
+                match store.begin_content_addressed_upload(&canonical_key).await? {
+                    BeginMultipartUploadResult::AlreadyExists => PutOutcome::AlreadyExists,
+                    BeginMultipartUploadResult::Upload(mut upload) => {
+                        let mut sha256 = Sha256::new();
+                        let mut total_length = 0_u64;
+                        while let Some(bytes) = body.next_bytes().await? {
+                            sha256.update(&bytes);
+                            total_length = checked_add(total_length, u64::try_from(bytes.len())?)?;
+                            upload.write(&bytes);
+                            if let Err(error) = upload.wait_for_capacity(4).await {
+                                let _ignored = upload.abort().await;
+                                return Err(ServerError::from(error));
+                            }
+                        }
+                        let observed = hex::encode(sha256.finalize());
+                        if observed != digest_hex {
+                            let _ignored = upload.abort().await;
+                            return Err(ServerError::ExpectedBodyHashMismatch);
+                        }
+                        let _total_length = total_length;
+                        upload.finish().await?;
+                        PutOutcome::Inserted
+                    }
+                };
+            if canonical_key == *object_key {
+                return Ok(canonical_outcome);
+            }
+            object_store.copy_if_absent(&canonical_key, object_key)
+        }
+        ServerObjectStore::Local(_) | ServerObjectStore::Blackhole => {
+            let bytes = read_body_to_bytes(&mut body).await?;
+            let observed = hex::encode(Sha256::digest(&bytes));
+            if observed != digest_hex {
+                return Err(ServerError::ExpectedBodyHashMismatch);
+            }
+            let integrity = ObjectIntegrity::new(
+                ShardlineHash::from_bytes(*blake3::hash(&bytes).as_bytes()),
+                u64::try_from(bytes.len())?,
+            );
+            let canonical_outcome = object_store.put_if_absent(
+                &canonical_key,
+                ObjectBody::from_vec(bytes),
+                &integrity,
+            )?;
+            if canonical_key == *object_key {
+                return Ok(canonical_outcome);
+            }
+            object_store.copy_if_absent(&canonical_key, object_key)
         }
     }
 }

--- a/crates/server/src/local_backend.rs
+++ b/crates/server/src/local_backend.rs
@@ -647,7 +647,7 @@ impl LocalBackend {
         })
     }
 
-    fn object_store(&self) -> ServerObjectStore {
+    pub(crate) fn object_store(&self) -> ServerObjectStore {
         self.object_store.clone()
     }
 

--- a/crates/server/src/postgres_backend.rs
+++ b/crates/server/src/postgres_backend.rs
@@ -649,7 +649,7 @@ impl PostgresBackend {
         })
     }
 
-    fn object_store(&self) -> ServerObjectStore {
+    pub(crate) fn object_store(&self) -> ServerObjectStore {
         self.object_store.clone()
     }
 

--- a/crates/server/src/upload_ingest.rs
+++ b/crates/server/src/upload_ingest.rs
@@ -89,6 +89,11 @@ impl RequestBodyReader {
         }
     }
 
+    /// Returns the expected total body size when the transport declared one.
+    pub(crate) const fn expected_total_bytes(&self) -> Option<usize> {
+        self.expected_total_bytes
+    }
+
     /// Reads the next body chunk while enforcing the configured total byte limit.
     pub(crate) async fn next_bytes(&mut self) -> Result<Option<Bytes>, ServerError> {
         let Some(chunk) = self.stream.next().await else {

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -45,5 +45,8 @@ pub use key::{ObjectKey, ObjectKeyError, ObjectPrefix, ObjectPrefixError};
 pub use local::{LocalObjectStore, LocalObjectStoreError};
 pub use local_path::{DirectoryPathError, ensure_directory_path_components_are_not_symlinked};
 pub use object::{DeleteOutcome, ObjectBody, ObjectIntegrity, ObjectMetadata, PutOutcome};
-pub use s3::{S3ByteStream, S3ObjectStore, S3ObjectStoreConfig, S3ObjectStoreError};
+pub use s3::{
+    BeginMultipartUploadResult, S3ByteStream, S3MultipartUploadWriter, S3ObjectStore,
+    S3ObjectStoreConfig, S3ObjectStoreError,
+};
 pub use store::ObjectStore;

--- a/crates/storage/src/s3.rs
+++ b/crates/storage/src/s3.rs
@@ -37,6 +37,67 @@ use crate::{
 
 /// Async byte stream returned from ranged S3 reads.
 pub type S3ByteStream = Pin<Box<dyn Stream<Item = Result<Bytes, S3ObjectStoreError>> + Send>>;
+
+/// Result of beginning a direct multipart upload for an immutable destination key.
+pub enum BeginMultipartUploadResult {
+    /// The destination already exists.
+    AlreadyExists,
+    /// The caller can stream bytes into the returned multipart writer.
+    Upload(S3MultipartUploadWriter),
+}
+
+/// Multipart upload writer for direct request-body streaming into S3-compatible storage.
+pub struct S3MultipartUploadWriter {
+    writer: WriteMultipart,
+}
+
+impl S3MultipartUploadWriter {
+    /// Queues bytes into the multipart writer.
+    pub fn write(&mut self, bytes: &[u8]) {
+        self.writer.write(bytes);
+    }
+
+    /// Waits until the multipart writer has spare upload capacity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`S3ObjectStoreError`] when the upstream multipart writer fails.
+    pub async fn wait_for_capacity(
+        &mut self,
+        max_in_flight_parts: usize,
+    ) -> Result<(), S3ObjectStoreError> {
+        self.writer
+            .wait_for_capacity(max_in_flight_parts)
+            .await
+            .map_err(S3ObjectStoreError::External)
+    }
+
+    /// Finishes the multipart upload.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`S3ObjectStoreError`] when the upstream multipart finalize call fails.
+    pub async fn finish(self) -> Result<(), S3ObjectStoreError> {
+        self.writer
+            .finish()
+            .await
+            .map(|_result| ())
+            .map_err(S3ObjectStoreError::External)
+    }
+
+    /// Aborts the multipart upload.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`S3ObjectStoreError`] when the upstream multipart abort call fails.
+    pub async fn abort(self) -> Result<(), S3ObjectStoreError> {
+        self.writer
+            .abort()
+            .await
+            .map_err(S3ObjectStoreError::External)
+    }
+}
+
 const STREAM_UPLOAD_CHUNK_BYTES: usize = 8 * 1024 * 1024;
 const STREAM_COMPARE_CHUNK_BYTES: usize = 256 * 1024;
 static TEMP_UPLOAD_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -366,6 +427,37 @@ impl S3ObjectStore {
             .map_err(S3ObjectStoreError::External)?;
 
         stream_payload_for_range(result, expected_range)
+    }
+
+    /// Begins a direct multipart upload to a content-addressed destination key.
+    ///
+    /// This path is intended for immutable digest-addressed objects, where callers
+    /// validate the stream contents independently and concurrent writers for the same
+    /// key can only be writing identical bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`S3ObjectStoreError`] when the destination lookup or multipart
+    /// initialization fails.
+    pub async fn begin_content_addressed_upload(
+        &self,
+        key: &ObjectKey,
+    ) -> Result<BeginMultipartUploadResult, S3ObjectStoreError> {
+        if self.metadata(key)?.is_some() {
+            return Ok(BeginMultipartUploadResult::AlreadyExists);
+        }
+
+        let location = self.location_for_key(key)?;
+        let upload = self
+            .inner
+            .put_multipart(&location)
+            .await
+            .map_err(S3ObjectStoreError::External)?;
+        Ok(BeginMultipartUploadResult::Upload(
+            S3MultipartUploadWriter {
+                writer: WriteMultipart::new_with_chunk_size(upload, STREAM_UPLOAD_CHUNK_BYTES),
+            },
+        ))
     }
 
     fn metadata_from_external(


### PR DESCRIPTION
## Description

This PR replaces the temporary-file staging path I added for direct digest-addressed protocol uploads with direct request-body streaming into S3 multipart uploads.

It matters because the previous approach removed the single-request S3 `put` bottleneck, but it still paid local disk I/O overhead by writing each upload to a temporary file and then reading it back. The new path keeps multipart upload for S3 while removing that local staging cost.

## Changes

- `crates/server/src/app/protocol_routes.rs`
  Switched digest-addressed direct upload routes to stream request bodies through a new backend helper instead of staging to local temp files.
  Affected routes: Git LFS object upload, Bazel CAS upload, and OCI direct blob upload via `POST .../blobs/uploads?digest=...`.
- `crates/server/src/backend.rs`
  Added an async helper that handles digest-addressed request-body uploads.
  On S3 it streams directly into multipart upload; on local and blackhole backends it keeps the existing in-memory byte path.
- `crates/storage/src/s3.rs`
  Added a direct multipart upload handle for content-addressed destinations so the server can push request chunks into S3 without disk staging.
- `crates/server/src/upload_ingest.rs`
  Removed the temporary-file staging helper and kept only the bounded body reader and in-memory byte reader helpers.
- `crates/server/src/local_backend.rs`, `crates/server/src/postgres_backend.rs`, `crates/storage/src/lib.rs`
  Minimal plumbing changes to expose the object store and export the new S3 multipart helper type.

For cross-crate or runtime changes, include:

- Affected crates: `server`, `storage`
- Cross-crate interaction changes: `server` now drives digest-addressed S3 multipart uploads by streaming request chunks through a storage-layer multipart writer instead of asking `storage` to upload a staged local file.
- Migration or rollout requirements: none

## Motivation

Business or operator motivation:

- Reduce upload-path overhead for large direct protocol uploads backed by S3.
- Avoid local disk churn on transfer nodes handling digest-addressed object ingestion.

Technical motivation:

- Preserve multipart upload behavior for S3-backed direct uploads.
- Eliminate the extra write-then-read temp-file cycle.
- Keep local backend behavior simple by retaining its existing in-memory path.

Alternative approaches considered:

- Keep local temp-file staging and rely on multipart only after the file is materialized. Rejected because it adds avoidable local I/O.
- Buffer full request bodies in memory for all backends and continue using the existing byte-based S3 write path. Rejected because that would give up multipart upload on the S3 hot path.

## Scope and impact

- Affected crates: `server`, `storage`
- Protocol or API changes: none
- Backward compatibility: preserved
- Performance impact: direct digest-addressed S3 uploads no longer write/read a local temp file before multipart upload; small local-backend behavior remains unchanged
- Security impact: no new trust boundary; digest validation still happens before finalizing digest-addressed writes
- Operational impact: lower local disk activity on S3-backed direct upload routes; no config change

## Testing

- [x] Unit tests
- [x] Integration tests
- [ ] Manual verification
- [x] Performance checks (if applicable)
- [ ] Security checks (if applicable)

Commands/results:

```bash
cargo test -p shardline-server protocol_frontends_http -- --nocapture
cargo make ci
cargo make shardline-bench-ingest -- --scenario initial-upload --iterations 3 --json
```

Results:

- `cargo make ci` passed, including `cargo fmt --check`, workspace clippy with `-D warnings`, nextest, release-binary verification, and `cargo audit`.
- `cargo test -p shardline-server protocol_frontends_http -- --nocapture` passed with 37 protocol frontend tests.
- `cargo make shardline-bench-ingest -- --scenario initial-upload --iterations 3 --json` completed successfully for a small local ingest workload.
  Report highlights:
  - `average_initial_upload_micros`: `355`
  - `average_initial_upload_bytes_per_second`: `2948198687`
  - Workload: `1 MiB` uploads, `64 KiB` chunk size, `3` iterations, local ingest mode

## Related issues and documentation

- Fixes:
- Related:
- Architecture docs: `docs/ARCHITECTURE.md`
- Protocol docs: `docs/PROTOCOL_CONFORMANCE.md`
- Security/invariants docs: `docs/SECURITY_AND_INVARIANTS.md`
- Operations/runbook updates: none required

## Reviewer checklist

- [x] Code follows project standards and crate-boundary constraints
- [x] Tests added or updated and passing
- [x] Documentation updated where behavior or config changed
- [x] No undocumented breaking change
- [x] Performance trade-offs documented where relevant
- [x] Security considerations addressed where relevant

## Additional notes

- This change only affects direct digest-addressed upload routes.
- OCI chunked upload sessions still use their existing persisted upload-session body path; this PR does not change that workflow.
