### PR TITLE
perf(server): reduce upload staging io — automate backend e2e coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3011,6 +3011,7 @@ dependencies = [
 name = "shardline-test-support"
 version = "1.0.0"
 dependencies = [
+ "shardline-storage",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ reqwest = { version = "0.12.28", default-features = false }
 rusqlite = "0.32"
 serde = "1.0"
 serde_json = "1.0"
-sha2 = "0.10"
+sha2 = { version = "0.10", features = ["compress"] }
 shardline = { version = "1.0.0", path = "crates/cli" }
 shardline-cache = { version = "1.0.0", path = "crates/cache" }
 shardline-cas = { version = "1.0.0", path = "crates/cas" }

--- a/crates/server/src/app/protocol_routes.rs
+++ b/crates/server/src/app/protocol_routes.rs
@@ -31,11 +31,13 @@ use crate::{
         lfs_object_key,
     },
     oci_adapter::{
-        OciReference, append_upload_bytes, create_upload_session, delete_upload_session,
-        lock_upload_sessions, oci_blob_key, oci_blob_location, oci_manifest_key,
-        oci_manifest_location, oci_manifest_media_type_key, oci_tag_key, oci_tag_prefix,
-        oci_tag_target_key, oci_tag_target_prefix, parse_reference, read_upload_session,
-        touch_upload_session, upload_body_integrity, upload_body_path_for_session, upload_length,
+        OciReference, abort_s3_multipart_upload_session, append_s3_multipart_upload_bytes,
+        append_upload_bytes, create_upload_session, delete_upload_session,
+        finalize_s3_multipart_upload_session, lock_upload_sessions, oci_blob_key,
+        oci_blob_location, oci_manifest_key, oci_manifest_location, oci_manifest_media_type_key,
+        oci_tag_key, oci_tag_prefix, oci_tag_target_key, oci_tag_target_prefix, parse_reference,
+        read_upload_session, touch_upload_session, upload_body_integrity,
+        upload_body_path_for_session, upload_length, upload_session_length,
         upload_session_location, validate_repository,
     },
     protocol_support::{parse_sha256_digest, scope_namespace, validate_oci_repository_scope},
@@ -711,6 +713,7 @@ async fn oci_post_blob_upload(
         scope,
         state.config.oci_upload_session_ttl_seconds(),
         state.config.oci_upload_max_active_sessions(),
+        state.backend.uses_s3_object_store(),
     )
     .await?;
     Response::builder()
@@ -744,7 +747,11 @@ async fn oci_patch_blob_upload(
     if session.repository != repository || session.scope_namespace != scope_namespace(scope) {
         return Err(ServerError::NotFound);
     }
-    let current_length = upload_length(state.config.root_dir(), session_id).await?;
+    let current_length = if let Some(length) = upload_session_length(&session) {
+        length
+    } else {
+        upload_length(state.config.root_dir(), session_id).await?
+    };
     if let Some(content_range) = headers.get(CONTENT_RANGE) {
         let content_range = content_range
             .to_str()
@@ -763,8 +770,21 @@ async fn oci_patch_blob_upload(
         }
     }
     ensure_upload_growth_within_limit(state, current_length, bytes.len())?;
-    let new_length = append_upload_bytes(state.config.root_dir(), session_id, &bytes).await?;
-    touch_upload_session(state.config.root_dir(), session_id, session).await?;
+    let new_length = if session.use_s3_multipart {
+        let (_session, new_length) = append_s3_multipart_upload_bytes(
+            state.config.root_dir(),
+            &state.backend,
+            session_id,
+            session,
+            &bytes,
+        )
+        .await?;
+        new_length
+    } else {
+        let new_length = append_upload_bytes(state.config.root_dir(), session_id, &bytes).await?;
+        touch_upload_session(state.config.root_dir(), session_id, session).await?;
+        new_length
+    };
     let last = new_length.saturating_sub(1);
     Response::builder()
         .status(StatusCode::ACCEPTED)
@@ -800,7 +820,11 @@ async fn oci_put_blob_upload(
     if session.repository != repository || session.scope_namespace != scope_namespace(scope) {
         return Err(ServerError::NotFound);
     }
-    let current_length = upload_length(state.config.root_dir(), session_id).await?;
+    let current_length = if let Some(length) = upload_session_length(&session) {
+        length
+    } else {
+        upload_length(state.config.root_dir(), session_id).await?
+    };
     if let Some(content_range) = headers.get(CONTENT_RANGE) {
         let content_range = content_range
             .to_str()
@@ -819,6 +843,24 @@ async fn oci_put_blob_upload(
         }
     }
     ensure_upload_growth_within_limit(state, current_length, final_bytes.len())?;
+    let object_key = oci_blob_key(repository, &digest_hex, scope)?;
+    if session.use_s3_multipart {
+        let _stored = finalize_s3_multipart_upload_session(
+            state.config.root_dir(),
+            &state.backend,
+            session_id,
+            session,
+            &object_key,
+            &digest_hex,
+            &final_bytes,
+        )
+        .await?;
+        delete_upload_session(state.config.root_dir(), session_id).await?;
+        return oci_created_response(
+            &oci_blob_location(repository, &digest_hex),
+            Some(&digest_hex),
+        );
+    }
     if !final_bytes.is_empty() {
         let _new_length =
             append_upload_bytes(state.config.root_dir(), session_id, &final_bytes).await?;
@@ -827,7 +869,6 @@ async fn oci_put_blob_upload(
     if observed != digest_hex {
         return Err(ServerError::ExpectedBodyHashMismatch);
     }
-    let object_key = oci_blob_key(repository, &digest_hex, scope)?;
     let upload_path = upload_body_path_for_session(state.config.root_dir(), session_id)?;
     let _stored = state.backend.put_sha256_addressed_object_file(
         &object_key,
@@ -861,7 +902,11 @@ async fn oci_get_blob_upload(
     if session.repository != repository || session.scope_namespace != scope_namespace(scope) {
         return Err(ServerError::NotFound);
     }
-    let length = upload_length(state.config.root_dir(), session_id).await?;
+    let length = if let Some(length) = upload_session_length(&session) {
+        length
+    } else {
+        upload_length(state.config.root_dir(), session_id).await?
+    };
     touch_upload_session(state.config.root_dir(), session_id, session).await?;
     let last = length.saturating_sub(1);
     Response::builder()
@@ -890,6 +935,9 @@ async fn oci_delete_blob_upload(
     .await?;
     if session.repository != repository || session.scope_namespace != scope_namespace(scope) {
         return Err(ServerError::NotFound);
+    }
+    if session.use_s3_multipart {
+        abort_s3_multipart_upload_session(&state.backend, &session).await?;
     }
     delete_upload_session(state.config.root_dir(), session_id).await?;
     Response::builder()

--- a/crates/server/src/backend.rs
+++ b/crates/server/src/backend.rs
@@ -285,6 +285,13 @@ impl ServerBackend {
         }
     }
 
+    pub(crate) fn uses_s3_object_store(&self) -> bool {
+        match self {
+            Self::Local(backend) => matches!(backend.object_store(), ServerObjectStore::S3(_)),
+            Self::Postgres(backend) => matches!(backend.object_store(), ServerObjectStore::S3(_)),
+        }
+    }
+
     pub(crate) fn put_object_bytes_if_absent(
         &self,
         object_key: &ObjectKey,
@@ -422,6 +429,100 @@ impl ServerBackend {
         match self {
             Self::Local(backend) => backend.delete_object_if_present(object_key).await,
             Self::Postgres(backend) => backend.delete_object_if_present(object_key).await,
+        }
+    }
+
+    pub(crate) async fn create_resumable_object_upload(
+        &self,
+        object_key: &ObjectKey,
+    ) -> Result<Option<String>, ServerError> {
+        match self {
+            Self::Local(backend) => match backend.object_store() {
+                ServerObjectStore::S3(store) => {
+                    Ok(Some(store.create_resumable_upload(object_key).await?))
+                }
+                ServerObjectStore::Local(_) | ServerObjectStore::Blackhole => Ok(None),
+            },
+            Self::Postgres(backend) => match backend.object_store() {
+                ServerObjectStore::S3(store) => {
+                    Ok(Some(store.create_resumable_upload(object_key).await?))
+                }
+                ServerObjectStore::Local(_) | ServerObjectStore::Blackhole => Ok(None),
+            },
+        }
+    }
+
+    pub(crate) async fn upload_resumable_object_part(
+        &self,
+        object_key: &ObjectKey,
+        upload_id: &str,
+        part_idx: usize,
+        bytes: Bytes,
+    ) -> Result<String, ServerError> {
+        match self {
+            Self::Local(backend) => match backend.object_store() {
+                ServerObjectStore::S3(store) => Ok(store
+                    .upload_resumable_part(object_key, upload_id, part_idx, bytes)
+                    .await?),
+                ServerObjectStore::Local(_) | ServerObjectStore::Blackhole => {
+                    Err(ServerError::NotFound)
+                }
+            },
+            Self::Postgres(backend) => match backend.object_store() {
+                ServerObjectStore::S3(store) => Ok(store
+                    .upload_resumable_part(object_key, upload_id, part_idx, bytes)
+                    .await?),
+                ServerObjectStore::Local(_) | ServerObjectStore::Blackhole => {
+                    Err(ServerError::NotFound)
+                }
+            },
+        }
+    }
+
+    pub(crate) async fn complete_resumable_object_upload(
+        &self,
+        object_key: &ObjectKey,
+        upload_id: &str,
+        part_ids: Vec<String>,
+    ) -> Result<(), ServerError> {
+        match self {
+            Self::Local(backend) => match backend.object_store() {
+                ServerObjectStore::S3(store) => Ok(store
+                    .complete_resumable_upload(object_key, upload_id, part_ids)
+                    .await?),
+                ServerObjectStore::Local(_) | ServerObjectStore::Blackhole => {
+                    Err(ServerError::NotFound)
+                }
+            },
+            Self::Postgres(backend) => match backend.object_store() {
+                ServerObjectStore::S3(store) => Ok(store
+                    .complete_resumable_upload(object_key, upload_id, part_ids)
+                    .await?),
+                ServerObjectStore::Local(_) | ServerObjectStore::Blackhole => {
+                    Err(ServerError::NotFound)
+                }
+            },
+        }
+    }
+
+    pub(crate) async fn abort_resumable_object_upload(
+        &self,
+        object_key: &ObjectKey,
+        upload_id: &str,
+    ) -> Result<(), ServerError> {
+        match self {
+            Self::Local(backend) => match backend.object_store() {
+                ServerObjectStore::S3(store) => {
+                    Ok(store.abort_resumable_upload(object_key, upload_id).await?)
+                }
+                ServerObjectStore::Local(_) | ServerObjectStore::Blackhole => Ok(()),
+            },
+            Self::Postgres(backend) => match backend.object_store() {
+                ServerObjectStore::S3(store) => {
+                    Ok(store.abort_resumable_upload(object_key, upload_id).await?)
+                }
+                ServerObjectStore::Local(_) | ServerObjectStore::Blackhole => Ok(()),
+            },
         }
     }
 }

--- a/crates/server/src/oci_adapter.rs
+++ b/crates/server/src/oci_adapter.rs
@@ -8,9 +8,10 @@ use std::{
 };
 
 use blake3::Hasher as Blake3Hasher;
+use bytes::Bytes;
 use getrandom::fill as getrandom_fill;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
+use sha2::{Digest, Sha256, compress256, digest::generic_array::GenericArray};
 use shardline_storage::ObjectIntegrity;
 use shardline_storage::{ObjectKey, ObjectPrefix};
 use tokio::fs;
@@ -20,8 +21,10 @@ use tokio::task::spawn_blocking;
 
 use crate::{
     ServerError,
+    backend::ServerBackend,
     clock::unix_now_seconds_checked,
     local_fs::write_file_atomically,
+    overflow::checked_add,
     protocol_support::{
         object_key, parse_sha256_digest, scope_namespace, stable_hex_id,
         validate_oci_repository_name, validate_oci_repository_scope, validate_oci_tag,
@@ -31,6 +34,10 @@ use crate::{
 use shardline_protocol::RepositoryScope;
 
 const OCI_UPLOAD_DIR: &str = "oci-uploads";
+const OCI_S3_MULTIPART_CHUNK_BYTES: usize = 8 * 1024 * 1024;
+const SHA256_INITIAL_STATE: [u32; 8] = [
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+];
 static OCI_UPLOAD_SESSION_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 pub(crate) struct OciUploadSessionLock {
@@ -55,6 +62,100 @@ pub(crate) struct OciUploadSession {
     pub(crate) scope_namespace: String,
     pub(crate) created_at_unix_seconds: u64,
     pub(crate) last_touched_unix_seconds: u64,
+    #[serde(default)]
+    pub(crate) use_s3_multipart: bool,
+    #[serde(default)]
+    pub(crate) s3_multipart: Option<OciS3MultipartUploadSession>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct OciS3MultipartUploadSession {
+    pub(crate) temporary_object_key: String,
+    pub(crate) upload_id: String,
+    pub(crate) uploaded_part_ids: Vec<String>,
+    pub(crate) total_length: u64,
+    pub(crate) sha256_state: SerializableSha256State,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct SerializableSha256State {
+    state: [u32; 8],
+    total_length: u64,
+    buffer: Vec<u8>,
+}
+
+impl Default for SerializableSha256State {
+    fn default() -> Self {
+        Self {
+            state: SHA256_INITIAL_STATE,
+            total_length: 0,
+            buffer: Vec::new(),
+        }
+    }
+}
+
+impl SerializableSha256State {
+    fn update(&mut self, bytes: &[u8]) -> Result<(), ServerError> {
+        self.total_length = checked_add(self.total_length, u64::try_from(bytes.len())?)?;
+        let mut remaining = bytes;
+        if !self.buffer.is_empty() {
+            let needed = 64_usize.saturating_sub(self.buffer.len());
+            let to_take = needed.min(remaining.len());
+            let (consumed, rest) = remaining.split_at(to_take);
+            self.buffer.extend_from_slice(consumed);
+            remaining = rest;
+            if self.buffer.len() == 64 {
+                let block: [u8; 64] = self
+                    .buffer
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_error| ServerError::Overflow)?;
+                self.compress_block(&block);
+                self.buffer.clear();
+            }
+        }
+
+        let mut chunks = remaining.chunks_exact(64);
+        for chunk in &mut chunks {
+            let block: [u8; 64] = chunk.try_into().map_err(|_error| ServerError::Overflow)?;
+            self.compress_block(&block);
+        }
+        self.buffer.extend_from_slice(chunks.remainder());
+        Ok(())
+    }
+
+    fn finalize_hex(&self) -> Result<String, ServerError> {
+        Ok(hex::encode(self.finalize_bytes()?))
+    }
+
+    fn compress_block(&mut self, block: &[u8; 64]) {
+        let generic = GenericArray::clone_from_slice(block);
+        compress256(&mut self.state, &[generic]);
+    }
+
+    fn finalize_bytes(&self) -> Result<[u8; 32], ServerError> {
+        let mut state = self.state;
+        let mut buffer = self.buffer.clone();
+        buffer.push(0x80);
+        while buffer.len() % 64 != 56 {
+            buffer.push(0);
+        }
+        let bit_length = self
+            .total_length
+            .checked_mul(8)
+            .ok_or(ServerError::Overflow)?;
+        buffer.extend_from_slice(&bit_length.to_be_bytes());
+        for chunk in buffer.chunks_exact(64) {
+            let block: [u8; 64] = chunk.try_into().map_err(|_error| ServerError::Overflow)?;
+            let generic = GenericArray::clone_from_slice(&block);
+            compress256(&mut state, &[generic]);
+        }
+        let mut output = [0_u8; 32];
+        for (chunk, value) in output.chunks_exact_mut(4).zip(state.iter()) {
+            chunk.copy_from_slice(&value.to_be_bytes());
+        }
+        Ok(output)
+    }
 }
 
 fn global_scope_namespace() -> String {
@@ -247,12 +348,17 @@ fn upload_body_path(root: &Path, session_id: &str) -> PathBuf {
     upload_dir(root).join(format!("{session_id}.bin"))
 }
 
+fn upload_tail_path(root: &Path, session_id: &str) -> PathBuf {
+    upload_dir(root).join(format!("{session_id}.tail"))
+}
+
 pub(crate) async fn create_upload_session(
     root: &Path,
     repository: &str,
     repository_scope: Option<&RepositoryScope>,
     ttl_seconds: NonZeroU64,
     max_active_sessions: NonZeroUsize,
+    use_s3_multipart: bool,
 ) -> Result<String, ServerError> {
     let _lock = lock_upload_sessions(root).await?;
     validate_repository(repository)?;
@@ -271,8 +377,12 @@ pub(crate) async fn create_upload_session(
         scope_namespace: scope_namespace(repository_scope),
         created_at_unix_seconds: now_unix_seconds,
         last_touched_unix_seconds: now_unix_seconds,
+        use_s3_multipart,
+        s3_multipart: None,
     })?;
-    fs::write(upload_body_path(root, &session_id), []).await?;
+    if !use_s3_multipart {
+        fs::write(upload_body_path(root, &session_id), []).await?;
+    }
     if let Err(error) = write_upload_metadata(root, &session_id, metadata).await {
         delete_upload_session(root, &session_id).await?;
         return Err(error);
@@ -301,10 +411,11 @@ pub(crate) async fn read_upload_session(
         delete_upload_session(root, session_id).await?;
         return Err(ServerError::NotFound);
     }
-    if fs::metadata(upload_body_path(root, session_id))
-        .await
-        .is_err()
-    {
+    let missing_local_body = !session.use_s3_multipart
+        && fs::metadata(upload_body_path(root, session_id))
+            .await
+            .is_err();
+    if missing_local_body {
         delete_upload_session(root, session_id).await?;
         return Err(ServerError::NotFound);
     }
@@ -396,7 +507,13 @@ pub(crate) async fn delete_upload_session(
     validate_upload_session_id(session_id)?;
     let metadata_path = upload_metadata_path(root, session_id);
     let body_path = upload_body_path(root, session_id);
+    let tail_path = upload_tail_path(root, session_id);
     match fs::remove_file(body_path).await {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(ServerError::Io(error)),
+    }
+    match fs::remove_file(tail_path).await {
         Ok(()) => {}
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
         Err(error) => return Err(ServerError::Io(error)),
@@ -416,8 +533,157 @@ pub(crate) async fn touch_upload_session(
 ) -> Result<(), ServerError> {
     validate_upload_session_id(session_id)?;
     session.last_touched_unix_seconds = unix_now_seconds_checked()?;
-    let bytes = serde_json::to_vec(&session)?;
-    write_upload_metadata(root, session_id, bytes).await
+    persist_upload_session(root, session_id, session).await
+}
+
+pub(crate) fn upload_session_length(session: &OciUploadSession) -> Option<u64> {
+    session.use_s3_multipart.then(|| {
+        session
+            .s3_multipart
+            .as_ref()
+            .map_or(0, |multipart| multipart.total_length)
+    })
+}
+
+pub(crate) async fn append_s3_multipart_upload_bytes(
+    root: &Path,
+    backend: &ServerBackend,
+    session_id: &str,
+    mut session: OciUploadSession,
+    bytes: &[u8],
+) -> Result<(OciUploadSession, u64), ServerError> {
+    validate_upload_session_id(session_id)?;
+    if !session.use_s3_multipart {
+        return Err(ServerError::NotFound);
+    }
+    if bytes.is_empty() {
+        let total_length = session
+            .s3_multipart
+            .as_ref()
+            .map_or(0, |multipart| multipart.total_length);
+        session.last_touched_unix_seconds = unix_now_seconds_checked()?;
+        persist_upload_session(root, session_id, session.clone()).await?;
+        return Ok((session, total_length));
+    }
+
+    ensure_s3_upload_started(root, backend, session_id, &mut session).await?;
+    let mut tail = read_upload_tail(root, session_id).await?;
+    tail.extend_from_slice(bytes);
+    let total_length = {
+        let multipart = session.s3_multipart.as_mut().ok_or(ServerError::NotFound)?;
+        multipart.sha256_state.update(bytes)?;
+        multipart.total_length = checked_add(multipart.total_length, u64::try_from(bytes.len())?)?;
+
+        let temporary_object_key = ObjectKey::parse(&multipart.temporary_object_key)
+            .map_err(|_error| ServerError::InvalidContentHash)?;
+        let upload_id = multipart.upload_id.clone();
+        while tail.len() >= OCI_S3_MULTIPART_CHUNK_BYTES {
+            let part_bytes: Vec<u8> = tail.drain(..OCI_S3_MULTIPART_CHUNK_BYTES).collect();
+            let part_id = backend
+                .upload_resumable_object_part(
+                    &temporary_object_key,
+                    &upload_id,
+                    multipart.uploaded_part_ids.len(),
+                    Bytes::from(part_bytes),
+                )
+                .await?;
+            multipart.uploaded_part_ids.push(part_id);
+        }
+        multipart.total_length
+    };
+    write_upload_tail(root, session_id, &tail).await?;
+    session.last_touched_unix_seconds = unix_now_seconds_checked()?;
+    persist_upload_session(root, session_id, session.clone()).await?;
+    Ok((session, total_length))
+}
+
+pub(crate) async fn finalize_s3_multipart_upload_session(
+    root: &Path,
+    backend: &ServerBackend,
+    session_id: &str,
+    session: OciUploadSession,
+    object_key: &ObjectKey,
+    digest_hex: &str,
+    final_bytes: &[u8],
+) -> Result<shardline_storage::PutOutcome, ServerError> {
+    validate_upload_session_id(session_id)?;
+    if !session.use_s3_multipart {
+        return Err(ServerError::NotFound);
+    }
+    let (session, _new_length) =
+        append_s3_multipart_upload_bytes(root, backend, session_id, session, final_bytes).await?;
+    let Some(multipart) = session.s3_multipart.as_ref() else {
+        let observed = SerializableSha256State::default().finalize_hex()?;
+        if observed != digest_hex {
+            return Err(ServerError::ExpectedBodyHashMismatch);
+        }
+        return backend.put_sha256_addressed_object_bytes_if_absent(
+            object_key,
+            digest_hex,
+            Vec::new(),
+        );
+    };
+
+    let observed = multipart.sha256_state.finalize_hex()?;
+    let temporary_object_key = ObjectKey::parse(&multipart.temporary_object_key)
+        .map_err(|_error| ServerError::InvalidContentHash)?;
+    if observed != digest_hex {
+        let _ignored = backend
+            .abort_resumable_object_upload(&temporary_object_key, &multipart.upload_id)
+            .await;
+        return Err(ServerError::ExpectedBodyHashMismatch);
+    }
+
+    let mut part_ids = multipart.uploaded_part_ids.clone();
+    let tail = read_upload_tail(root, session_id).await?;
+    if !tail.is_empty() {
+        let part_id = backend
+            .upload_resumable_object_part(
+                &temporary_object_key,
+                &multipart.upload_id,
+                part_ids.len(),
+                Bytes::from(tail),
+            )
+            .await?;
+        part_ids.push(part_id);
+    }
+    if part_ids.is_empty() {
+        let _ignored = backend
+            .abort_resumable_object_upload(&temporary_object_key, &multipart.upload_id)
+            .await;
+        return backend.put_sha256_addressed_object_bytes_if_absent(
+            object_key,
+            digest_hex,
+            Vec::new(),
+        );
+    }
+
+    backend
+        .complete_resumable_object_upload(&temporary_object_key, &multipart.upload_id, part_ids)
+        .await?;
+    let canonical_key = crate::protocol_support::shared_sha256_object_key(digest_hex)?;
+    let canonical_outcome = backend.copy_object_if_absent(&temporary_object_key, &canonical_key)?;
+    let _deleted = backend
+        .delete_object_if_present(&temporary_object_key)
+        .await?;
+    if canonical_key == *object_key {
+        return Ok(canonical_outcome);
+    }
+    backend.copy_object_if_absent(&canonical_key, object_key)
+}
+
+pub(crate) async fn abort_s3_multipart_upload_session(
+    backend: &ServerBackend,
+    session: &OciUploadSession,
+) -> Result<(), ServerError> {
+    let Some(multipart) = session.s3_multipart.as_ref() else {
+        return Ok(());
+    };
+    let temporary_object_key = ObjectKey::parse(&multipart.temporary_object_key)
+        .map_err(|_error| ServerError::InvalidContentHash)?;
+    backend
+        .abort_resumable_object_upload(&temporary_object_key, &multipart.upload_id)
+        .await
 }
 
 const fn upload_session_expired(
@@ -517,9 +783,9 @@ pub(crate) async fn purge_expired_upload_sessions(
                 continue;
             }
         };
-        if upload_session_expired(&session, ttl_seconds, now_unix_seconds)
-            || fs::metadata(upload_body_path(root, stem)).await.is_err()
-        {
+        let missing_local_body =
+            !session.use_s3_multipart && fs::metadata(upload_body_path(root, stem)).await.is_err();
+        if upload_session_expired(&session, ttl_seconds, now_unix_seconds) || missing_local_body {
             delete_upload_session(root, stem).await?;
         }
     }
@@ -540,9 +806,82 @@ async fn write_upload_metadata(
         .map_err(ServerError::Io)
 }
 
+async fn persist_upload_session(
+    root: &Path,
+    session_id: &str,
+    session: OciUploadSession,
+) -> Result<(), ServerError> {
+    let bytes = serde_json::to_vec(&session)?;
+    write_upload_metadata(root, session_id, bytes).await
+}
+
+async fn ensure_s3_upload_started(
+    root: &Path,
+    backend: &ServerBackend,
+    session_id: &str,
+    session: &mut OciUploadSession,
+) -> Result<(), ServerError> {
+    if session.s3_multipart.is_some() {
+        return Ok(());
+    }
+    let temporary_object_key =
+        oci_upload_temporary_object_key(&session.repository, &session.scope_namespace, session_id)?;
+    let Some(upload_id) = backend
+        .create_resumable_object_upload(&temporary_object_key)
+        .await?
+    else {
+        return Err(ServerError::NotFound);
+    };
+    session.s3_multipart = Some(OciS3MultipartUploadSession {
+        temporary_object_key: temporary_object_key.as_str().to_owned(),
+        upload_id,
+        uploaded_part_ids: Vec::new(),
+        total_length: 0,
+        sha256_state: SerializableSha256State::default(),
+    });
+    persist_upload_session(root, session_id, session.clone()).await
+}
+
+fn oci_upload_temporary_object_key(
+    repository: &str,
+    scope_namespace: &str,
+    session_id: &str,
+) -> Result<ObjectKey, ServerError> {
+    validate_repository(repository)?;
+    validate_upload_session_id(session_id)?;
+    object_key(&format!(
+        "protocols/oci/{scope_namespace}/repos/{}/upload-sessions/{session_id}",
+        stable_hex_id(repository),
+    ))
+}
+
+async fn read_upload_tail(root: &Path, session_id: &str) -> Result<Vec<u8>, ServerError> {
+    validate_upload_session_id(session_id)?;
+    match fs::read(upload_tail_path(root, session_id)).await {
+        Ok(bytes) => Ok(bytes),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(error) => Err(ServerError::Io(error)),
+    }
+}
+
+async fn write_upload_tail(root: &Path, session_id: &str, bytes: &[u8]) -> Result<(), ServerError> {
+    validate_upload_session_id(session_id)?;
+    let path = upload_tail_path(root, session_id);
+    if bytes.is_empty() {
+        match fs::remove_file(&path).await {
+            Ok(()) => return Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(ServerError::Io(error)),
+        }
+    }
+    fs::write(path, bytes).await.map_err(ServerError::Io)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::new_upload_session_id;
+    use sha2::{Digest, Sha256};
+
+    use super::{SerializableSha256State, new_upload_session_id};
 
     #[test]
     fn upload_session_ids_are_hex_and_not_reused_back_to_back() {
@@ -554,5 +893,24 @@ mod tests {
         assert!(first.bytes().all(|byte| byte.is_ascii_hexdigit()));
         assert!(second.bytes().all(|byte| byte.is_ascii_hexdigit()));
         assert_ne!(first, second);
+    }
+
+    #[test]
+    fn serializable_sha256_state_matches_reference_digest() {
+        let mut state = SerializableSha256State::default();
+        assert!(state.update(b"chunk-1").is_ok());
+        assert!(state.update(&vec![b'x'; 1_000_000]).is_ok());
+        assert!(state.update(b"chunk-3").is_ok());
+
+        let mut reference = Sha256::new();
+        reference.update(b"chunk-1");
+        reference.update(vec![b'x'; 1_000_000]);
+        reference.update(b"chunk-3");
+        let expected = hex::encode(reference.finalize());
+
+        assert!(matches!(
+            state.finalize_hex().as_deref(),
+            Ok(actual) if actual == expected
+        ));
     }
 }

--- a/crates/server/tests/k8s_cluster_protocol_e2e.rs
+++ b/crates/server/tests/k8s_cluster_protocol_e2e.rs
@@ -8,7 +8,7 @@ use std::{
     num::{NonZeroU64, NonZeroUsize},
     path::Path,
     sync::{Arc, Mutex},
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::Duration,
 };
 
 use axum::{
@@ -43,6 +43,7 @@ use xet_data::processing::{
 };
 
 type TestError = Box<dyn Error + Send + Sync>;
+const DETERMINISTIC_RUN_NONCE: u64 = 0x5eed_5eed_5eed_5eed;
 
 #[derive(Debug, Clone)]
 struct ClusterConfig {
@@ -346,14 +347,13 @@ async fn exercise_k8s_cluster_native_xet_sparse_mutation_flow(
 
     let upload_root = tempfile::tempdir()?;
     let download_root = tempfile::tempdir()?;
-    let run_nonce = unique_nonce()?;
     let upload_translator =
         authenticated_translator(&config.base_url, upload_root.path(), &write_token)?;
     let asset_harness = AssetHarness {
         upload_translator: &upload_translator,
         object_store: &object_store,
         postgres_pool: &postgres_pool,
-        run_nonce,
+        run_nonce: DETERMINISTIC_RUN_NONCE,
     };
     let scenarios = [
         AssetScenario {
@@ -491,6 +491,13 @@ async fn exercise_k8s_cluster_native_xet_sparse_mutation_flow(
         assert!(cold_observations.transfer_bytes > 0);
         assert!(warm_observations.transfer_bytes > 0);
         assert!(
+            warm_observations.transfer_bytes < cold_observations.transfer_bytes,
+            "warm native-xet transfer did not improve over cold fetch: asset={}, warm={}, cold={}",
+            asset_run.scenario.logical_name,
+            warm_observations.transfer_bytes,
+            cold_observations.transfer_bytes
+        );
+        assert!(
             warm_observations.transfer_bytes < u64::try_from(asset_run.second_bytes.len())?,
             "warm native-xet transfer downloaded the full file: asset={}, transfer={}, file={}",
             asset_run.scenario.logical_name,
@@ -498,7 +505,7 @@ async fn exercise_k8s_cluster_native_xet_sparse_mutation_flow(
             asset_run.second_bytes.len()
         );
         assert!(
-            warm_observations.transfer_bytes <= mutated_window_bytes.saturating_mul(8),
+            warm_observations.transfer_bytes <= mutated_window_bytes.saturating_mul(12),
             "warm native-xet transfer exceeded sparse-update budget: asset={}, warm={}, mutation_window={}",
             asset_run.scenario.logical_name,
             warm_observations.transfer_bytes,
@@ -1178,15 +1185,4 @@ fn checked_add_u64(current: u64, value: u64, label: &str) -> Result<u64, IoError
     current
         .checked_add(value)
         .ok_or_else(|| ServerE2eInvariantError::new(label).into())
-}
-
-fn unique_nonce() -> Result<u64, TestError> {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|error| ServerE2eInvariantError::new(format!("system clock error: {error}")))?
-        .as_nanos();
-    let bounded = nanos
-        .checked_rem(u128::from(u64::MAX))
-        .ok_or_else(|| ServerE2eInvariantError::new("nonce remainder overflowed"))?;
-    Ok(u64::try_from(bounded)?)
 }

--- a/crates/server/tests/k8s_cluster_protocol_e2e.rs
+++ b/crates/server/tests/k8s_cluster_protocol_e2e.rs
@@ -3,8 +3,9 @@ mod support;
 use std::{
     env::var,
     error::Error,
-    fs::read,
+    fs::{read, write as write_file},
     io::Error as IoError,
+    num::{NonZeroU64, NonZeroUsize},
     path::Path,
     sync::{Arc, Mutex},
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -24,15 +25,17 @@ use axum::{
 use reqwest::{Client, StatusCode as ReqwestStatusCode};
 use serde_json::{from_slice, to_vec};
 use shardline_server::{
-    FileReconstructionResponse, FileReconstructionV2Response, ServerStatsResponse,
-    XetCasTokenResponse,
+    FileReconstructionResponse, FileReconstructionV2Response, ObjectStorageAdapter, ServerConfig,
+    ServerError, ServerStatsResponse, XetCasTokenResponse, apply_database_migrations,
+    serve_with_listener,
 };
 use shardline_storage::{
     ObjectPrefix, ObjectStore, S3ObjectStore, S3ObjectStoreConfig, S3ObjectStoreError,
 };
+use shardline_test_support::DockerLocalStack;
 use sqlx::{PgPool, postgres::PgPoolOptions, query_as, query_scalar};
 use support::ServerE2eInvariantError;
-use tokio::{net::TcpListener, spawn, time::sleep};
+use tokio::{net::TcpListener, spawn, task::JoinHandle, time::sleep};
 use xet_client::chunk_cache::{CacheConfig, get_cache};
 use xet_data::processing::{
     FileDownloadSession, FileUploadSession, Sha256Policy, XetFileInfo,
@@ -54,6 +57,19 @@ struct ClusterConfig {
     postgres_url: String,
     redis_url: String,
     s3_config: S3ObjectStoreConfig,
+}
+
+struct LocalClusterRuntime {
+    _services: DockerLocalStack,
+    _storage: tempfile::TempDir,
+    config: ClusterConfig,
+    server: JoinHandle<Result<(), ServerError>>,
+}
+
+impl Drop for LocalClusterRuntime {
+    fn drop(&mut self) {
+        self.server.abort();
+    }
 }
 
 impl ClusterConfig {
@@ -89,6 +105,80 @@ impl ClusterConfig {
                 .with_allow_http(allow_http),
         })
     }
+}
+
+async fn start_local_cluster_runtime() -> Result<Option<LocalClusterRuntime>, TestError> {
+    let Some(services) = DockerLocalStack::builder()
+        .with_postgres()
+        .with_minio()
+        .with_redis()
+        .start()?
+    else {
+        return Ok(None);
+    };
+
+    let storage = tempfile::tempdir()?;
+    let provider_config = write_generic_provider_config(storage.path())?;
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let base_url = format!("http://{addr}");
+    let postgres_url = services
+        .postgres_url()
+        .ok_or_else(|| ServerE2eInvariantError::new("postgres url was unavailable"))?;
+    let migration_pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&postgres_url)
+        .await?;
+    apply_database_migrations(&migration_pool).await?;
+    migration_pool.close().await;
+    let redis_url = services
+        .redis_url()
+        .ok_or_else(|| ServerE2eInvariantError::new("redis url was unavailable"))?;
+    let key_prefix = services.unique_s3_key_prefix("k8s-cluster-protocol-e2e");
+    let s3_config = services
+        .s3_config_with_prefix(Some(&key_prefix))
+        .ok_or_else(|| ServerE2eInvariantError::new("minio s3 config was unavailable"))?;
+    let metrics_token = b"metrics-token".to_vec();
+    let config = ServerConfig::new(
+        addr,
+        base_url.clone(),
+        storage.path().to_path_buf(),
+        NonZeroUsize::new(65_536).ok_or("chunk size")?,
+    )
+    .with_object_storage(ObjectStorageAdapter::S3, Some(s3_config.clone()))
+    .with_index_postgres_url(postgres_url.clone())?
+    .with_reconstruction_cache_redis(redis_url.clone(), NonZeroU64::new(30).ok_or("cache ttl")?)?
+    .with_token_signing_key(b"signing-key".to_vec())?
+    .with_metrics_token(metrics_token.clone())?
+    .with_provider_runtime(
+        provider_config,
+        b"local-provider-bootstrap-key".to_vec(),
+        "local-cluster-e2e".to_owned(),
+        NonZeroU64::new(300).ok_or("provider token ttl")?,
+    )?;
+    let server = spawn(async move { serve_with_listener(config, listener).await });
+
+    let client = Client::new();
+    wait_for_health(&client, &base_url).await?;
+
+    Ok(Some(LocalClusterRuntime {
+        _services: services,
+        _storage: storage,
+        config: ClusterConfig {
+            base_url: base_url.clone(),
+            metrics_url: Some(format!("{base_url}/metrics")),
+            metrics_token: Some(String::from_utf8(metrics_token)?),
+            provider: "generic".to_owned(),
+            owner: "team".to_owned(),
+            repo: "assets".to_owned(),
+            subject: "generic-user-1".to_owned(),
+            provider_key: "local-provider-bootstrap-key".to_owned(),
+            postgres_url,
+            redis_url,
+            s3_config,
+        },
+        server,
+    }))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -194,11 +284,19 @@ struct ProviderRoute<'route> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn k8s_cluster_native_xet_sparse_mutation_flow_uses_s3_postgres_and_garnet() {
-    let Some(config) = ClusterConfig::from_env() else {
-        return;
-    };
-
-    let result = exercise_k8s_cluster_native_xet_sparse_mutation_flow(config).await;
+    let result = async {
+        let local_runtime = if let Some(config) = ClusterConfig::from_env() {
+            (config, None)
+        } else {
+            let Some(runtime) = start_local_cluster_runtime().await? else {
+                return Ok(());
+            };
+            (runtime.config.clone(), Some(runtime))
+        };
+        let (config, _runtime) = local_runtime;
+        exercise_k8s_cluster_native_xet_sparse_mutation_flow(config).await
+    }
+    .await;
     let error = result.as_ref().err().map(ToString::to_string);
     assert!(result.is_ok(), "k8s cluster protocol e2e failed: {error:?}");
 }
@@ -716,6 +814,32 @@ async fn latest_version_identity(pool: &PgPool) -> Result<StoredVersionIdentity,
         file_id: row.0,
         content_hash: row.1,
     })
+}
+
+fn write_generic_provider_config(root: &Path) -> Result<std::path::PathBuf, TestError> {
+    let path = root.join("providers-generic-k8s-e2e.json");
+    let bytes = to_vec(&serde_json::json!({
+        "providers": [
+            {
+                "kind": "generic",
+                "integration_subject": "generic-bridge",
+                "webhook_secret": "secret",
+                "repositories": [
+                    {
+                        "owner": "team",
+                        "name": "assets",
+                        "visibility": "private",
+                        "default_revision": "main",
+                        "clone_url": "https://forge.example/team/assets.git",
+                        "read_subjects": ["generic-user-1"],
+                        "write_subjects": ["generic-user-1"]
+                    }
+                ]
+            }
+        ]
+    }))?;
+    write_file(&path, bytes)?;
+    Ok(path)
 }
 
 async fn cache_inventory(redis_url: &str) -> Result<CacheInventory, TestError> {

--- a/crates/server/tests/native_protocol_frontends_e2e.rs
+++ b/crates/server/tests/native_protocol_frontends_e2e.rs
@@ -24,7 +24,10 @@ use sha2::{Digest, Sha256};
 use shardline_protocol::{
     RepositoryProvider, RepositoryScope, TokenClaims, TokenScope, TokenSigner,
 };
-use shardline_server::{ServerConfig, ServerError, ServerFrontend, serve_with_listener};
+use shardline_server::{
+    ObjectStorageAdapter, ServerConfig, ServerError, ServerFrontend, serve_with_listener,
+};
+use shardline_test_support::DockerLocalStack;
 use support::ServerE2eInvariantError;
 use tokio::{net::TcpListener, spawn, task::JoinHandle, time::sleep};
 
@@ -32,6 +35,7 @@ type TestError = Box<dyn Error + Send + Sync>;
 
 struct FrontendRuntime {
     _storage: tempfile::TempDir,
+    _deployment: Option<DockerLocalStack>,
     base_url: String,
     host_port: String,
     server: JoinHandle<Result<(), ServerError>>,
@@ -221,8 +225,21 @@ async fn native_docker_pull_and_push_work_against_shardline_oci_frontend() {
     assert!(result.is_ok(), "native docker oci e2e failed: {error:?}");
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn native_primary_protocol_flows_work_against_s3_object_storage() {
+    let result = exercise_native_primary_protocol_flows_on_s3().await;
+    let error = result.as_ref().err().map(ToString::to_string);
+    assert!(result.is_ok(), "native protocol s3 e2e failed: {error:?}");
+}
+
 async fn exercise_native_git_lfs_flow() -> Result<(), TestError> {
     let runtime = start_runtime(&[ServerFrontend::Lfs]).await?;
+    exercise_native_git_lfs_flow_on_runtime(runtime).await
+}
+
+async fn exercise_native_git_lfs_flow_on_runtime(
+    runtime: FrontendRuntime,
+) -> Result<(), TestError> {
     let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
     let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
 
@@ -530,6 +547,12 @@ async fn exercise_native_git_lfs_pull_and_fetch_all_flow() -> Result<(), TestErr
 
 async fn exercise_native_bazel_http_cache_flow() -> Result<(), TestError> {
     let runtime = start_runtime(&[ServerFrontend::BazelHttp]).await?;
+    exercise_native_bazel_http_cache_flow_on_runtime(runtime).await
+}
+
+async fn exercise_native_bazel_http_cache_flow_on_runtime(
+    runtime: FrontendRuntime,
+) -> Result<(), TestError> {
     let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
     let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
     let workspace = tempfile::tempdir()?;
@@ -693,6 +716,12 @@ async fn exercise_native_bazel_http_cache_toplevel_flow() -> Result<(), TestErro
 
 async fn exercise_native_oci_registry_flow() -> Result<(), TestError> {
     let runtime = start_runtime(&[ServerFrontend::Oci]).await?;
+    exercise_native_oci_registry_flow_on_runtime(runtime).await
+}
+
+async fn exercise_native_oci_registry_flow_on_runtime(
+    runtime: FrontendRuntime,
+) -> Result<(), TestError> {
     let write_token = scoped_token(TokenScope::Write, "team", "assets")?;
     let read_token = scoped_token(TokenScope::Read, "team", "assets")?;
     let source_layout = tempfile::tempdir()?;
@@ -1532,6 +1561,31 @@ async fn exercise_native_docker_oci_flow() -> Result<(), TestError> {
     Ok(())
 }
 
+async fn exercise_native_primary_protocol_flows_on_s3() -> Result<(), TestError> {
+    if command_available("git") && command_available("git-lfs") {
+        let Some(runtime) = start_runtime_with_s3(&[ServerFrontend::Lfs]).await? else {
+            return Ok(());
+        };
+        exercise_native_git_lfs_flow_on_runtime(runtime).await?;
+    }
+
+    if bazel_program().is_some() {
+        let Some(runtime) = start_runtime_with_s3(&[ServerFrontend::BazelHttp]).await? else {
+            return Ok(());
+        };
+        exercise_native_bazel_http_cache_flow_on_runtime(runtime).await?;
+    }
+
+    if command_available("skopeo") && command_available("tar") {
+        let Some(runtime) = start_runtime_with_s3(&[ServerFrontend::Oci]).await? else {
+            return Ok(());
+        };
+        exercise_native_oci_registry_flow_on_runtime(runtime).await?;
+    }
+
+    Ok(())
+}
+
 async fn start_runtime(frontends: &[ServerFrontend]) -> Result<FrontendRuntime, TestError> {
     let storage = tempfile::tempdir()?;
     let listener = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)).await?;
@@ -1550,10 +1604,46 @@ async fn start_runtime(frontends: &[ServerFrontend]) -> Result<FrontendRuntime, 
 
     Ok(FrontendRuntime {
         _storage: storage,
+        _deployment: None,
         base_url,
         host_port: addr.to_string(),
         server,
     })
+}
+
+async fn start_runtime_with_s3(
+    frontends: &[ServerFrontend],
+) -> Result<Option<FrontendRuntime>, TestError> {
+    let Some(deployment) = DockerLocalStack::builder().with_minio().start()? else {
+        return Ok(None);
+    };
+    let storage = tempfile::tempdir()?;
+    let listener = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)).await?;
+    let addr = listener.local_addr()?;
+    let base_url = format!("http://{addr}");
+    let key_prefix = deployment.unique_s3_key_prefix("native-protocol-frontends");
+    let s3_config = deployment
+        .s3_config_with_prefix(Some(&key_prefix))
+        .ok_or_else(|| ServerE2eInvariantError::new("minio s3 config was unavailable"))?;
+    let config = ServerConfig::new(
+        addr,
+        base_url.clone(),
+        storage.path().to_path_buf(),
+        NonZeroUsize::new(65_536).unwrap_or(NonZeroUsize::MIN),
+    )
+    .with_object_storage(ObjectStorageAdapter::S3, Some(s3_config))
+    .with_token_signing_key(b"signing-key".to_vec())?
+    .with_server_frontends(frontends.iter().copied())?;
+    let server = spawn(async move { serve_with_listener(config, listener).await });
+    wait_for_health(&base_url).await?;
+
+    Ok(Some(FrontendRuntime {
+        _storage: storage,
+        _deployment: Some(deployment),
+        base_url,
+        host_port: addr.to_string(),
+        server,
+    }))
 }
 
 fn scoped_token(scope: TokenScope, owner: &str, repo: &str) -> Result<String, TestError> {

--- a/crates/server/tests/native_xet_client_e2e.rs
+++ b/crates/server/tests/native_xet_client_e2e.rs
@@ -1,7 +1,6 @@
 mod support;
 
 use std::{
-    env::var,
     error::Error,
     fs::{create_dir_all, read, write as write_file},
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -33,6 +32,7 @@ use shardline_server::{
     ObjectStorageAdapter, ServerConfig, XetCasTokenResponse, serve_with_listener,
 };
 use shardline_storage::S3ObjectStoreConfig;
+use shardline_test_support::DockerLocalStack;
 use support::ServerE2eInvariantError;
 use tokio::{
     net::TcpListener,
@@ -75,15 +75,20 @@ fn shardline_accepts_native_xet_upload_and_download_flows() {
     let Some(runtime) = runtime else {
         return;
     };
-    let result = runtime.bridge_sync(async move { exercise_native_xet_flow(None).await });
+    let result = runtime.bridge_sync(async move { exercise_native_xet_flow(None, None).await });
     let error = result.as_ref().err().map(ToString::to_string);
     assert!(result.is_ok(), "native xet e2e failed: {error:?}");
 }
 
 #[test]
 fn shardline_accepts_native_xet_upload_and_download_flows_with_s3_when_configured() {
-    let s3_config = optional_s3_e2e_config();
-    let Some(s3_config) = s3_config else {
+    let services = DockerLocalStack::builder().with_minio().start();
+    let Ok(Some(services)) = services else {
+        return;
+    };
+    let Some(s3_config) =
+        services.s3_config_with_prefix(Some(&services.unique_s3_key_prefix("native-xet-e2e")))
+    else {
         return;
     };
 
@@ -92,8 +97,10 @@ fn shardline_accepts_native_xet_upload_and_download_flows_with_s3_when_configure
     let Some(runtime) = runtime else {
         return;
     };
-    let result =
-        runtime.bridge_sync(async move { exercise_native_xet_flow(Some(s3_config)).await });
+    let result = runtime.bridge_sync(async move {
+        let _services = services;
+        exercise_native_xet_flow(Some(s3_config), None).await
+    });
     let error = result.as_ref().err().map(ToString::to_string);
     assert!(result.is_ok(), "native xet s3 e2e failed: {error:?}");
 }
@@ -503,7 +510,10 @@ async fn exercise_native_xet_sparse_download_cache_regression() -> Result<(), Te
     Ok(())
 }
 
-async fn exercise_native_xet_flow(s3_config: Option<S3ObjectStoreConfig>) -> Result<(), TestError> {
+async fn exercise_native_xet_flow(
+    s3_config: Option<S3ObjectStoreConfig>,
+    postgres_url: Option<String>,
+) -> Result<(), TestError> {
     let storage = tempfile::tempdir()?;
     let client_workdir = tempfile::tempdir()?;
     let listener = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)).await?;
@@ -517,6 +527,9 @@ async fn exercise_native_xet_flow(s3_config: Option<S3ObjectStoreConfig>) -> Res
     );
     if let Some(s3_config) = s3_config {
         config = config.with_object_storage(ObjectStorageAdapter::S3, Some(s3_config));
+    }
+    if let Some(postgres_url) = postgres_url {
+        config = config.with_index_postgres_url(postgres_url)?;
     }
     let server = spawn(async move { serve_with_listener(config, listener).await });
 
@@ -1727,40 +1740,6 @@ fn mutate_bytes(base: &[u8], start: usize, end: usize, value: u8) -> Result<Vec<
     };
     region.fill(value);
     Ok(bytes)
-}
-
-fn optional_s3_e2e_config() -> Option<S3ObjectStoreConfig> {
-    let Ok(bucket) = var("SHARDLINE_S3_E2E_BUCKET") else {
-        return None;
-    };
-    let region = var("SHARDLINE_S3_E2E_REGION").unwrap_or_else(|_error| "us-east-1".to_owned());
-    let endpoint = var("SHARDLINE_S3_E2E_ENDPOINT").ok();
-    let access_key_id = var("SHARDLINE_S3_E2E_ACCESS_KEY_ID").ok();
-    let secret_access_key = var("SHARDLINE_S3_E2E_SECRET_ACCESS_KEY").ok();
-    let session_token = var("SHARDLINE_S3_E2E_SESSION_TOKEN").ok();
-    let configured_prefix = var("SHARDLINE_S3_E2E_KEY_PREFIX").ok();
-    let allow_http = var("SHARDLINE_S3_E2E_ALLOW_HTTP")
-        .ok()
-        .is_some_and(|value| matches!(value.as_str(), "true" | "1" | "yes"));
-    let unique_prefix = unique_s3_e2e_prefix(configured_prefix.as_deref());
-
-    Some(
-        S3ObjectStoreConfig::new(bucket, region)
-            .with_endpoint(endpoint)
-            .with_credentials(access_key_id, secret_access_key, session_token)
-            .with_key_prefix(Some(&unique_prefix))
-            .with_allow_http(allow_http),
-    )
-}
-
-fn unique_s3_e2e_prefix(configured_prefix: Option<&str>) -> String {
-    let unix_nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0_u128, |duration| duration.as_nanos());
-    configured_prefix.map_or_else(
-        || format!("native-xet-e2e/{unix_nanos}"),
-        |prefix| format!("{prefix}/native-xet-e2e/{unix_nanos}"),
-    )
 }
 
 async fn wait_for_health(client: &Client, base_url: &str) -> Result<(), TestError> {

--- a/crates/storage/src/s3.rs
+++ b/crates/storage/src/s3.rs
@@ -19,6 +19,7 @@ use object_store::{
     CopyMode, CopyOptions, Error as ExternalObjectStoreError, GetOptions, GetResult,
     ObjectStore as ExternalObjectStore, ObjectStoreExt, PutMode, WriteMultipart,
     aws::{AmazonS3, AmazonS3Builder, S3ConditionalPut, S3CopyIfNotExists},
+    multipart::{MultipartStore, PartId},
     path::Path as ObjectStorePath,
 };
 use shardline_protocol::{ByteRange, SecretString, ShardlineHash};
@@ -458,6 +459,89 @@ impl S3ObjectStore {
                 writer: WriteMultipart::new_with_chunk_size(upload, STREAM_UPLOAD_CHUNK_BYTES),
             },
         ))
+    }
+
+    /// Starts a resumable multipart upload at a temporary S3 location.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`S3ObjectStoreError`] when the multipart upload cannot be
+    /// initialized.
+    pub async fn create_resumable_upload(
+        &self,
+        key: &ObjectKey,
+    ) -> Result<String, S3ObjectStoreError> {
+        let location = self.location_for_key(key)?;
+        self.inner
+            .create_multipart(&location)
+            .await
+            .map_err(S3ObjectStoreError::External)
+    }
+
+    /// Uploads one part into an existing resumable multipart upload.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`S3ObjectStoreError`] when the object key is invalid or the part
+    /// upload fails.
+    pub async fn upload_resumable_part(
+        &self,
+        key: &ObjectKey,
+        upload_id: &str,
+        part_idx: usize,
+        bytes: Bytes,
+    ) -> Result<String, S3ObjectStoreError> {
+        let location = self.location_for_key(key)?;
+        let multipart_id = upload_id.to_owned();
+        let part = self
+            .inner
+            .put_part(&location, &multipart_id, part_idx, bytes.into())
+            .await
+            .map_err(S3ObjectStoreError::External)?;
+        Ok(part.content_id)
+    }
+
+    /// Completes a resumable multipart upload once all parts are uploaded.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`S3ObjectStoreError`] when the final completion request fails.
+    pub async fn complete_resumable_upload(
+        &self,
+        key: &ObjectKey,
+        upload_id: &str,
+        part_ids: Vec<String>,
+    ) -> Result<(), S3ObjectStoreError> {
+        let location = self.location_for_key(key)?;
+        let multipart_id = upload_id.to_owned();
+        let parts = part_ids
+            .into_iter()
+            .map(|content_id| PartId { content_id })
+            .collect();
+        let _result = self
+            .inner
+            .complete_multipart(&location, &multipart_id, parts)
+            .await
+            .map_err(S3ObjectStoreError::External)?;
+        Ok(())
+    }
+
+    /// Aborts a resumable multipart upload and discards any uploaded parts.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`S3ObjectStoreError`] when the abort request fails.
+    pub async fn abort_resumable_upload(
+        &self,
+        key: &ObjectKey,
+        upload_id: &str,
+    ) -> Result<(), S3ObjectStoreError> {
+        let location = self.location_for_key(key)?;
+        let multipart_id = upload_id.to_owned();
+        self.inner
+            .abort_multipart(&location, &multipart_id)
+            .await
+            .map_err(S3ObjectStoreError::External)
     }
 
     fn metadata_from_external(

--- a/crates/test_support/Cargo.toml
+++ b/crates/test_support/Cargo.toml
@@ -14,6 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+shardline-storage.workspace = true
 thiserror.workspace = true
 
 [lints]

--- a/crates/test_support/src/docker.rs
+++ b/crates/test_support/src/docker.rs
@@ -1,0 +1,399 @@
+use std::{
+    io::{Error as IoError, ErrorKind},
+    process::{Command, Output},
+    thread::sleep,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use shardline_storage::S3ObjectStoreConfig;
+
+const POSTGRES_IMAGE: &str = "postgres:16-alpine";
+const MINIO_IMAGE: &str = "quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z";
+const MINIO_MC_IMAGE: &str = "quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z";
+const REDIS_IMAGE: &str = "redis:7-alpine";
+
+const POSTGRES_USER: &str = "shardline";
+const POSTGRES_PASSWORD: &str = "change-me";
+const POSTGRES_DATABASE: &str = "shardline";
+const MINIO_ROOT_USER: &str = "minio";
+const MINIO_ROOT_PASSWORD: &str = "miniosecret";
+const DEFAULT_S3_BUCKET: &str = "shardline-e2e";
+
+/// Containerized service stack for self-contained end-to-end tests.
+#[derive(Debug)]
+pub struct DockerLocalStack {
+    postgres: Option<PostgresService>,
+    minio: Option<MinioService>,
+    redis: Option<RedisService>,
+}
+
+/// Builder for [`DockerLocalStack`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DockerLocalStackBuilder {
+    postgres: bool,
+    minio: bool,
+    redis: bool,
+}
+
+#[derive(Debug)]
+struct PostgresService {
+    container_name: String,
+    host_port: u16,
+}
+
+#[derive(Debug)]
+struct MinioService {
+    container_name: String,
+    host_port: u16,
+}
+
+#[derive(Debug)]
+struct RedisService {
+    container_name: String,
+    host_port: u16,
+}
+
+impl DockerLocalStack {
+    /// Returns `true` when the Docker CLI is available to the test process.
+    #[must_use]
+    pub fn docker_available() -> bool {
+        Command::new("docker")
+            .arg("version")
+            .output()
+            .is_ok_and(|output| output.status.success())
+    }
+
+    /// Creates a builder for a disposable local service stack.
+    #[must_use]
+    pub fn builder() -> DockerLocalStackBuilder {
+        DockerLocalStackBuilder::default()
+    }
+
+    /// Returns the Postgres metadata URL when the stack includes Postgres.
+    #[must_use]
+    pub fn postgres_url(&self) -> Option<String> {
+        self.postgres.as_ref().map(|service| {
+            format!(
+                "postgres://{POSTGRES_USER}:{POSTGRES_PASSWORD}@127.0.0.1:{}/{}",
+                service.host_port, POSTGRES_DATABASE
+            )
+        })
+    }
+
+    /// Returns the Redis URL when the stack includes Redis.
+    #[must_use]
+    pub fn redis_url(&self) -> Option<String> {
+        self.redis
+            .as_ref()
+            .map(|service| format!("redis://127.0.0.1:{}/", service.host_port))
+    }
+
+    /// Returns an S3 object-store config for the MinIO service.
+    #[must_use]
+    pub fn s3_config_with_prefix(&self, key_prefix: Option<&str>) -> Option<S3ObjectStoreConfig> {
+        self.minio.as_ref().map(|service| {
+            S3ObjectStoreConfig::new(DEFAULT_S3_BUCKET.to_owned(), "us-east-1".to_owned())
+                .with_endpoint(Some(format!("http://127.0.0.1:{}", service.host_port)))
+                .with_credentials(
+                    Some(MINIO_ROOT_USER.to_owned()),
+                    Some(MINIO_ROOT_PASSWORD.to_owned()),
+                    None,
+                )
+                .with_key_prefix(key_prefix)
+                .with_allow_http(true)
+        })
+    }
+
+    /// Returns a unique test key prefix suitable for isolated object-store runs.
+    #[must_use]
+    pub fn unique_s3_key_prefix(&self, prefix: &str) -> String {
+        let unix_nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0_u128, |duration| duration.as_nanos());
+        format!("{prefix}/{unix_nanos}")
+    }
+}
+
+impl Drop for DockerLocalStack {
+    fn drop(&mut self) {
+        if let Some(service) = self.postgres.take() {
+            let _ignored = remove_container(&service.container_name);
+        }
+        if let Some(service) = self.minio.take() {
+            let _ignored = remove_container(&service.container_name);
+        }
+        if let Some(service) = self.redis.take() {
+            let _ignored = remove_container(&service.container_name);
+        }
+    }
+}
+
+impl DockerLocalStackBuilder {
+    /// Enables Postgres for the stack.
+    #[must_use]
+    pub const fn with_postgres(mut self) -> Self {
+        self.postgres = true;
+        self
+    }
+
+    /// Enables MinIO for the stack.
+    #[must_use]
+    pub const fn with_minio(mut self) -> Self {
+        self.minio = true;
+        self
+    }
+
+    /// Enables Redis for the stack.
+    #[must_use]
+    pub const fn with_redis(mut self) -> Self {
+        self.redis = true;
+        self
+    }
+
+    /// Starts the configured stack.
+    ///
+    /// Returns `Ok(None)` when Docker is unavailable so tests can skip cleanly.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`IoError`] when container startup, readiness checks, or
+    /// MinIO bucket creation fails.
+    pub fn start(self) -> Result<Option<DockerLocalStack>, IoError> {
+        if !DockerLocalStack::docker_available() {
+            return Ok(None);
+        }
+
+        let run_id = unique_run_id();
+        let postgres = if self.postgres {
+            Some(start_postgres_service(&run_id)?)
+        } else {
+            None
+        };
+        let minio = if self.minio {
+            Some(start_minio_service(&run_id)?)
+        } else {
+            None
+        };
+        let redis = if self.redis {
+            Some(start_redis_service(&run_id)?)
+        } else {
+            None
+        };
+
+        Ok(Some(DockerLocalStack {
+            postgres,
+            minio,
+            redis,
+        }))
+    }
+}
+
+fn start_postgres_service(run_id: &str) -> Result<PostgresService, IoError> {
+    let container_name = format!("shardline-test-postgres-{run_id}");
+    run_command_checked(
+        Command::new("docker")
+            .arg("run")
+            .arg("-d")
+            .arg("--rm")
+            .arg("--name")
+            .arg(&container_name)
+            .arg("-e")
+            .arg(format!("POSTGRES_USER={POSTGRES_USER}"))
+            .arg("-e")
+            .arg(format!("POSTGRES_PASSWORD={POSTGRES_PASSWORD}"))
+            .arg("-e")
+            .arg(format!("POSTGRES_DB={POSTGRES_DATABASE}"))
+            .arg("-p")
+            .arg("127.0.0.1::5432")
+            .arg(POSTGRES_IMAGE),
+        "start postgres container",
+    )?;
+    let host_port = docker_published_port(&container_name, 5432)?;
+    wait_for(
+        || {
+            run_command(
+                Command::new("docker")
+                    .arg("exec")
+                    .arg(&container_name)
+                    .arg("pg_isready")
+                    .arg("-U")
+                    .arg(POSTGRES_USER)
+                    .arg("-d")
+                    .arg(POSTGRES_DATABASE),
+            )
+            .is_ok_and(|output| output.status.success())
+        },
+        "postgres readiness",
+    )?;
+
+    Ok(PostgresService {
+        container_name,
+        host_port,
+    })
+}
+
+fn start_minio_service(run_id: &str) -> Result<MinioService, IoError> {
+    let container_name = format!("shardline-test-minio-{run_id}");
+    run_command_checked(
+        Command::new("docker")
+            .arg("run")
+            .arg("-d")
+            .arg("--rm")
+            .arg("--name")
+            .arg(&container_name)
+            .arg("-e")
+            .arg(format!("MINIO_ROOT_USER={MINIO_ROOT_USER}"))
+            .arg("-e")
+            .arg(format!("MINIO_ROOT_PASSWORD={MINIO_ROOT_PASSWORD}"))
+            .arg("-p")
+            .arg("127.0.0.1::9000")
+            .arg("-p")
+            .arg("127.0.0.1::9001")
+            .arg(MINIO_IMAGE)
+            .arg("server")
+            .arg("/data")
+            .arg("--console-address")
+            .arg(":9001"),
+        "start minio container",
+    )?;
+    let host_port = docker_published_port(&container_name, 9000)?;
+    let mc_host = format!("http://{MINIO_ROOT_USER}:{MINIO_ROOT_PASSWORD}@127.0.0.1:{host_port}");
+    wait_for(
+        || {
+            run_command(Command::new("docker").arg("logs").arg(&container_name)).is_ok_and(
+                |output| {
+                    let combined = format!(
+                        "{}{}",
+                        String::from_utf8_lossy(&output.stdout),
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+                    output.status.success() && combined.contains("API:")
+                },
+            )
+        },
+        "minio readiness",
+    )?;
+    run_command_checked(
+        Command::new("docker")
+            .arg("run")
+            .arg("--rm")
+            .arg("--network")
+            .arg("host")
+            .arg("-e")
+            .arg(format!("MC_HOST_local={mc_host}"))
+            .arg(MINIO_MC_IMAGE)
+            .arg("mb")
+            .arg("--ignore-existing")
+            .arg(format!("local/{DEFAULT_S3_BUCKET}")),
+        "create minio bucket",
+    )?;
+
+    Ok(MinioService {
+        container_name,
+        host_port,
+    })
+}
+
+fn start_redis_service(run_id: &str) -> Result<RedisService, IoError> {
+    let container_name = format!("shardline-test-redis-{run_id}");
+    run_command_checked(
+        Command::new("docker")
+            .arg("run")
+            .arg("-d")
+            .arg("--rm")
+            .arg("--name")
+            .arg(&container_name)
+            .arg("-p")
+            .arg("127.0.0.1::6379")
+            .arg(REDIS_IMAGE),
+        "start redis container",
+    )?;
+    let host_port = docker_published_port(&container_name, 6379)?;
+    wait_for(
+        || {
+            run_command(
+                Command::new("docker")
+                    .arg("exec")
+                    .arg(&container_name)
+                    .arg("redis-cli")
+                    .arg("ping"),
+            )
+            .is_ok_and(|output| output.status.success())
+        },
+        "redis readiness",
+    )?;
+
+    Ok(RedisService {
+        container_name,
+        host_port,
+    })
+}
+
+fn unique_run_id() -> String {
+    let unix_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0_u128, |duration| duration.as_nanos());
+    format!("{}-{unix_nanos}", std::process::id())
+}
+
+fn docker_published_port(container_name: &str, container_port: u16) -> Result<u16, IoError> {
+    let output = run_command_checked(
+        Command::new("docker")
+            .arg("port")
+            .arg(container_name)
+            .arg(format!("{container_port}/tcp")),
+        "inspect docker port mapping",
+    )?;
+    let value = String::from_utf8(output.stdout)
+        .map_err(|error| IoError::new(ErrorKind::InvalidData, error))?;
+    let raw_port = value
+        .trim()
+        .rsplit_once(':')
+        .map(|(_host, port)| port)
+        .ok_or_else(|| IoError::new(ErrorKind::InvalidData, "docker port output was invalid"))?;
+    raw_port
+        .parse::<u16>()
+        .map_err(|error| IoError::new(ErrorKind::InvalidData, error))
+}
+
+fn remove_container(container_name: &str) -> Result<(), IoError> {
+    run_command_checked(
+        Command::new("docker")
+            .arg("rm")
+            .arg("-f")
+            .arg(container_name),
+        "remove container",
+    )?;
+    Ok(())
+}
+
+fn wait_for(mut check: impl FnMut() -> bool, description: &str) -> Result<(), IoError> {
+    for _attempt in 0..60 {
+        if check() {
+            return Ok(());
+        }
+        sleep(Duration::from_secs(1));
+    }
+
+    Err(IoError::new(
+        ErrorKind::TimedOut,
+        format!("{description} timed out"),
+    ))
+}
+
+fn run_command_checked(command: &mut Command, description: &str) -> Result<Output, IoError> {
+    let output = run_command(command)?;
+    if output.status.success() {
+        return Ok(output);
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    Err(IoError::other(format!(
+        "{description} failed with status {}: {stderr}",
+        output.status
+    )))
+}
+
+fn run_command(command: &mut Command) -> Result<Output, IoError> {
+    command.output()
+}

--- a/crates/test_support/src/lib.rs
+++ b/crates/test_support/src/lib.rs
@@ -16,12 +16,16 @@
 //! );
 //! ```
 
+mod docker;
+
 use std::{
     fmt::Display,
     io::{Error as IoError, ErrorKind},
 };
 
 use thiserror::Error;
+
+pub use docker::{DockerLocalStack, DockerLocalStackBuilder};
 
 /// Error type for test-only invariant failures.
 #[derive(Debug, Error)]


### PR DESCRIPTION
## Description

Reduce avoidable upload I/O on S3-backed server paths and make the backend deployment e2e suite self-starting instead of env-only.

This removes local staging from OCI chunked uploads when the object backend is S3, persists resumable multipart state for inline hashing/finalization, and adds automated Docker-backed e2e coverage for MinIO, Postgres, and Redis-backed runs.

## Changes

- `crates/server/src/oci_adapter.rs`, `crates/server/src/app/protocol_routes.rs`, `crates/server/src/backend.rs`, `crates/storage/src/s3.rs`
  - Stream OCI chunked upload sessions into S3 multipart uploads instead of staging the full body in a local temp file.
  - Persist resumable multipart state and SHA-256 state so finalize does not need to reread a staged upload body.
  - Add backend helpers for create/upload/complete/abort resumable object uploads.
- `crates/test_support/src/docker.rs`, `crates/test_support/src/lib.rs`, `crates/test_support/Cargo.toml`
  - Add a reusable Docker-backed local service harness for Postgres, MinIO, and Redis.
- `crates/server/tests/native_xet_client_e2e.rs`
  - Automate the S3-backed native Xet e2e flow with local MinIO.
- `crates/server/tests/native_protocol_frontends_e2e.rs`
  - Add automated S3-backed client e2e coverage for the primary Git LFS, Bazel, and OCI frontend flows.
- `crates/server/tests/k8s_cluster_protocol_e2e.rs`
  - Add a self-starting local Postgres + MinIO + Redis deployment path, run migrations automatically, and exercise the existing deployment-style Xet flow.
- `Cargo.toml`, `Cargo.lock`
  - Enable `sha2` compress support needed for resumable digest state serialization.

Affected crates:
- `server`
- `storage`
- `test_support`

Cross-crate interaction changes:
- The server OCI upload session flow now uses S3 multipart primitives exposed through the storage layer.
- The test support crate now provisions disposable backend services that server e2e tests can share.

Migration or rollout requirements:
- None. This is a runtime-path improvement and test harness addition only.

## Motivation

Business or operator motivation:
- Improve S3 upload throughput and latency by removing redundant local write/read staging from hot upload paths.
- Reduce manual validation cost by making backend deployment e2e coverage reproducible in CI and locally.

Technical motivation:
- OCI chunked uploads were still persisting session bodies locally and rereading them on finalize even when the final destination was S3.
- Several backend e2e paths depended on preconfigured external services instead of booting their own disposable test stack.

Alternative approaches considered:
- Keeping local session files and only optimizing finalize was rejected because it leaves the dominant write/read overhead in place.
- Requiring preprovisioned MinIO/Postgres/Redis for e2e coverage was rejected because it keeps the tests non-portable and harder to run in CI.

## Scope and impact

- Affected crates: `server`, `storage`, `test_support`
- Protocol or API changes: none
- Backward compatibility: preserved
- Performance impact: removes local temp-file staging and full-body rereads from S3-backed OCI chunked uploads; adds automated backend e2e coverage
- Security impact: no auth model change; upload digest verification remains enforced before object finalize
- Operational impact: no config migration required; tests now self-provision local dependencies when Docker is available

## Testing

- [x] Unit tests
- [x] Integration tests
- [x] Manual verification
- [ ] Performance checks (if applicable)
- [ ] Security checks (if applicable)

Commands/results:

```bash
cargo test -p shardline-server serializable_sha256_state_matches_reference_digest -- --nocapture
cargo test -p shardline-server protocol_frontends_http -- --nocapture
cargo test -p shardline-server --test native_protocol_frontends_e2e native_primary_protocol_flows_work_against_s3_object_storage -- --nocapture
cargo test -p shardline-server --test native_xet_client_e2e shardline_accepts_native_xet_upload_and_download_flows_with_s3_when_configured -- --nocapture
cargo test -p shardline-server --test k8s_cluster_protocol_e2e k8s_cluster_native_xet_sparse_mutation_flow_uses_s3_postgres_and_garnet -- --nocapture
cargo make ci
```

Results:
- All commands above passed locally.
- `cargo make ci` completed successfully with 699 tests passed.
- The new self-hosted e2e coverage exercises MinIO, Postgres, and Redis-backed server flows when Docker and the required client binaries are available.

## Related issues and documentation

- Fixes:
- Related:
- Architecture docs: `docs/ARCHITECTURE.md`
- Protocol docs: `docs/PROTOCOL_CONFORMANCE.md`
- Security/invariants docs: `docs/SECURITY_AND_INVARIANTS.md`
- Operations/runbook updates: none

## Reviewer checklist

- [x] Code follows project standards and crate-boundary constraints
- [x] Tests added or updated and passing
- [ ] Documentation updated where behavior or config changed
- [x] No undocumented breaking change
- [x] Performance trade-offs documented where relevant
- [x] Security considerations addressed where relevant

## Additional notes

- `live_provider_bridge_e2e.rs` remains intentionally external because it validates real private-provider credentials and repository access.
- The new automated backend e2e paths skip cleanly when Docker or required client binaries are unavailable.