### PR TITLE
fix: correct crate publish order and remove deprecated --token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,19 +30,24 @@ jobs:
     env:
       CRATE_PACKAGES: >-
         shardline-protocol
+        shardline-xet-core
+        shardline-metrics
         shardline-storage
         shardline-cache
         shardline-vcs
         shardline-index
         shardline-cas
         shardline-server-core
-        shardline-metrics
         shardline-oci-adapter
         shardline-protocol-adapters
-        shardline-hub-api
-        shardline-xet-core
         shardline-xet-adapter
+        shardline-provider-events
+        shardline-hub-api
+        shardline-fsck
+        shardline-gc
+        shardline-rebuild
         shardline-server
+        shardline-bench
         shardline
     steps:
       - name: Checkout
@@ -142,8 +147,9 @@ jobs:
               echo "${crate} ${version} already exists on crates.io; skipping"
               continue
             fi
-            if cargo publish --locked -p "${crate}" --token "${CARGO_REGISTRY_TOKEN}"; then
+            if cargo publish --locked -p "${crate}"; then
               echo "${crate} ${version} published successfully"
+              sleep 15
             else
               echo "::warning::Failed to publish ${crate} ${version} (may already exist from a parallel run); continuing"
             fi

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -4,7 +4,6 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Benchmarks and load testing for the Shardline server ecosystem."
-publish = false
 
 [[bench]]
 name = "reconstruction"

--- a/crates/fsck/Cargo.toml
+++ b/crates/fsck/Cargo.toml
@@ -8,7 +8,6 @@ homepage.workspace = true
 documentation = "https://docs.rs/shardline-fsck"
 readme = "../../README.md"
 description = "Storage integrity checking logic for the Shardline server ecosystem."
-publish = false
 
 [dependencies]
 serde_json.workspace = true

--- a/crates/gc/Cargo.toml
+++ b/crates/gc/Cargo.toml
@@ -8,7 +8,6 @@ homepage.workspace = true
 documentation = "https://docs.rs/shardline-gc"
 readme = "../../README.md"
 description = "Garbage collection for Shardline chunk storage."
-publish = false
 
 [dependencies]
 serde.workspace = true

--- a/crates/provider_events/Cargo.toml
+++ b/crates/provider_events/Cargo.toml
@@ -8,7 +8,6 @@ homepage.workspace = true
 documentation = "https://docs.rs/shardline-provider-events"
 readme = "../../README.md"
 description = "Provider webhook event processing for the Shardline server."
-publish = false
 
 [dependencies]
 serde_json.workspace = true

--- a/crates/rebuild/Cargo.toml
+++ b/crates/rebuild/Cargo.toml
@@ -8,7 +8,6 @@ homepage.workspace = true
 documentation = "https://docs.rs/shardline-rebuild"
 readme = "../../README.md"
 description = "Index rebuild logic for the Shardline server ecosystem."
-publish = false
 
 [dependencies]
 serde.workspace = true

--- a/crates/test_support/Cargo.toml
+++ b/crates/test_support/Cargo.toml
@@ -8,7 +8,6 @@ homepage.workspace = true
 documentation = "https://docs.rs/shardline-test-support"
 readme = "../../README.md"
 description = "Test support utilities for Shardline crates."
-publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
## Problem

Release CI failed because crates were published in wrong dependency order. Crates like  tried to resolve  before it was published, and  deps (fsck, gc, rebuild, provider-events) were marked .

## Changes

- **Reorder CRATE_PACKAGES** to topological dependency order (20 crates, was 15)
- **Remove ** from fsck, gc, rebuild, provider-events, test_support, bench — they are regular dependencies of published crates
- **Remove deprecated  flag** — use CARGO_REGISTRY_TOKEN env var instead
- **Add 15s sleep** between publishes for crates.io indexing