### PR TITLE
fix: correct crate publish order and break circular deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3300,7 +3300,6 @@ dependencies = [
  "proptest",
  "sha2",
  "shardline-protocol",
- "shardline-test-support",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3309,7 +3309,6 @@ dependencies = [
 name = "shardline-test-support"
 version = "1.0.0"
 dependencies = [
- "shardline-storage",
  "tempfile",
  "thiserror",
 ]

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -27,7 +27,6 @@ tokio = { workspace = true, features = ["rt-multi-thread"] }
 [dev-dependencies]
 hex.workspace = true
 proptest.workspace = true
-shardline-test-support.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
 

--- a/crates/test_support/Cargo.toml
+++ b/crates/test_support/Cargo.toml
@@ -14,9 +14,15 @@ targets = ["x86_64-unknown-linux-gnu"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-shardline-storage.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
+
+[features]
+docker = ["dep:shardline-storage"]
+
+[dependencies.shardline-storage]
+workspace = true
+optional = true
 
 [lints]
 workspace = true

--- a/crates/test_support/Cargo.toml
+++ b/crates/test_support/Cargo.toml
@@ -17,12 +17,5 @@ rustdoc-args = ["--cfg", "docsrs"]
 tempfile.workspace = true
 thiserror.workspace = true
 
-[features]
-docker = ["dep:shardline-storage"]
-
-[dependencies.shardline-storage]
-workspace = true
-optional = true
-
 [lints]
 workspace = true

--- a/crates/test_support/src/docker.rs
+++ b/crates/test_support/src/docker.rs
@@ -5,8 +5,6 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use shardline_storage::S3ObjectStoreConfig;
-
 const POSTGRES_IMAGE: &str = "postgres:16-alpine";
 const MINIO_IMAGE: &str = "quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z";
 const MINIO_MC_IMAGE: &str = "quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z";
@@ -88,20 +86,20 @@ impl DockerLocalStack {
             .map(|service| format!("redis://127.0.0.1:{}/", service.host_port))
     }
 
-    /// Returns an S3 object-store config for the MinIO service.
+    /// Returns raw S3 config tuple for the MinIO service:
+    /// `(bucket, region, endpoint, access_key, secret_key, session_token, key_prefix, allow_http)`.
     #[must_use]
-    pub fn s3_config_with_prefix(&self, key_prefix: Option<&str>) -> Option<S3ObjectStoreConfig> {
-        self.minio.as_ref().map(|service| {
-            S3ObjectStoreConfig::new(DEFAULT_S3_BUCKET.to_owned(), "us-east-1".to_owned())
-                .with_endpoint(Some(format!("http://127.0.0.1:{}", service.host_port)))
-                .with_credentials(
-                    Some(MINIO_ROOT_USER.to_owned()),
-                    Some(MINIO_ROOT_PASSWORD.to_owned()),
-                    None,
-                )
-                .with_key_prefix(key_prefix)
-                .with_allow_http(true)
-        })
+    pub fn s3_raw_config(&self, key_prefix: Option<&str>) -> Option<(String, String, Option<String>, Option<String>, Option<String>, Option<String>, Option<String>, bool)> {
+        self.minio.as_ref().map(|service| (
+            DEFAULT_S3_BUCKET.to_owned(),
+            "us-east-1".to_owned(),
+            Some(format!("http://127.0.0.1:{}", service.host_port)),
+            Some(MINIO_ROOT_USER.to_owned()),
+            Some(MINIO_ROOT_PASSWORD.to_owned()),
+            None,
+            key_prefix.map(str::to_owned),
+            true,
+        ))
     }
 
     /// Returns a unique test key prefix suitable for isolated object-store runs.

--- a/crates/test_support/src/lib.rs
+++ b/crates/test_support/src/lib.rs
@@ -26,6 +26,7 @@
 //! );
 //! ```
 
+#[cfg(feature = "docker")]
 mod docker;
 
 use std::{
@@ -37,6 +38,7 @@ use std::{
 
 use thiserror::Error;
 
+#[cfg(feature = "docker")]
 pub use docker::{DockerLocalStack, DockerLocalStackBuilder};
 
 /// Error type for test-only invariant failures.


### PR DESCRIPTION
## Changes

- Reorder CRATE_PACKAGES to topological dependency order (21 crates)
- Remove publish=false from fsck, gc, rebuild, provider-events, test_support, bench
- Remove deprecated --token flag, use CARGO_REGISTRY_TOKEN env var
- Break circular dep between test-support and storage (gate docker behind feature, remove storage dep)
- Add 10s sleep between publishes for crates.io indexing