### PR TITLE
feat(cli): add config file support, shardline.toml and .env file loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3495,6 +3495,7 @@ dependencies = [
  "blake3",
  "bytes",
  "criterion",
+ "dotenvy",
  "futures-util",
  "getrandom 0.3.4",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3083,6 +3083,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3523,6 +3532,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "toml",
  "tower",
  "tower-http",
  "tracing",
@@ -4248,6 +4258,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -5211,6 +5262,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wiremock"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3174,6 +3174,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
+ "dotenvy",
  "hex",
  "libc",
  "reqwest 0.12.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ documentation = "https://docs.rs/shardline"
 [workspace.dependencies]
 async-trait = "0.1"
 dotenvy = "0.15"
+toml = "0.8"
 axum = "0.8.8"
 base64 = "0.22"
 blake3 = "1.8.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ documentation = "https://docs.rs/shardline"
 
 [workspace.dependencies]
 async-trait = "0.1"
+dotenvy = "0.15"
 axum = "0.8.8"
 base64 = "0.22"
 blake3 = "1.8.3"

--- a/crates/shardline-server/Cargo.toml
+++ b/crates/shardline-server/Cargo.toml
@@ -51,6 +51,7 @@ sqlx = { workspace = true, features = [
 subtle.workspace = true
 thiserror.workspace = true
 toml.workspace = true
+dotenvy.workspace = true
 tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time", "test-util"] }
 tracing.workspace = true
 url.workspace = true

--- a/crates/shardline-server/Cargo.toml
+++ b/crates/shardline-server/Cargo.toml
@@ -69,7 +69,7 @@ hmac.workspace = true
 redis = { workspace = true, features = ["tokio-rustls-comp"] }
 reqwest = { workspace = true, features = ["json", "rustls-tls", "stream"] }
 rusqlite = { workspace = true, features = ["bundled"] }
-serial_test = "3"
+serial_test.workspace = true
 shardline-test-support.workspace = true
 tempfile.workspace = true
 wiremock = "0.6"

--- a/crates/shardline-server/Cargo.toml
+++ b/crates/shardline-server/Cargo.toml
@@ -50,6 +50,7 @@ sqlx = { workspace = true, features = [
 ] }
 subtle.workspace = true
 thiserror.workspace = true
+toml.workspace = true
 tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time", "test-util"] }
 tracing.workspace = true
 url.workspace = true

--- a/crates/shardline-server/Cargo.toml
+++ b/crates/shardline-server/Cargo.toml
@@ -62,6 +62,7 @@ zeroize.workspace = true
 
 [dev-dependencies]
 async-trait.workspace = true
+dotenvy.workspace = true
 criterion = { workspace = true, features = ["async_tokio", "cargo_bench_support"] }
 hmac.workspace = true
 redis = { workspace = true, features = ["tokio-rustls-comp"] }

--- a/crates/shardline-server/src/config/env.rs
+++ b/crates/shardline-server/src/config/env.rs
@@ -451,11 +451,11 @@ pub fn load_server_config_from_env_with_toml(
     if let Some(auth) = &toml.auth {
         set_if_unset("SHARDLINE_AUTH_PROVIDER", auth.provider.clone());
         set_if_unset(
-            "SHARDLINE_TOKEN_SIGNING_KEY_PATH",
+            "SHARDLINE_TOKEN_SIGNING_KEY_FILE",
             auth.token_signing_key_path.clone(),
         );
         set_if_unset(
-            "SHARDLINE_PROVIDER_API_KEY_PATH",
+            "SHARDLINE_PROVIDER_API_KEY_FILE",
             auth.provider_api_key_path.clone(),
         );
         set_if_unset(
@@ -468,14 +468,9 @@ pub fn load_server_config_from_env_with_toml(
         );
         if let Some(jwks) = &auth.jwks {
             set_if_unset("SHARDLINE_AUTH_JWKS_URL", jwks.url.clone());
-            set_if_unset(
-                "SHARDLINE_AUTH_JWKS_REFRESH_INTERVAL_SECONDS",
-                jwks.refresh_interval_seconds.map(|v| v.to_string()),
-            );
         }
         if let Some(oidc) = &auth.oidc {
-            set_if_unset("SHARDLINE_AUTH_OIDC_ISSUER_URL", oidc.issuer_url.clone());
-            set_if_unset("SHARDLINE_AUTH_OIDC_CLIENT_ID", oidc.client_id.clone());
+            set_if_unset("SHARDLINE_AUTH_OIDC_ISSUER", oidc.issuer_url.clone());
         }
     }
 
@@ -493,23 +488,106 @@ fn interpolate_env_vars(value: &str) -> String {
     let mut result = String::with_capacity(value.len());
     let mut chars = value.chars().peekable();
 
-    while let Some(ch) = chars.next() {
+    'outer: while let Some(ch) = chars.next() {
         if ch == '$' && chars.peek() == Some(&'{') {
             chars.next(); // consume '{'
             let mut var_name = String::new();
-            for c in chars.by_ref() {
-                if c == '}' {
-                    break;
+            loop {
+                match chars.next() {
+                    Some('}') => {
+                        let resolved =
+                            var(&var_name).unwrap_or_else(|_| format!("${{{var_name}}}"));
+                        result.push_str(&resolved);
+                        break;
+                    }
+                    Some(c) => var_name.push(c),
+                    None => {
+                        // Unclosed ${ — preserve original text
+                        result.push('$');
+                        result.push('{');
+                        result.push_str(&var_name);
+                        break 'outer;
+                    }
                 }
-                var_name.push(c);
             }
-            let resolved = var(&var_name).unwrap_or_else(|_| format!("${{{var_name}}}"));
-            result.push_str(&resolved);
         } else {
             result.push(ch);
         }
     }
     result
+}
+
+#[cfg(test)]
+mod interpolate_tests {
+    use super::interpolate_env_vars;
+
+    #[test]
+    fn test_no_vars() {
+        assert_eq!(interpolate_env_vars("plain text"), "plain text");
+    }
+
+    #[test]
+    fn test_known_var() {
+        let content = "_TEST_INTERP_VAR=resolved".to_owned();
+        let _ = dotenvy::from_read(std::io::Cursor::new(content.as_bytes()));
+        assert_eq!(
+            interpolate_env_vars("prefix-${_TEST_INTERP_VAR}-suffix"),
+            "prefix-resolved-suffix"
+        );
+    }
+
+    #[test]
+    fn test_missing_var() {
+        assert_eq!(
+            interpolate_env_vars("${_NONEXISTENT_VAR_XYZ}"),
+            "${_NONEXISTENT_VAR_XYZ}"
+        );
+    }
+
+    #[test]
+    fn test_empty_var_name() {
+        assert_eq!(interpolate_env_vars("${}"), "${}");
+    }
+
+    #[test]
+    fn test_dollar_without_brace() {
+        assert_eq!(interpolate_env_vars("$VAR"), "$VAR");
+        assert_eq!(interpolate_env_vars("$$"), "$$");
+    }
+
+    #[test]
+    fn test_multiple_vars() {
+        let content = "_TEST_A=hello\n_TEST_B=world";
+        let _ = dotenvy::from_read(std::io::Cursor::new(content.as_bytes()));
+        let result = interpolate_env_vars("${_TEST_A} ${_TEST_B}");
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn test_unclosed_brace_preserves_text() {
+        // Malformed input without closing } should be preserved
+        assert_eq!(interpolate_env_vars("${HOST"), "${HOST");
+    }
+
+    #[test]
+    fn test_unclosed_brace_at_end() {
+        assert_eq!(interpolate_env_vars("prefix-${VAR"), "prefix-${VAR");
+    }
+
+    #[test]
+    fn test_nested_dollar_signs() {
+        assert_eq!(interpolate_env_vars("$${VAR}"), "$${VAR}");
+    }
+
+    #[test]
+    fn test_empty_input() {
+        assert_eq!(interpolate_env_vars(""), "");
+    }
+
+    #[test]
+    fn test_only_brace_no_var() {
+        assert_eq!(interpolate_env_vars("${}"), "${}");
+    }
 }
 
 #[cfg(test)]

--- a/crates/shardline-server/src/config/env.rs
+++ b/crates/shardline-server/src/config/env.rs
@@ -384,7 +384,8 @@ pub fn load_server_config_from_env_with_toml(
         if let Some(value) = value
             && var(key).is_err()
         {
-            let _ignored = writeln!(buf, "{key}={value}");
+            let interpolated = interpolate_env_vars(&value);
+            let _ignored = writeln!(buf, "{key}={interpolated}");
         }
     };
 
@@ -484,6 +485,31 @@ pub fn load_server_config_from_env_with_toml(
     }
 
     load_server_config_from_env()
+}
+
+/// Interpolates `${VAR_NAME}` patterns in `value` using the current process
+/// environment. Returns the original value when no patterns are found.
+fn interpolate_env_vars(value: &str) -> String {
+    let mut result = String::with_capacity(value.len());
+    let mut chars = value.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '$' && chars.peek() == Some(&'{') {
+            chars.next(); // consume '{'
+            let mut var_name = String::new();
+            for c in chars.by_ref() {
+                if c == '}' {
+                    break;
+                }
+                var_name.push(c);
+            }
+            let resolved = var(&var_name).unwrap_or_else(|_| format!("${{{var_name}}}"));
+            result.push_str(&resolved);
+        } else {
+            result.push(ch);
+        }
+    }
+    result
 }
 
 #[cfg(test)]

--- a/crates/shardline-server/src/config/env.rs
+++ b/crates/shardline-server/src/config/env.rs
@@ -377,7 +377,9 @@ pub fn load_server_config_from_env_with_toml(
 ) -> Result<ServerConfig, ServerConfigError> {
     use std::io::Write;
 
-    // Collect TOML values into a buffer as KEY=VALUE lines.
+    // Collect TOML values into a buffer as quoted dotenv assignments. Quoting
+    // keeps TOML strings containing whitespace, `#`, quotes, or newlines from
+    // being interpreted as dotenv syntax or additional assignments.
     let mut buf = Vec::new();
 
     let mut set_if_unset = |key: &str, value: Option<String>| {
@@ -385,7 +387,7 @@ pub fn load_server_config_from_env_with_toml(
             && var(key).is_err()
         {
             let interpolated = interpolate_env_vars(&value);
-            let _ignored = writeln!(buf, "{key}={interpolated}");
+            let _ignored = writeln!(buf, "{key}={interpolated:?}");
         }
     };
 
@@ -421,9 +423,13 @@ pub fn load_server_config_from_env_with_toml(
             set_if_unset("SHARDLINE_S3_ENDPOINT", s3.endpoint.clone());
             set_if_unset("SHARDLINE_S3_REGION", s3.region.clone());
             set_if_unset("SHARDLINE_S3_BUCKET", s3.bucket.clone());
-            set_if_unset("SHARDLINE_S3_PREFIX", s3.prefix.clone());
+            set_if_unset("SHARDLINE_S3_KEY_PREFIX", s3.prefix.clone());
             set_if_unset(
-                "SHARDLINE_S3_VIRTUAL_HOSTED_STYLE",
+                "SHARDLINE_S3_ALLOW_HTTP",
+                s3.allow_http.map(|v| v.to_string()),
+            );
+            set_if_unset(
+                "SHARDLINE_S3_VIRTUAL_HOSTED_STYLE_REQUEST",
                 s3.virtual_hosted_style.map(|v| v.to_string()),
             );
         }
@@ -476,7 +482,11 @@ pub fn load_server_config_from_env_with_toml(
 
     // Apply TOML values to the process environment for keys not already set.
     if !buf.is_empty() {
-        drop(dotenvy::from_read(std::io::Cursor::new(buf)));
+        dotenvy::from_read(std::io::Cursor::new(buf)).map_err(|_error| {
+            ServerConfigError::ConfigFileError(
+                "failed to apply validated TOML configuration values".to_owned(),
+            )
+        })?;
     }
 
     load_server_config_from_env()
@@ -596,8 +606,8 @@ mod tests {
     use crate::ServerFrontend;
 
     use super::{
-        load_non_zero_usize_env, optional_token_signing_key_from_sources,
-        parse_server_frontends_env,
+        load_non_zero_usize_env, load_server_config_from_env_with_toml,
+        optional_token_signing_key_from_sources, parse_server_frontends_env,
     };
 
     fn set_env_var(key: &str, value: &str) {
@@ -609,6 +619,81 @@ mod tests {
     fn remove_env_var(key: &str) {
         // SAFETY: Same threading constraints as `set_env_var`.
         unsafe { std::env::remove_var(key) };
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn toml_s3_values_use_the_runtime_environment_keys() {
+        const S3_KEYS: &[&str] = &[
+            "SHARDLINE_OBJECT_STORAGE_ADAPTER",
+            "SHARDLINE_S3_BUCKET",
+            "SHARDLINE_S3_REGION",
+            "SHARDLINE_S3_ENDPOINT",
+            "SHARDLINE_S3_KEY_PREFIX",
+            "SHARDLINE_S3_PREFIX",
+            "SHARDLINE_S3_ALLOW_HTTP",
+            "SHARDLINE_S3_VIRTUAL_HOSTED_STYLE_REQUEST",
+            "SHARDLINE_S3_VIRTUAL_HOSTED_STYLE",
+        ];
+        for key in S3_KEYS {
+            remove_env_var(key);
+        }
+
+        let toml: super::ShardlineTomlConfig = toml::from_str(
+            r#"
+[storage]
+adapter = "s3"
+[storage.s3]
+bucket = "test-bucket"
+region = "eu-west-1"
+endpoint = "http://localhost:9000"
+prefix = "toml-prefix/"
+allow_http = true
+virtual_hosted_style = true
+"#,
+        )
+        .unwrap();
+        let config = load_server_config_from_env_with_toml(&toml).unwrap();
+        let rendered = format!("{:?}", config.s3_object_store_config().unwrap());
+        assert!(rendered.contains("key_prefix: Some(\"toml-prefix\")"));
+        assert!(rendered.contains("allow_http: true"));
+        assert!(rendered.contains("virtual_hosted_style_request: true"));
+
+        for key in S3_KEYS {
+            remove_env_var(key);
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn toml_values_with_dotenv_syntax_are_applied_as_single_values() {
+        const KEYS: &[&str] = &[
+            "SHARDLINE_ROOT_DIR",
+            "SHARDLINE_AUTH_PROVIDER",
+            "SHARDLINE_INJECTED_VALUE",
+        ];
+        for key in KEYS {
+            remove_env_var(key);
+        }
+
+        let toml: super::ShardlineTomlConfig = toml::from_str(
+            r#"
+[server]
+root_dir = "runtime#dir\nSHARDLINE_INJECTED_VALUE=unexpected"
+"#,
+        )
+        .unwrap();
+        let config = load_server_config_from_env_with_toml(&toml).unwrap();
+        assert_eq!(
+            config.root_dir(),
+            std::path::Path::new("runtime#dir\nSHARDLINE_INJECTED_VALUE=unexpected")
+        );
+        assert_eq!(config.auth_provider(), super::AuthProviderKind::Local);
+        assert!(std::env::var("SHARDLINE_INJECTED_VALUE").is_err());
+
+        for key in KEYS {
+            remove_env_var(key);
+        }
     }
 
     // ── parse_server_frontends_env ─────────────────────────────────────────

--- a/crates/shardline-server/src/config/env.rs
+++ b/crates/shardline-server/src/config/env.rs
@@ -6,6 +6,7 @@ use std::{
 
 use shardline_protocol::{SecretBytes, SecretString};
 
+use super::file::ShardlineTomlConfig;
 use super::secrets::{
     configure_provider_runtime_from_paths, load_redis_tls_config_from_env,
     load_s3_object_store_config_from_env, read_secret_file_bytes,
@@ -357,6 +358,132 @@ fn load_non_zero_usize_env(
         .parse::<usize>()
         .map_err(parse_error)?;
     NonZeroUsize::new(raw).ok_or_else(zero_error)
+}
+
+/// Loads server configuration from environment variables, applying optional
+/// TOML config file values as defaults. Environment variables already set in
+/// the process take precedence over TOML values.
+///
+/// This is a thin wrapper around [`load_server_config_from_env`] that pre-fills
+/// environment variables from a parsed `shardline.toml` before delegating to
+/// the standard env-based loader.
+///
+/// # Errors
+///
+/// Returns [`ServerConfigError`] when required configuration is missing or
+/// invalid.
+pub fn load_server_config_from_env_with_toml(
+    toml: &ShardlineTomlConfig,
+) -> Result<ServerConfig, ServerConfigError> {
+    use std::io::Write;
+
+    // Collect TOML values into a buffer as KEY=VALUE lines.
+    let mut buf = Vec::new();
+
+    let mut set_if_unset = |key: &str, value: Option<String>| {
+        if let Some(value) = value
+            && var(key).is_err()
+        {
+            let _ignored = writeln!(buf, "{key}={value}");
+        }
+    };
+
+    if let Some(srv) = &toml.server {
+        set_if_unset("SHARDLINE_BIND_ADDR", srv.bind_addr.clone());
+        set_if_unset("SHARDLINE_PUBLIC_BASE_URL", srv.public_base_url.clone());
+        set_if_unset("SHARDLINE_SERVER_ROLE", srv.server_role.clone());
+        if let Some(frontends) = &srv.frontends {
+            set_if_unset("SHARDLINE_SERVER_FRONTENDS", Some(frontends.join(",")));
+        }
+        set_if_unset("SHARDLINE_ROOT_DIR", srv.root_dir.clone());
+        set_if_unset(
+            "SHARDLINE_MAX_REQUEST_BODY_BYTES",
+            srv.max_request_body_bytes.map(|v| v.to_string()),
+        );
+        set_if_unset(
+            "SHARDLINE_CHUNK_SIZE_BYTES",
+            srv.chunk_size_bytes.map(|v| v.to_string()),
+        );
+        set_if_unset(
+            "SHARDLINE_UPLOAD_MAX_IN_FLIGHT_CHUNKS",
+            srv.upload_max_in_flight_chunks.map(|v| v.to_string()),
+        );
+        set_if_unset(
+            "SHARDLINE_TRANSFER_MAX_IN_FLIGHT_CHUNKS",
+            srv.transfer_max_in_flight_chunks.map(|v| v.to_string()),
+        );
+    }
+
+    if let Some(stg) = &toml.storage {
+        set_if_unset("SHARDLINE_OBJECT_STORAGE_ADAPTER", stg.adapter.clone());
+        if let Some(s3) = &stg.s3 {
+            set_if_unset("SHARDLINE_S3_ENDPOINT", s3.endpoint.clone());
+            set_if_unset("SHARDLINE_S3_REGION", s3.region.clone());
+            set_if_unset("SHARDLINE_S3_BUCKET", s3.bucket.clone());
+            set_if_unset("SHARDLINE_S3_PREFIX", s3.prefix.clone());
+            set_if_unset(
+                "SHARDLINE_S3_VIRTUAL_HOSTED_STYLE",
+                s3.virtual_hosted_style.map(|v| v.to_string()),
+            );
+        }
+    }
+
+    if let Some(idx) = &toml.index {
+        set_if_unset("SHARDLINE_INDEX_POSTGRES_URL", idx.postgres_url.clone());
+    }
+
+    if let Some(cch) = &toml.cache {
+        set_if_unset(
+            "SHARDLINE_RECONSTRUCTION_CACHE_ADAPTER",
+            cch.adapter.clone(),
+        );
+        set_if_unset(
+            "SHARDLINE_RECONSTRUCTION_CACHE_REDIS_URL",
+            cch.redis_url.clone(),
+        );
+        set_if_unset(
+            "SHARDLINE_RECONSTRUCTION_CACHE_TTL_SECONDS",
+            cch.ttl_seconds.map(|v| v.to_string()),
+        );
+    }
+
+    if let Some(auth) = &toml.auth {
+        set_if_unset("SHARDLINE_AUTH_PROVIDER", auth.provider.clone());
+        set_if_unset(
+            "SHARDLINE_TOKEN_SIGNING_KEY_PATH",
+            auth.token_signing_key_path.clone(),
+        );
+        set_if_unset(
+            "SHARDLINE_PROVIDER_API_KEY_PATH",
+            auth.provider_api_key_path.clone(),
+        );
+        set_if_unset(
+            "SHARDLINE_PROVIDER_TOKEN_ISSUER",
+            auth.provider_token_issuer.clone(),
+        );
+        set_if_unset(
+            "SHARDLINE_PROVIDER_TOKEN_TTL_SECONDS",
+            auth.provider_token_ttl_seconds.map(|v| v.to_string()),
+        );
+        if let Some(jwks) = &auth.jwks {
+            set_if_unset("SHARDLINE_AUTH_JWKS_URL", jwks.url.clone());
+            set_if_unset(
+                "SHARDLINE_AUTH_JWKS_REFRESH_INTERVAL_SECONDS",
+                jwks.refresh_interval_seconds.map(|v| v.to_string()),
+            );
+        }
+        if let Some(oidc) = &auth.oidc {
+            set_if_unset("SHARDLINE_AUTH_OIDC_ISSUER_URL", oidc.issuer_url.clone());
+            set_if_unset("SHARDLINE_AUTH_OIDC_CLIENT_ID", oidc.client_id.clone());
+        }
+    }
+
+    // Apply TOML values to the process environment for keys not already set.
+    if !buf.is_empty() {
+        drop(dotenvy::from_read(std::io::Cursor::new(buf)));
+    }
+
+    load_server_config_from_env()
 }
 
 #[cfg(test)]

--- a/crates/shardline-server/src/config/file.rs
+++ b/crates/shardline-server/src/config/file.rs
@@ -8,80 +8,80 @@ use serde::Deserialize;
 
 /// Top-level TOML configuration document.
 #[derive(Debug, Default, Deserialize)]
-pub(crate) struct ShardlineTomlConfig {
+pub struct ShardlineTomlConfig {
     #[serde(default)]
-    server: Option<ServerSection>,
+    pub server: Option<ServerSection>,
     #[serde(default)]
-    storage: Option<StorageSection>,
+    pub storage: Option<StorageSection>,
     #[serde(default)]
-    index: Option<IndexSection>,
+    pub index: Option<IndexSection>,
     #[serde(default)]
-    cache: Option<CacheSection>,
+    pub cache: Option<CacheSection>,
     #[serde(default)]
-    auth: Option<AuthSection>,
+    pub auth: Option<AuthSection>,
 }
 
 #[derive(Debug, Deserialize)]
-struct ServerSection {
-    bind_addr: Option<String>,
-    public_base_url: Option<String>,
-    server_role: Option<String>,
-    frontends: Option<Vec<String>>,
-    root_dir: Option<String>,
-    max_request_body_bytes: Option<u64>,
-    chunk_size_bytes: Option<u64>,
-    upload_max_in_flight_chunks: Option<u64>,
-    transfer_max_in_flight_chunks: Option<u64>,
+pub struct ServerSection {
+    pub bind_addr: Option<String>,
+    pub public_base_url: Option<String>,
+    pub server_role: Option<String>,
+    pub frontends: Option<Vec<String>>,
+    pub root_dir: Option<String>,
+    pub max_request_body_bytes: Option<u64>,
+    pub chunk_size_bytes: Option<u64>,
+    pub upload_max_in_flight_chunks: Option<u64>,
+    pub transfer_max_in_flight_chunks: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
-struct StorageSection {
-    adapter: Option<String>,
-    s3: Option<S3Section>,
+pub struct StorageSection {
+    pub adapter: Option<String>,
+    pub s3: Option<S3Section>,
 }
 
 #[derive(Debug, Deserialize)]
-struct S3Section {
-    endpoint: Option<String>,
-    region: Option<String>,
-    bucket: Option<String>,
-    prefix: Option<String>,
-    virtual_hosted_style: Option<bool>,
+pub struct S3Section {
+    pub endpoint: Option<String>,
+    pub region: Option<String>,
+    pub bucket: Option<String>,
+    pub prefix: Option<String>,
+    pub virtual_hosted_style: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
-struct IndexSection {
-    postgres_url: Option<String>,
+pub struct IndexSection {
+    pub postgres_url: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
-struct CacheSection {
-    redis_url: Option<String>,
-    adapter: Option<String>,
-    ttl_seconds: Option<u64>,
+pub struct CacheSection {
+    pub redis_url: Option<String>,
+    pub adapter: Option<String>,
+    pub ttl_seconds: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
-struct AuthSection {
-    provider: Option<String>,
-    token_signing_key_path: Option<String>,
-    provider_api_key_path: Option<String>,
-    provider_token_issuer: Option<String>,
-    provider_token_ttl_seconds: Option<u64>,
-    jwks: Option<JwksSection>,
-    oidc: Option<OidcSection>,
+pub struct AuthSection {
+    pub provider: Option<String>,
+    pub token_signing_key_path: Option<String>,
+    pub provider_api_key_path: Option<String>,
+    pub provider_token_issuer: Option<String>,
+    pub provider_token_ttl_seconds: Option<u64>,
+    pub jwks: Option<JwksSection>,
+    pub oidc: Option<OidcSection>,
 }
 
 #[derive(Debug, Deserialize)]
-struct JwksSection {
-    url: Option<String>,
-    refresh_interval_seconds: Option<u64>,
+pub struct JwksSection {
+    pub url: Option<String>,
+    pub refresh_interval_seconds: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
-struct OidcSection {
-    issuer_url: Option<String>,
-    client_id: Option<String>,
+pub struct OidcSection {
+    pub issuer_url: Option<String>,
+    pub client_id: Option<String>,
 }
 
 /// Standard paths checked for shardline.toml, in priority order (first found wins).
@@ -262,6 +262,22 @@ pub fn load_toml_env_overrides(
     config_path: Option<&Path>,
 ) -> Result<Option<HashMap<String, String>>, String> {
     resolve_config_path(config_path).map_or(Ok(None), |bytes| toml_to_env_map(&bytes).map(Some))
+}
+
+/// Parses a shardline.toml file at the given path (or auto-detected) and
+/// returns the deserialized config struct.
+///
+/// # Errors
+///
+/// Returns an error message when the file exists but cannot be read or parsed.
+pub fn load_toml_config(config_path: Option<&Path>) -> Result<Option<ShardlineTomlConfig>, String> {
+    let Some(content) = resolve_config_path(config_path) else {
+        return Ok(None);
+    };
+    let text = std::str::from_utf8(&content).map_err(|e| format!("TOML encoding error: {e}"))?;
+    let config: ShardlineTomlConfig =
+        toml::from_str(text).map_err(|e| format!("TOML parse error: {e}"))?;
+    Ok(Some(config))
 }
 
 #[cfg(test)]

--- a/crates/shardline-server/src/config/file.rs
+++ b/crates/shardline-server/src/config/file.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     fs,
     path::{Path, PathBuf},
 };
@@ -104,164 +103,17 @@ fn expand_tilde(path: &str) -> PathBuf {
 /// Resolves the active shardline.toml path.
 /// Returns `None` when neither an explicit `--config` path nor any
 /// auto-detected candidate exists.
-pub(crate) fn resolve_config_path(explicit: Option<&Path>) -> Option<Vec<u8>> {
+/// Resolves the active shardline.toml content as a string.
+/// Returns `None` when neither an explicit `--config` path nor any
+/// auto-detected candidate exists.
+pub(crate) fn resolve_config_content(explicit: Option<&Path>) -> Option<String> {
     if let Some(path) = explicit {
-        return fs::read(path).ok();
+        return fs::read_to_string(path).ok();
     }
-    for candidate in CONFIG_FILE_CANDIDATES {
+    CONFIG_FILE_CANDIDATES.iter().find_map(|candidate| {
         let expanded = expand_tilde(candidate);
-        if let Ok(content) = fs::read(&expanded) {
-            return Some(content);
-        }
-    }
-    None
-}
-
-/// Interpolates `${VAR_NAME}` patterns in `value` using the current process
-/// environment. Returns the original value when no patterns are found.
-fn interpolate_env_vars(value: &str) -> String {
-    let mut result = String::with_capacity(value.len());
-    let mut chars = value.chars().peekable();
-
-    while let Some(ch) = chars.next() {
-        if ch == '$' && chars.peek() == Some(&'{') {
-            chars.next(); // consume '{'
-            let mut var_name = String::new();
-            for c in chars.by_ref() {
-                if c == '}' {
-                    break;
-                }
-                var_name.push(c);
-            }
-            let resolved = std::env::var(&var_name).unwrap_or_else(|_| format!("${{{var_name}}}"));
-            result.push_str(&resolved);
-        } else {
-            result.push(ch);
-        }
-    }
-    result
-}
-
-/// Parses shardline.toml content into a mapping of SHARDLINE_* env var names
-/// to their interpolated values. Values that reference `${VAR}` are resolved
-/// from the current process environment.
-fn toml_to_env_map(content: &[u8]) -> Result<HashMap<String, String>, String> {
-    let text = std::str::from_utf8(content).map_err(|e| format!("TOML encoding error: {e}"))?;
-    let config: ShardlineTomlConfig =
-        toml::from_str(text).map_err(|e| format!("TOML parse error: {e}"))?;
-
-    let mut map = HashMap::new();
-    let mut add = |key: &str, value: Option<String>| {
-        if let Some(value) = value {
-            map.insert(key.to_owned(), interpolate_env_vars(&value));
-        }
-    };
-
-    // Server section
-    if let Some(srv) = &config.server {
-        add("SHARDLINE_BIND_ADDR", srv.bind_addr.clone());
-        add("SHARDLINE_PUBLIC_BASE_URL", srv.public_base_url.clone());
-        add("SHARDLINE_SERVER_ROLE", srv.server_role.clone());
-        if let Some(frontends) = &srv.frontends {
-            add("SHARDLINE_SERVER_FRONTENDS", Some(frontends.join(",")));
-        }
-        add("SHARDLINE_ROOT_DIR", srv.root_dir.clone());
-        add(
-            "SHARDLINE_MAX_REQUEST_BODY_BYTES",
-            srv.max_request_body_bytes.map(|v| v.to_string()),
-        );
-        add(
-            "SHARDLINE_CHUNK_SIZE_BYTES",
-            srv.chunk_size_bytes.map(|v| v.to_string()),
-        );
-        add(
-            "SHARDLINE_UPLOAD_MAX_IN_FLIGHT_CHUNKS",
-            srv.upload_max_in_flight_chunks.map(|v| v.to_string()),
-        );
-        add(
-            "SHARDLINE_TRANSFER_MAX_IN_FLIGHT_CHUNKS",
-            srv.transfer_max_in_flight_chunks.map(|v| v.to_string()),
-        );
-    }
-
-    // Storage section
-    if let Some(stg) = &config.storage {
-        add("SHARDLINE_OBJECT_STORAGE_ADAPTER", stg.adapter.clone());
-        if let Some(s3) = &stg.s3 {
-            add("SHARDLINE_S3_ENDPOINT", s3.endpoint.clone());
-            add("SHARDLINE_S3_REGION", s3.region.clone());
-            add("SHARDLINE_S3_BUCKET", s3.bucket.clone());
-            add("SHARDLINE_S3_PREFIX", s3.prefix.clone());
-            add(
-                "SHARDLINE_S3_VIRTUAL_HOSTED_STYLE",
-                s3.virtual_hosted_style.map(|v| v.to_string()),
-            );
-        }
-    }
-
-    // Index section
-    if let Some(idx) = &config.index {
-        add("SHARDLINE_INDEX_POSTGRES_URL", idx.postgres_url.clone());
-    }
-
-    // Cache section
-    if let Some(cch) = &config.cache {
-        add(
-            "SHARDLINE_RECONSTRUCTION_CACHE_ADAPTER",
-            cch.adapter.clone(),
-        );
-        add(
-            "SHARDLINE_RECONSTRUCTION_CACHE_REDIS_URL",
-            cch.redis_url.clone(),
-        );
-        add(
-            "SHARDLINE_RECONSTRUCTION_CACHE_TTL_SECONDS",
-            cch.ttl_seconds.map(|v| v.to_string()),
-        );
-    }
-
-    // Auth section
-    if let Some(auth) = &config.auth {
-        add("SHARDLINE_AUTH_PROVIDER", auth.provider.clone());
-        add(
-            "SHARDLINE_TOKEN_SIGNING_KEY_PATH",
-            auth.token_signing_key_path.clone(),
-        );
-        add(
-            "SHARDLINE_PROVIDER_API_KEY_PATH",
-            auth.provider_api_key_path.clone(),
-        );
-        add(
-            "SHARDLINE_PROVIDER_TOKEN_ISSUER",
-            auth.provider_token_issuer.clone(),
-        );
-        add(
-            "SHARDLINE_PROVIDER_TOKEN_TTL_SECONDS",
-            auth.provider_token_ttl_seconds.map(|v| v.to_string()),
-        );
-        if let Some(jwks) = &auth.jwks {
-            add("SHARDLINE_AUTH_JWKS_URL", jwks.url.clone());
-            add(
-                "SHARDLINE_AUTH_JWKS_REFRESH_INTERVAL_SECONDS",
-                jwks.refresh_interval_seconds.map(|v| v.to_string()),
-            );
-        }
-        if let Some(oidc) = &auth.oidc {
-            add("SHARDLINE_AUTH_OIDC_ISSUER_URL", oidc.issuer_url.clone());
-            add("SHARDLINE_AUTH_OIDC_CLIENT_ID", oidc.client_id.clone());
-        }
-    }
-
-    Ok(map)
-}
-
-/// # Errors
-///
-/// Returns an error message when the file exists but cannot be parsed.
-pub fn load_toml_env_overrides(
-    config_path: Option<&Path>,
-) -> Result<Option<HashMap<String, String>>, String> {
-    resolve_config_path(config_path).map_or(Ok(None), |bytes| toml_to_env_map(&bytes).map(Some))
+        fs::read_to_string(&expanded).ok()
+    })
 }
 
 /// Parses a shardline.toml file at the given path (or auto-detected) and
@@ -269,14 +121,14 @@ pub fn load_toml_env_overrides(
 ///
 /// # Errors
 ///
-/// Returns an error message when the file exists but cannot be read or parsed.
+/// Returns an error message string when the file exists but cannot be
+/// read or parsed as valid TOML.
 pub fn load_toml_config(config_path: Option<&Path>) -> Result<Option<ShardlineTomlConfig>, String> {
-    let Some(content) = resolve_config_path(config_path) else {
+    let Some(content) = resolve_config_content(config_path) else {
         return Ok(None);
     };
-    let text = std::str::from_utf8(&content).map_err(|e| format!("TOML encoding error: {e}"))?;
     let config: ShardlineTomlConfig =
-        toml::from_str(text).map_err(|e| format!("TOML parse error: {e}"))?;
+        toml::from_str(&content).map_err(|e| format!("TOML parse error: {e}"))?;
     Ok(Some(config))
 }
 
@@ -303,360 +155,25 @@ mod tests {
     }
 
     #[test]
-    fn test_interpolate_no_vars() {
-        assert_eq!(interpolate_env_vars("plain text"), "plain text");
-    }
-
-    fn set_env_var(key: &str, value: &str) {
-        let content = format!("{key}={value}");
-        let _ignored = dotenvy::from_read(std::io::Cursor::new(content.as_bytes()));
-    }
-
-    #[test]
-    fn test_interpolate_known_var() {
-        set_env_var("_TEST_SHARDLINE_VAR", "resolved_value");
-        assert_eq!(
-            interpolate_env_vars("prefix-${_TEST_SHARDLINE_VAR}-suffix"),
-            "prefix-resolved_value-suffix"
-        );
-    }
-
-    #[test]
-    fn test_interpolate_missing_var() {
-        let result = interpolate_env_vars("${_MISSING_VAR_XYZ}");
-        assert_eq!(result, "${_MISSING_VAR_XYZ}");
-    }
-
-    #[test]
-    fn test_interpolate_empty_var_name() {
-        // Empty var name cannot be resolved, so the literal ${} is preserved.
-        assert_eq!(interpolate_env_vars("${}"), "${}");
-    }
-
-    #[test]
-    fn test_interpolate_dollar_without_brace() {
-        assert_eq!(interpolate_env_vars("$VAR"), "$VAR");
-        assert_eq!(interpolate_env_vars("$$"), "$$");
-    }
-
-    #[test]
-    fn test_interpolate_multiple_vars() {
-        set_env_var("_TEST_INTERP_A", "hello");
-        set_env_var("_TEST_INTERP_B", "world");
-        let result = interpolate_env_vars("${_TEST_INTERP_A} ${_TEST_INTERP_B}");
-        assert_eq!(result, "hello world");
-    }
-
-    #[test]
-    fn test_toml_to_env_map_empty_document() {
-        let result = toml_to_env_map(b"");
-        assert!(result.is_ok(), "empty document is valid TOML");
-        let map = result.unwrap();
-        assert!(map.is_empty(), "empty document produces no env vars");
-    }
-
-    #[test]
-    fn test_toml_to_env_map_minimal() {
-        let toml = b"[server]\nbind_addr = \"0.0.0.0:9090\"\n";
-        let map = toml_to_env_map(toml).expect("valid toml");
-        assert_eq!(map.get("SHARDLINE_BIND_ADDR").unwrap(), "0.0.0.0:9090");
-    }
-
-    #[test]
-    fn test_toml_to_env_map_server_section() {
-        let toml = b"
-[server]
-bind_addr = \"127.0.0.1:8080\"
-public_base_url = \"http://localhost:8080\"
-server_role = \"api\"
-frontends = [\"xet\", \"oci\"]
-root_dir = \"/data/shardline\"
-max_request_body_bytes = 134217728
-chunk_size_bytes = 131072
-upload_max_in_flight_chunks = 16
-transfer_max_in_flight_chunks = 32
-";
-        let map = toml_to_env_map(toml).expect("valid toml");
-        assert_eq!(map.get("SHARDLINE_BIND_ADDR").unwrap(), "127.0.0.1:8080");
-        assert_eq!(
-            map.get("SHARDLINE_PUBLIC_BASE_URL").unwrap(),
-            "http://localhost:8080"
-        );
-        assert_eq!(map.get("SHARDLINE_SERVER_ROLE").unwrap(), "api");
-        assert_eq!(map.get("SHARDLINE_SERVER_FRONTENDS").unwrap(), "xet,oci");
-        assert_eq!(map.get("SHARDLINE_ROOT_DIR").unwrap(), "/data/shardline");
-        assert_eq!(
-            map.get("SHARDLINE_MAX_REQUEST_BODY_BYTES").unwrap(),
-            "134217728"
-        );
-        assert_eq!(map.get("SHARDLINE_CHUNK_SIZE_BYTES").unwrap(), "131072");
-        assert_eq!(
-            map.get("SHARDLINE_UPLOAD_MAX_IN_FLIGHT_CHUNKS").unwrap(),
-            "16"
-        );
-        assert_eq!(
-            map.get("SHARDLINE_TRANSFER_MAX_IN_FLIGHT_CHUNKS").unwrap(),
-            "32"
-        );
-    }
-
-    #[test]
-    fn test_toml_to_env_map_storage_s3() {
-        let toml = b"
-[storage]
-adapter = \"s3\"
-
-[storage.s3]
-endpoint = \"https://minio.example.com:9000\"
-region = \"us-east-1\"
-bucket = \"shardline-data\"
-prefix = \"dev/\"
-virtual_hosted_style = true
-";
-        let map = toml_to_env_map(toml).expect("valid toml");
-        assert_eq!(map.get("SHARDLINE_OBJECT_STORAGE_ADAPTER").unwrap(), "s3");
-        assert_eq!(
-            map.get("SHARDLINE_S3_ENDPOINT").unwrap(),
-            "https://minio.example.com:9000"
-        );
-        assert_eq!(map.get("SHARDLINE_S3_REGION").unwrap(), "us-east-1");
-        assert_eq!(map.get("SHARDLINE_S3_BUCKET").unwrap(), "shardline-data");
-        assert_eq!(map.get("SHARDLINE_S3_PREFIX").unwrap(), "dev/");
-        assert_eq!(
-            map.get("SHARDLINE_S3_VIRTUAL_HOSTED_STYLE").unwrap(),
-            "true"
-        );
-    }
-
-    #[test]
-    fn test_toml_to_env_map_index() {
-        let toml = b"[index]\npostgres_url = \"${_TEST_DB_URL}\"\n";
-        set_env_var("_TEST_DB_URL", "postgres://user:pass@localhost/db");
-        let map = toml_to_env_map(toml).expect("valid toml");
-        assert_eq!(
-            map.get("SHARDLINE_INDEX_POSTGRES_URL").unwrap(),
-            "postgres://user:pass@localhost/db"
-        );
-    }
-
-    #[test]
-    fn test_toml_to_env_map_cache() {
-        let toml = b"
-[cache]
-adapter = \"redis\"
-redis_url = \"redis://localhost:6379\"
-ttl_seconds = 120
-";
-        let map = toml_to_env_map(toml).expect("valid toml");
-        assert_eq!(
-            map.get("SHARDLINE_RECONSTRUCTION_CACHE_ADAPTER").unwrap(),
-            "redis"
-        );
-        assert_eq!(
-            map.get("SHARDLINE_RECONSTRUCTION_CACHE_REDIS_URL").unwrap(),
-            "redis://localhost:6379"
-        );
-        assert_eq!(
-            map.get("SHARDLINE_RECONSTRUCTION_CACHE_TTL_SECONDS")
-                .unwrap(),
-            "120"
-        );
-    }
-
-    #[test]
-    fn test_toml_to_env_map_auth() {
-        let toml = b"
-[auth]
-provider = \"oidc\"
-provider_token_issuer = \"shardline\"
-provider_token_ttl_seconds = 7200
-
-[auth.oidc]
-issuer_url = \"https://accounts.example.com\"
-client_id = \"my-client\"
-";
-        let map = toml_to_env_map(toml).expect("valid toml");
-        assert_eq!(map.get("SHARDLINE_AUTH_PROVIDER").unwrap(), "oidc");
-        assert_eq!(
-            map.get("SHARDLINE_PROVIDER_TOKEN_ISSUER").unwrap(),
-            "shardline"
-        );
-        assert_eq!(
-            map.get("SHARDLINE_PROVIDER_TOKEN_TTL_SECONDS").unwrap(),
-            "7200"
-        );
-        assert_eq!(
-            map.get("SHARDLINE_AUTH_OIDC_ISSUER_URL").unwrap(),
-            "https://accounts.example.com"
-        );
-        assert_eq!(
-            map.get("SHARDLINE_AUTH_OIDC_CLIENT_ID").unwrap(),
-            "my-client"
-        );
-    }
-
-    #[test]
-    fn test_toml_to_env_map_jwks() {
-        let toml = b"
-[auth]
-provider = \"jwks\"
-
-[auth.jwks]
-url = \"https://example.com/jwks.json\"
-refresh_interval_seconds = 1800
-";
-        let map = toml_to_env_map(toml).expect("valid toml");
-        assert_eq!(map.get("SHARDLINE_AUTH_PROVIDER").unwrap(), "jwks");
-        assert_eq!(
-            map.get("SHARDLINE_AUTH_JWKS_URL").unwrap(),
-            "https://example.com/jwks.json"
-        );
-        assert_eq!(
-            map.get("SHARDLINE_AUTH_JWKS_REFRESH_INTERVAL_SECONDS")
-                .unwrap(),
-            "1800"
-        );
-    }
-
-    #[test]
-    fn test_toml_to_env_map_invalid_toml() {
-        let result = toml_to_env_map(b"[[[invalid]]]");
-        assert!(result.is_err(), "invalid TOML should fail");
-    }
-
-    #[test]
-    fn test_toml_to_env_map_invalid_utf8() {
-        let result = toml_to_env_map(b"\xff\xfe\x00");
-        assert!(result.is_err(), "invalid UTF-8 should fail");
-    }
-
-    #[test]
-    fn test_resolve_config_path_explicit() {
+    fn test_resolve_config_content_explicit() {
         let mut file = NamedTempFile::new().unwrap();
         writeln!(file, "[server]\nbind_addr = \"0.0.0.0:9999\"").unwrap();
-        let content = resolve_config_path(Some(file.path()));
+        let content = resolve_config_content(Some(file.path()));
         assert!(content.is_some());
-        let map = toml_to_env_map(&content.unwrap()).unwrap();
-        assert_eq!(map.get("SHARDLINE_BIND_ADDR").unwrap(), "0.0.0.0:9999");
+        assert!(content.unwrap().contains("0.0.0.0:9999"));
     }
 
     #[test]
-    fn test_resolve_config_path_nonexistent() {
-        let content = resolve_config_path(Some(Path::new("/nonexistent/path/shardline.toml")));
+    fn test_resolve_config_content_nonexistent() {
+        let content = resolve_config_content(Some(Path::new("/nonexistent/path/shardline.toml")));
         assert!(content.is_none());
     }
 
     #[test]
-    fn test_load_toml_env_overrides_explicit() {
-        let mut file = NamedTempFile::new().unwrap();
-        writeln!(file, "[server]\nserver_role = \"transfer\"").unwrap();
-        let result = load_toml_env_overrides(Some(file.path())).unwrap();
-        assert!(result.is_some());
-        let map = result.unwrap();
-        assert_eq!(map.get("SHARDLINE_SERVER_ROLE").unwrap(), "transfer");
-    }
-
-    #[test]
-    fn test_load_toml_env_overrides_nonexistent() {
-        let result = load_toml_env_overrides(None).unwrap();
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_env_precedence_over_toml() {
-        let toml = b"[server]\nserver_role = \"api\"\n";
-        let map = toml_to_env_map(toml).expect("valid toml");
-        // Simulate env already set: the TOML value is returned in the map
-        // but the caller (funcs.rs) skips keys already set in env.
-        assert_eq!(map.get("SHARDLINE_SERVER_ROLE").unwrap(), "api");
-    }
-
-    #[test]
-    fn test_partial_config_only_server() {
-        let toml = b"[server]\nbind_addr = \"0.0.0.0:7070\"\n";
-        let map = toml_to_env_map(toml).expect("valid toml");
-        assert_eq!(map.len(), 1);
-    }
-
-    #[test]
-    fn test_full_config_roundtrip() {
-        let toml = br#"
-[server]
-bind_addr = "0.0.0.0:8080"
-public_base_url = "https://shardline.example.com"
-server_role = "all"
-frontends = ["xet", "oci", "hub"]
-root_dir = "/var/lib/shardline"
-
-[storage]
-adapter = "s3"
-
-[storage.s3]
-endpoint = "https://s3.example.com"
-region = "us-east-1"
-bucket = "data"
-prefix = "prod/"
-
-[index]
-postgres_url = "postgres://user@localhost/db"
-
-[cache]
-adapter = "redis"
-redis_url = "redis://localhost"
-ttl_seconds = 60
-
-[auth]
-provider = "local-hmac"
-provider_token_issuer = "shardline"
-
-[auth.jwks]
-url = "https://example.com/jwks"
-"#;
-        let map = toml_to_env_map(toml).expect("valid full config");
-        assert_eq!(map.get("SHARDLINE_BIND_ADDR").unwrap(), "0.0.0.0:8080");
-        assert_eq!(
-            map.get("SHARDLINE_PUBLIC_BASE_URL").unwrap(),
-            "https://shardline.example.com"
-        );
-        assert_eq!(map.get("SHARDLINE_SERVER_ROLE").unwrap(), "all");
-        assert_eq!(
-            map.get("SHARDLINE_SERVER_FRONTENDS").unwrap(),
-            "xet,oci,hub"
-        );
-        assert_eq!(map.get("SHARDLINE_ROOT_DIR").unwrap(), "/var/lib/shardline");
-        assert_eq!(map.get("SHARDLINE_OBJECT_STORAGE_ADAPTER").unwrap(), "s3");
-        assert_eq!(
-            map.get("SHARDLINE_S3_ENDPOINT").unwrap(),
-            "https://s3.example.com"
-        );
-        assert_eq!(map.get("SHARDLINE_S3_REGION").unwrap(), "us-east-1");
-        assert_eq!(map.get("SHARDLINE_S3_BUCKET").unwrap(), "data");
-        assert_eq!(map.get("SHARDLINE_S3_PREFIX").unwrap(), "prod/");
-        assert_eq!(
-            map.get("SHARDLINE_INDEX_POSTGRES_URL").unwrap(),
-            "postgres://user@localhost/db"
-        );
-        assert_eq!(
-            map.get("SHARDLINE_RECONSTRUCTION_CACHE_ADAPTER").unwrap(),
-            "redis"
-        );
-        assert_eq!(
-            map.get("SHARDLINE_RECONSTRUCTION_CACHE_REDIS_URL").unwrap(),
-            "redis://localhost"
-        );
-        assert_eq!(
-            map.get("SHARDLINE_RECONSTRUCTION_CACHE_TTL_SECONDS")
-                .unwrap(),
-            "60"
-        );
-        assert_eq!(map.get("SHARDLINE_AUTH_PROVIDER").unwrap(), "local-hmac");
-        assert_eq!(
-            map.get("SHARDLINE_PROVIDER_TOKEN_ISSUER").unwrap(),
-            "shardline"
-        );
-        assert_eq!(
-            map.get("SHARDLINE_AUTH_JWKS_URL").unwrap(),
-            "https://example.com/jwks"
-        );
+    fn test_resolve_config_content_auto_detect() {
+        // When no explicit path is given, auto-detection tries candidates.
+        // In a test environment none should exist, so returns None.
+        let content = resolve_config_content(None);
+        assert!(content.is_none());
     }
 }

--- a/crates/shardline-server/src/config/file.rs
+++ b/crates/shardline-server/src/config/file.rs
@@ -255,13 +255,6 @@ fn toml_to_env_map(content: &[u8]) -> Result<HashMap<String, String>, String> {
     Ok(map)
 }
 
-/// Reads an optional shardline.toml (explicit path or auto-detected) and
-/// returns a mapping of SHARDLINE_* env var names to their interpolated values.
-/// Returns `Ok(None)` when no config file is found.
-///
-/// The caller is responsible for applying these values to the environment
-/// before calling the env-based config loader.
-///
 /// # Errors
 ///
 /// Returns an error message when the file exists but cannot be parsed.
@@ -269,4 +262,385 @@ pub fn load_toml_env_overrides(
     config_path: Option<&Path>,
 ) -> Result<Option<HashMap<String, String>>, String> {
     resolve_config_path(config_path).map_or(Ok(None), |bytes| toml_to_env_map(&bytes).map(Some))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_expand_tilde_no_tilde() {
+        let result = expand_tilde("/etc/shardline/shardline.toml");
+        assert_eq!(result, PathBuf::from("/etc/shardline/shardline.toml"));
+    }
+
+    #[test]
+    fn test_expand_tilde_with_home() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".to_owned());
+        let result = expand_tilde("~/.config/shardline/shardline.toml");
+        assert_eq!(
+            result,
+            PathBuf::from(home).join(".config/shardline/shardline.toml")
+        );
+    }
+
+    #[test]
+    fn test_interpolate_no_vars() {
+        assert_eq!(interpolate_env_vars("plain text"), "plain text");
+    }
+
+    fn set_env_var(key: &str, value: &str) {
+        let content = format!("{key}={value}");
+        let _ignored = dotenvy::from_read(std::io::Cursor::new(content.as_bytes()));
+    }
+
+    #[test]
+    fn test_interpolate_known_var() {
+        set_env_var("_TEST_SHARDLINE_VAR", "resolved_value");
+        assert_eq!(
+            interpolate_env_vars("prefix-${_TEST_SHARDLINE_VAR}-suffix"),
+            "prefix-resolved_value-suffix"
+        );
+    }
+
+    #[test]
+    fn test_interpolate_missing_var() {
+        let result = interpolate_env_vars("${_MISSING_VAR_XYZ}");
+        assert_eq!(result, "${_MISSING_VAR_XYZ}");
+    }
+
+    #[test]
+    fn test_interpolate_empty_var_name() {
+        // Empty var name cannot be resolved, so the literal ${} is preserved.
+        assert_eq!(interpolate_env_vars("${}"), "${}");
+    }
+
+    #[test]
+    fn test_interpolate_dollar_without_brace() {
+        assert_eq!(interpolate_env_vars("$VAR"), "$VAR");
+        assert_eq!(interpolate_env_vars("$$"), "$$");
+    }
+
+    #[test]
+    fn test_interpolate_multiple_vars() {
+        set_env_var("_TEST_INTERP_A", "hello");
+        set_env_var("_TEST_INTERP_B", "world");
+        let result = interpolate_env_vars("${_TEST_INTERP_A} ${_TEST_INTERP_B}");
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn test_toml_to_env_map_empty_document() {
+        let result = toml_to_env_map(b"");
+        assert!(result.is_ok(), "empty document is valid TOML");
+        let map = result.unwrap();
+        assert!(map.is_empty(), "empty document produces no env vars");
+    }
+
+    #[test]
+    fn test_toml_to_env_map_minimal() {
+        let toml = b"[server]\nbind_addr = \"0.0.0.0:9090\"\n";
+        let map = toml_to_env_map(toml).expect("valid toml");
+        assert_eq!(map.get("SHARDLINE_BIND_ADDR").unwrap(), "0.0.0.0:9090");
+    }
+
+    #[test]
+    fn test_toml_to_env_map_server_section() {
+        let toml = b"
+[server]
+bind_addr = \"127.0.0.1:8080\"
+public_base_url = \"http://localhost:8080\"
+server_role = \"api\"
+frontends = [\"xet\", \"oci\"]
+root_dir = \"/data/shardline\"
+max_request_body_bytes = 134217728
+chunk_size_bytes = 131072
+upload_max_in_flight_chunks = 16
+transfer_max_in_flight_chunks = 32
+";
+        let map = toml_to_env_map(toml).expect("valid toml");
+        assert_eq!(map.get("SHARDLINE_BIND_ADDR").unwrap(), "127.0.0.1:8080");
+        assert_eq!(
+            map.get("SHARDLINE_PUBLIC_BASE_URL").unwrap(),
+            "http://localhost:8080"
+        );
+        assert_eq!(map.get("SHARDLINE_SERVER_ROLE").unwrap(), "api");
+        assert_eq!(map.get("SHARDLINE_SERVER_FRONTENDS").unwrap(), "xet,oci");
+        assert_eq!(map.get("SHARDLINE_ROOT_DIR").unwrap(), "/data/shardline");
+        assert_eq!(
+            map.get("SHARDLINE_MAX_REQUEST_BODY_BYTES").unwrap(),
+            "134217728"
+        );
+        assert_eq!(map.get("SHARDLINE_CHUNK_SIZE_BYTES").unwrap(), "131072");
+        assert_eq!(
+            map.get("SHARDLINE_UPLOAD_MAX_IN_FLIGHT_CHUNKS").unwrap(),
+            "16"
+        );
+        assert_eq!(
+            map.get("SHARDLINE_TRANSFER_MAX_IN_FLIGHT_CHUNKS").unwrap(),
+            "32"
+        );
+    }
+
+    #[test]
+    fn test_toml_to_env_map_storage_s3() {
+        let toml = b"
+[storage]
+adapter = \"s3\"
+
+[storage.s3]
+endpoint = \"https://minio.example.com:9000\"
+region = \"us-east-1\"
+bucket = \"shardline-data\"
+prefix = \"dev/\"
+virtual_hosted_style = true
+";
+        let map = toml_to_env_map(toml).expect("valid toml");
+        assert_eq!(map.get("SHARDLINE_OBJECT_STORAGE_ADAPTER").unwrap(), "s3");
+        assert_eq!(
+            map.get("SHARDLINE_S3_ENDPOINT").unwrap(),
+            "https://minio.example.com:9000"
+        );
+        assert_eq!(map.get("SHARDLINE_S3_REGION").unwrap(), "us-east-1");
+        assert_eq!(map.get("SHARDLINE_S3_BUCKET").unwrap(), "shardline-data");
+        assert_eq!(map.get("SHARDLINE_S3_PREFIX").unwrap(), "dev/");
+        assert_eq!(
+            map.get("SHARDLINE_S3_VIRTUAL_HOSTED_STYLE").unwrap(),
+            "true"
+        );
+    }
+
+    #[test]
+    fn test_toml_to_env_map_index() {
+        let toml = b"[index]\npostgres_url = \"${_TEST_DB_URL}\"\n";
+        set_env_var("_TEST_DB_URL", "postgres://user:pass@localhost/db");
+        let map = toml_to_env_map(toml).expect("valid toml");
+        assert_eq!(
+            map.get("SHARDLINE_INDEX_POSTGRES_URL").unwrap(),
+            "postgres://user:pass@localhost/db"
+        );
+    }
+
+    #[test]
+    fn test_toml_to_env_map_cache() {
+        let toml = b"
+[cache]
+adapter = \"redis\"
+redis_url = \"redis://localhost:6379\"
+ttl_seconds = 120
+";
+        let map = toml_to_env_map(toml).expect("valid toml");
+        assert_eq!(
+            map.get("SHARDLINE_RECONSTRUCTION_CACHE_ADAPTER").unwrap(),
+            "redis"
+        );
+        assert_eq!(
+            map.get("SHARDLINE_RECONSTRUCTION_CACHE_REDIS_URL").unwrap(),
+            "redis://localhost:6379"
+        );
+        assert_eq!(
+            map.get("SHARDLINE_RECONSTRUCTION_CACHE_TTL_SECONDS")
+                .unwrap(),
+            "120"
+        );
+    }
+
+    #[test]
+    fn test_toml_to_env_map_auth() {
+        let toml = b"
+[auth]
+provider = \"oidc\"
+provider_token_issuer = \"shardline\"
+provider_token_ttl_seconds = 7200
+
+[auth.oidc]
+issuer_url = \"https://accounts.example.com\"
+client_id = \"my-client\"
+";
+        let map = toml_to_env_map(toml).expect("valid toml");
+        assert_eq!(map.get("SHARDLINE_AUTH_PROVIDER").unwrap(), "oidc");
+        assert_eq!(
+            map.get("SHARDLINE_PROVIDER_TOKEN_ISSUER").unwrap(),
+            "shardline"
+        );
+        assert_eq!(
+            map.get("SHARDLINE_PROVIDER_TOKEN_TTL_SECONDS").unwrap(),
+            "7200"
+        );
+        assert_eq!(
+            map.get("SHARDLINE_AUTH_OIDC_ISSUER_URL").unwrap(),
+            "https://accounts.example.com"
+        );
+        assert_eq!(
+            map.get("SHARDLINE_AUTH_OIDC_CLIENT_ID").unwrap(),
+            "my-client"
+        );
+    }
+
+    #[test]
+    fn test_toml_to_env_map_jwks() {
+        let toml = b"
+[auth]
+provider = \"jwks\"
+
+[auth.jwks]
+url = \"https://example.com/jwks.json\"
+refresh_interval_seconds = 1800
+";
+        let map = toml_to_env_map(toml).expect("valid toml");
+        assert_eq!(map.get("SHARDLINE_AUTH_PROVIDER").unwrap(), "jwks");
+        assert_eq!(
+            map.get("SHARDLINE_AUTH_JWKS_URL").unwrap(),
+            "https://example.com/jwks.json"
+        );
+        assert_eq!(
+            map.get("SHARDLINE_AUTH_JWKS_REFRESH_INTERVAL_SECONDS")
+                .unwrap(),
+            "1800"
+        );
+    }
+
+    #[test]
+    fn test_toml_to_env_map_invalid_toml() {
+        let result = toml_to_env_map(b"[[[invalid]]]");
+        assert!(result.is_err(), "invalid TOML should fail");
+    }
+
+    #[test]
+    fn test_toml_to_env_map_invalid_utf8() {
+        let result = toml_to_env_map(b"\xff\xfe\x00");
+        assert!(result.is_err(), "invalid UTF-8 should fail");
+    }
+
+    #[test]
+    fn test_resolve_config_path_explicit() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "[server]\nbind_addr = \"0.0.0.0:9999\"").unwrap();
+        let content = resolve_config_path(Some(file.path()));
+        assert!(content.is_some());
+        let map = toml_to_env_map(&content.unwrap()).unwrap();
+        assert_eq!(map.get("SHARDLINE_BIND_ADDR").unwrap(), "0.0.0.0:9999");
+    }
+
+    #[test]
+    fn test_resolve_config_path_nonexistent() {
+        let content = resolve_config_path(Some(Path::new("/nonexistent/path/shardline.toml")));
+        assert!(content.is_none());
+    }
+
+    #[test]
+    fn test_load_toml_env_overrides_explicit() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "[server]\nserver_role = \"transfer\"").unwrap();
+        let result = load_toml_env_overrides(Some(file.path())).unwrap();
+        assert!(result.is_some());
+        let map = result.unwrap();
+        assert_eq!(map.get("SHARDLINE_SERVER_ROLE").unwrap(), "transfer");
+    }
+
+    #[test]
+    fn test_load_toml_env_overrides_nonexistent() {
+        let result = load_toml_env_overrides(None).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_env_precedence_over_toml() {
+        let toml = b"[server]\nserver_role = \"api\"\n";
+        let map = toml_to_env_map(toml).expect("valid toml");
+        // Simulate env already set: the TOML value is returned in the map
+        // but the caller (funcs.rs) skips keys already set in env.
+        assert_eq!(map.get("SHARDLINE_SERVER_ROLE").unwrap(), "api");
+    }
+
+    #[test]
+    fn test_partial_config_only_server() {
+        let toml = b"[server]\nbind_addr = \"0.0.0.0:7070\"\n";
+        let map = toml_to_env_map(toml).expect("valid toml");
+        assert_eq!(map.len(), 1);
+    }
+
+    #[test]
+    fn test_full_config_roundtrip() {
+        let toml = br#"
+[server]
+bind_addr = "0.0.0.0:8080"
+public_base_url = "https://shardline.example.com"
+server_role = "all"
+frontends = ["xet", "oci", "hub"]
+root_dir = "/var/lib/shardline"
+
+[storage]
+adapter = "s3"
+
+[storage.s3]
+endpoint = "https://s3.example.com"
+region = "us-east-1"
+bucket = "data"
+prefix = "prod/"
+
+[index]
+postgres_url = "postgres://user@localhost/db"
+
+[cache]
+adapter = "redis"
+redis_url = "redis://localhost"
+ttl_seconds = 60
+
+[auth]
+provider = "local-hmac"
+provider_token_issuer = "shardline"
+
+[auth.jwks]
+url = "https://example.com/jwks"
+"#;
+        let map = toml_to_env_map(toml).expect("valid full config");
+        assert_eq!(map.get("SHARDLINE_BIND_ADDR").unwrap(), "0.0.0.0:8080");
+        assert_eq!(
+            map.get("SHARDLINE_PUBLIC_BASE_URL").unwrap(),
+            "https://shardline.example.com"
+        );
+        assert_eq!(map.get("SHARDLINE_SERVER_ROLE").unwrap(), "all");
+        assert_eq!(
+            map.get("SHARDLINE_SERVER_FRONTENDS").unwrap(),
+            "xet,oci,hub"
+        );
+        assert_eq!(map.get("SHARDLINE_ROOT_DIR").unwrap(), "/var/lib/shardline");
+        assert_eq!(map.get("SHARDLINE_OBJECT_STORAGE_ADAPTER").unwrap(), "s3");
+        assert_eq!(
+            map.get("SHARDLINE_S3_ENDPOINT").unwrap(),
+            "https://s3.example.com"
+        );
+        assert_eq!(map.get("SHARDLINE_S3_REGION").unwrap(), "us-east-1");
+        assert_eq!(map.get("SHARDLINE_S3_BUCKET").unwrap(), "data");
+        assert_eq!(map.get("SHARDLINE_S3_PREFIX").unwrap(), "prod/");
+        assert_eq!(
+            map.get("SHARDLINE_INDEX_POSTGRES_URL").unwrap(),
+            "postgres://user@localhost/db"
+        );
+        assert_eq!(
+            map.get("SHARDLINE_RECONSTRUCTION_CACHE_ADAPTER").unwrap(),
+            "redis"
+        );
+        assert_eq!(
+            map.get("SHARDLINE_RECONSTRUCTION_CACHE_REDIS_URL").unwrap(),
+            "redis://localhost"
+        );
+        assert_eq!(
+            map.get("SHARDLINE_RECONSTRUCTION_CACHE_TTL_SECONDS")
+                .unwrap(),
+            "60"
+        );
+        assert_eq!(map.get("SHARDLINE_AUTH_PROVIDER").unwrap(), "local-hmac");
+        assert_eq!(
+            map.get("SHARDLINE_PROVIDER_TOKEN_ISSUER").unwrap(),
+            "shardline"
+        );
+        assert_eq!(
+            map.get("SHARDLINE_AUTH_JWKS_URL").unwrap(),
+            "https://example.com/jwks"
+        );
+    }
 }

--- a/crates/shardline-server/src/config/file.rs
+++ b/crates/shardline-server/src/config/file.rs
@@ -1,0 +1,272 @@
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde::Deserialize;
+
+/// Top-level TOML configuration document.
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct ShardlineTomlConfig {
+    #[serde(default)]
+    server: Option<ServerSection>,
+    #[serde(default)]
+    storage: Option<StorageSection>,
+    #[serde(default)]
+    index: Option<IndexSection>,
+    #[serde(default)]
+    cache: Option<CacheSection>,
+    #[serde(default)]
+    auth: Option<AuthSection>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ServerSection {
+    bind_addr: Option<String>,
+    public_base_url: Option<String>,
+    server_role: Option<String>,
+    frontends: Option<Vec<String>>,
+    root_dir: Option<String>,
+    max_request_body_bytes: Option<u64>,
+    chunk_size_bytes: Option<u64>,
+    upload_max_in_flight_chunks: Option<u64>,
+    transfer_max_in_flight_chunks: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StorageSection {
+    adapter: Option<String>,
+    s3: Option<S3Section>,
+}
+
+#[derive(Debug, Deserialize)]
+struct S3Section {
+    endpoint: Option<String>,
+    region: Option<String>,
+    bucket: Option<String>,
+    prefix: Option<String>,
+    virtual_hosted_style: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct IndexSection {
+    postgres_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CacheSection {
+    redis_url: Option<String>,
+    adapter: Option<String>,
+    ttl_seconds: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AuthSection {
+    provider: Option<String>,
+    token_signing_key_path: Option<String>,
+    provider_api_key_path: Option<String>,
+    provider_token_issuer: Option<String>,
+    provider_token_ttl_seconds: Option<u64>,
+    jwks: Option<JwksSection>,
+    oidc: Option<OidcSection>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JwksSection {
+    url: Option<String>,
+    refresh_interval_seconds: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OidcSection {
+    issuer_url: Option<String>,
+    client_id: Option<String>,
+}
+
+/// Standard paths checked for shardline.toml, in priority order (first found wins).
+const CONFIG_FILE_CANDIDATES: &[&str] = &[
+    "shardline.toml",
+    "~/.config/shardline/shardline.toml",
+    "/etc/shardline/shardline.toml",
+];
+
+/// Expands a leading `~/` to the user's home directory.
+fn expand_tilde(path: &str) -> PathBuf {
+    if let Some(rest) = path.strip_prefix("~/")
+        && let Ok(home) = std::env::var("HOME")
+    {
+        return PathBuf::from(home).join(rest);
+    }
+    PathBuf::from(path)
+}
+
+/// Resolves the active shardline.toml path.
+/// Returns `None` when neither an explicit `--config` path nor any
+/// auto-detected candidate exists.
+pub(crate) fn resolve_config_path(explicit: Option<&Path>) -> Option<Vec<u8>> {
+    if let Some(path) = explicit {
+        return fs::read(path).ok();
+    }
+    for candidate in CONFIG_FILE_CANDIDATES {
+        let expanded = expand_tilde(candidate);
+        if let Ok(content) = fs::read(&expanded) {
+            return Some(content);
+        }
+    }
+    None
+}
+
+/// Interpolates `${VAR_NAME}` patterns in `value` using the current process
+/// environment. Returns the original value when no patterns are found.
+fn interpolate_env_vars(value: &str) -> String {
+    let mut result = String::with_capacity(value.len());
+    let mut chars = value.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '$' && chars.peek() == Some(&'{') {
+            chars.next(); // consume '{'
+            let mut var_name = String::new();
+            for c in chars.by_ref() {
+                if c == '}' {
+                    break;
+                }
+                var_name.push(c);
+            }
+            let resolved = std::env::var(&var_name).unwrap_or_else(|_| format!("${{{var_name}}}"));
+            result.push_str(&resolved);
+        } else {
+            result.push(ch);
+        }
+    }
+    result
+}
+
+/// Parses shardline.toml content into a mapping of SHARDLINE_* env var names
+/// to their interpolated values. Values that reference `${VAR}` are resolved
+/// from the current process environment.
+fn toml_to_env_map(content: &[u8]) -> Result<HashMap<String, String>, String> {
+    let text = std::str::from_utf8(content).map_err(|e| format!("TOML encoding error: {e}"))?;
+    let config: ShardlineTomlConfig =
+        toml::from_str(text).map_err(|e| format!("TOML parse error: {e}"))?;
+
+    let mut map = HashMap::new();
+    let mut add = |key: &str, value: Option<String>| {
+        if let Some(value) = value {
+            map.insert(key.to_owned(), interpolate_env_vars(&value));
+        }
+    };
+
+    // Server section
+    if let Some(srv) = &config.server {
+        add("SHARDLINE_BIND_ADDR", srv.bind_addr.clone());
+        add("SHARDLINE_PUBLIC_BASE_URL", srv.public_base_url.clone());
+        add("SHARDLINE_SERVER_ROLE", srv.server_role.clone());
+        if let Some(frontends) = &srv.frontends {
+            add("SHARDLINE_SERVER_FRONTENDS", Some(frontends.join(",")));
+        }
+        add("SHARDLINE_ROOT_DIR", srv.root_dir.clone());
+        add(
+            "SHARDLINE_MAX_REQUEST_BODY_BYTES",
+            srv.max_request_body_bytes.map(|v| v.to_string()),
+        );
+        add(
+            "SHARDLINE_CHUNK_SIZE_BYTES",
+            srv.chunk_size_bytes.map(|v| v.to_string()),
+        );
+        add(
+            "SHARDLINE_UPLOAD_MAX_IN_FLIGHT_CHUNKS",
+            srv.upload_max_in_flight_chunks.map(|v| v.to_string()),
+        );
+        add(
+            "SHARDLINE_TRANSFER_MAX_IN_FLIGHT_CHUNKS",
+            srv.transfer_max_in_flight_chunks.map(|v| v.to_string()),
+        );
+    }
+
+    // Storage section
+    if let Some(stg) = &config.storage {
+        add("SHARDLINE_OBJECT_STORAGE_ADAPTER", stg.adapter.clone());
+        if let Some(s3) = &stg.s3 {
+            add("SHARDLINE_S3_ENDPOINT", s3.endpoint.clone());
+            add("SHARDLINE_S3_REGION", s3.region.clone());
+            add("SHARDLINE_S3_BUCKET", s3.bucket.clone());
+            add("SHARDLINE_S3_PREFIX", s3.prefix.clone());
+            add(
+                "SHARDLINE_S3_VIRTUAL_HOSTED_STYLE",
+                s3.virtual_hosted_style.map(|v| v.to_string()),
+            );
+        }
+    }
+
+    // Index section
+    if let Some(idx) = &config.index {
+        add("SHARDLINE_INDEX_POSTGRES_URL", idx.postgres_url.clone());
+    }
+
+    // Cache section
+    if let Some(cch) = &config.cache {
+        add(
+            "SHARDLINE_RECONSTRUCTION_CACHE_ADAPTER",
+            cch.adapter.clone(),
+        );
+        add(
+            "SHARDLINE_RECONSTRUCTION_CACHE_REDIS_URL",
+            cch.redis_url.clone(),
+        );
+        add(
+            "SHARDLINE_RECONSTRUCTION_CACHE_TTL_SECONDS",
+            cch.ttl_seconds.map(|v| v.to_string()),
+        );
+    }
+
+    // Auth section
+    if let Some(auth) = &config.auth {
+        add("SHARDLINE_AUTH_PROVIDER", auth.provider.clone());
+        add(
+            "SHARDLINE_TOKEN_SIGNING_KEY_PATH",
+            auth.token_signing_key_path.clone(),
+        );
+        add(
+            "SHARDLINE_PROVIDER_API_KEY_PATH",
+            auth.provider_api_key_path.clone(),
+        );
+        add(
+            "SHARDLINE_PROVIDER_TOKEN_ISSUER",
+            auth.provider_token_issuer.clone(),
+        );
+        add(
+            "SHARDLINE_PROVIDER_TOKEN_TTL_SECONDS",
+            auth.provider_token_ttl_seconds.map(|v| v.to_string()),
+        );
+        if let Some(jwks) = &auth.jwks {
+            add("SHARDLINE_AUTH_JWKS_URL", jwks.url.clone());
+            add(
+                "SHARDLINE_AUTH_JWKS_REFRESH_INTERVAL_SECONDS",
+                jwks.refresh_interval_seconds.map(|v| v.to_string()),
+            );
+        }
+        if let Some(oidc) = &auth.oidc {
+            add("SHARDLINE_AUTH_OIDC_ISSUER_URL", oidc.issuer_url.clone());
+            add("SHARDLINE_AUTH_OIDC_CLIENT_ID", oidc.client_id.clone());
+        }
+    }
+
+    Ok(map)
+}
+
+/// Reads an optional shardline.toml (explicit path or auto-detected) and
+/// returns a mapping of SHARDLINE_* env var names to their interpolated values.
+/// Returns `Ok(None)` when no config file is found.
+///
+/// The caller is responsible for applying these values to the environment
+/// before calling the env-based config loader.
+///
+/// # Errors
+///
+/// Returns an error message when the file exists but cannot be parsed.
+pub fn load_toml_env_overrides(
+    config_path: Option<&Path>,
+) -> Result<Option<HashMap<String, String>>, String> {
+    resolve_config_path(config_path).map_or(Ok(None), |bytes| toml_to_env_map(&bytes).map(Some))
+}

--- a/crates/shardline-server/src/config/file.rs
+++ b/crates/shardline-server/src/config/file.rs
@@ -74,13 +74,11 @@ pub struct AuthSection {
 #[derive(Debug, Deserialize)]
 pub struct JwksSection {
     pub url: Option<String>,
-    pub refresh_interval_seconds: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct OidcSection {
     pub issuer_url: Option<String>,
-    pub client_id: Option<String>,
 }
 
 /// Standard paths checked for shardline.toml, in priority order (first found wins).

--- a/crates/shardline-server/src/config/file.rs
+++ b/crates/shardline-server/src/config/file.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 
 /// Top-level TOML configuration document.
 #[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ShardlineTomlConfig {
     #[serde(default)]
     pub server: Option<ServerSection>,
@@ -21,6 +22,7 @@ pub struct ShardlineTomlConfig {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ServerSection {
     pub bind_addr: Option<String>,
     pub public_base_url: Option<String>,
@@ -34,26 +36,31 @@ pub struct ServerSection {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct StorageSection {
     pub adapter: Option<String>,
     pub s3: Option<S3Section>,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct S3Section {
     pub endpoint: Option<String>,
     pub region: Option<String>,
     pub bucket: Option<String>,
     pub prefix: Option<String>,
+    pub allow_http: Option<bool>,
     pub virtual_hosted_style: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct IndexSection {
     pub postgres_url: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CacheSection {
     pub redis_url: Option<String>,
     pub adapter: Option<String>,
@@ -61,6 +68,7 @@ pub struct CacheSection {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AuthSection {
     pub provider: Option<String>,
     pub token_signing_key_path: Option<String>,
@@ -72,6 +80,7 @@ pub struct AuthSection {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct JwksSection {
     pub url: Option<String>,
 }
@@ -104,14 +113,21 @@ fn expand_tilde(path: &str) -> PathBuf {
 /// Resolves the active shardline.toml content as a string.
 /// Returns `None` when neither an explicit `--config` path nor any
 /// auto-detected candidate exists.
-pub(crate) fn resolve_config_content(explicit: Option<&Path>) -> Option<String> {
+pub(crate) fn resolve_config_content(explicit: Option<&Path>) -> Result<Option<String>, String> {
     if let Some(path) = explicit {
-        return fs::read_to_string(path).ok();
+        return fs::read_to_string(path)
+            .map(Some)
+            .map_err(|error| format!("failed to read config file {}: {error}", path.display()));
     }
-    CONFIG_FILE_CANDIDATES.iter().find_map(|candidate| {
+    for candidate in CONFIG_FILE_CANDIDATES {
         let expanded = expand_tilde(candidate);
-        fs::read_to_string(&expanded).ok()
-    })
+        if expanded.exists() {
+            return fs::read_to_string(&expanded).map(Some).map_err(|error| {
+                format!("failed to read config file {}: {error}", expanded.display())
+            });
+        }
+    }
+    Ok(None)
 }
 
 /// Parses a shardline.toml file at the given path (or auto-detected) and
@@ -122,7 +138,7 @@ pub(crate) fn resolve_config_content(explicit: Option<&Path>) -> Option<String> 
 /// Returns an error message string when the file exists but cannot be
 /// read or parsed as valid TOML.
 pub fn load_toml_config(config_path: Option<&Path>) -> Result<Option<ShardlineTomlConfig>, String> {
-    let Some(content) = resolve_config_content(config_path) else {
+    let Some(content) = resolve_config_content(config_path)? else {
         return Ok(None);
     };
     let config: ShardlineTomlConfig =
@@ -156,7 +172,7 @@ mod tests {
     fn test_resolve_config_content_explicit() {
         let mut file = NamedTempFile::new().unwrap();
         writeln!(file, "[server]\nbind_addr = \"0.0.0.0:9999\"").unwrap();
-        let content = resolve_config_content(Some(file.path()));
+        let content = resolve_config_content(Some(file.path())).unwrap();
         assert!(content.is_some());
         assert!(content.unwrap().contains("0.0.0.0:9999"));
     }
@@ -164,14 +180,14 @@ mod tests {
     #[test]
     fn test_resolve_config_content_nonexistent() {
         let content = resolve_config_content(Some(Path::new("/nonexistent/path/shardline.toml")));
-        assert!(content.is_none());
+        assert!(content.is_err());
     }
 
     #[test]
     fn test_resolve_config_content_auto_detect() {
         // When no explicit path is given, auto-detection tries candidates.
         // In a test environment none should exist, so returns None.
-        let content = resolve_config_content(None);
+        let content = resolve_config_content(None).unwrap();
         assert!(content.is_none());
     }
 }

--- a/crates/shardline-server/src/config/mod.rs
+++ b/crates/shardline-server/src/config/mod.rs
@@ -4,6 +4,8 @@ mod types;
 
 pub use types::*;
 
+pub(crate) mod file;
+
 #[cfg(test)]
 use secrets::{
     PendingS3ObjectStoreConfig, configure_s3_object_store_config, optional_s3_secret_from_sources,

--- a/crates/shardline-server/src/config/mod.rs
+++ b/crates/shardline-server/src/config/mod.rs
@@ -6,6 +6,8 @@ pub use types::*;
 
 pub(crate) mod file;
 
+pub use env::load_server_config_from_env_with_toml;
+
 #[cfg(test)]
 use secrets::{
     PendingS3ObjectStoreConfig, configure_s3_object_store_config, optional_s3_secret_from_sources,

--- a/crates/shardline-server/src/config/types/error.rs
+++ b/crates/shardline-server/src/config/types/error.rs
@@ -300,6 +300,9 @@ pub enum ServerConfigError {
     /// The public base URL is not a valid URL.
     #[error("SHARDLINE_PUBLIC_BASE_URL is not a valid URL: {0}")]
     InvalidPublicBaseUrl(String),
+    /// A configuration file could not be loaded.
+    #[error("configuration file error: {0}")]
+    ConfigFileError(String),
     /// OIDC auth provider requires an issuer URL.
     #[error("oidc auth provider requires SHARDLINE_AUTH_OIDC_ISSUER")]
     MissingOidcIssuer,

--- a/crates/shardline-server/src/lib.rs
+++ b/crates/shardline-server/src/lib.rs
@@ -142,7 +142,7 @@ pub use app::{serve, serve_with_listener};
 pub use backup::{BackupManifestReport, write_backup_manifest};
 pub use config::{
     AuthProviderKind, ObjectStorageAdapter, ServerConfig, ServerConfigError, ShardMetadataLimits,
-    file::load_toml_config, file::load_toml_env_overrides, load_server_config_from_env_with_toml,
+    file::load_toml_config, load_server_config_from_env_with_toml,
 };
 pub use database_migration::{
     DatabaseMigration, DatabaseMigrationCommand, DatabaseMigrationError, DatabaseMigrationOptions,

--- a/crates/shardline-server/src/lib.rs
+++ b/crates/shardline-server/src/lib.rs
@@ -142,7 +142,7 @@ pub use app::{serve, serve_with_listener};
 pub use backup::{BackupManifestReport, write_backup_manifest};
 pub use config::{
     AuthProviderKind, ObjectStorageAdapter, ServerConfig, ServerConfigError, ShardMetadataLimits,
-    file::load_toml_env_overrides,
+    file::load_toml_config, file::load_toml_env_overrides, load_server_config_from_env_with_toml,
 };
 pub use database_migration::{
     DatabaseMigration, DatabaseMigrationCommand, DatabaseMigrationError, DatabaseMigrationOptions,

--- a/crates/shardline-server/src/lib.rs
+++ b/crates/shardline-server/src/lib.rs
@@ -142,6 +142,7 @@ pub use app::{serve, serve_with_listener};
 pub use backup::{BackupManifestReport, write_backup_manifest};
 pub use config::{
     AuthProviderKind, ObjectStorageAdapter, ServerConfig, ServerConfigError, ShardMetadataLimits,
+    file::load_toml_env_overrides,
 };
 pub use database_migration::{
     DatabaseMigration, DatabaseMigrationCommand, DatabaseMigrationError, DatabaseMigrationOptions,

--- a/crates/shardline-server/tests/server_config_e2e.rs
+++ b/crates/shardline-server/tests/server_config_e2e.rs
@@ -12,17 +12,11 @@
     clippy::panic
 )]
 
-use std::{
-    io::Write,
-    num::NonZeroUsize,
-    path::Path,
-};
-
+use std::{io::Write, num::NonZeroUsize, path::Path};
 
 use shardline_protocol::{RepositoryProvider, RepositoryScope, TokenClaims, TokenScope};
 use shardline_server::{
-    ServerConfig, ServerConfigError, ServerFrontend, ServerRole, app,
-    load_server_config_from_env_with_toml, load_toml_config,
+    ServerConfig, ServerConfigError, ServerFrontend, ServerRole, app, load_toml_config,
 };
 use shardline_server_core::{AuthProvider, auth::LocalHmacProvider};
 use tempfile::TempDir;
@@ -155,14 +149,21 @@ fn write_toml(dir: &Path, content: &str) -> std::path::PathBuf {
 #[test]
 fn test_load_toml_config_found() {
     let dir = TempDir::new().unwrap();
-    write_toml(dir.path(), r#"[server]
+    write_toml(
+        dir.path(),
+        r#"[server]
 bind_addr = "127.0.0.1:9090"
 server_role = "api"
 frontends = ["xet", "oci"]
-"#);
+"#,
+    );
     let config_path = dir.path().join("shardline.toml");
     let result = load_toml_config(Some(&config_path));
-    assert!(result.is_ok(), "should parse valid TOML: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "should parse valid TOML: {:?}",
+        result.err()
+    );
     let toml = result.unwrap().unwrap();
     let srv = toml.server.expect("server section should be present");
     assert_eq!(srv.bind_addr.unwrap(), "127.0.0.1:9090");
@@ -186,35 +187,210 @@ fn test_load_toml_config_invalid_syntax() {
     assert!(result.is_err(), "invalid TOML should fail");
 }
 
+// ── Additional TOML config tests ────────────────────────────────────
+
 #[test]
-fn test_load_server_config_from_env_with_toml_integration() {
+fn test_load_toml_config_minimal() {
     let dir = TempDir::new().unwrap();
-    write_toml(dir.path(), r#"
-[server]
-bind_addr = "0.0.0.0:8080"
-public_base_url = "https://cas.example.com"
-server_role = "all"
-frontends = ["xet"]
-root_dir = "/tmp/shardline-test"
-
-[storage]
-adapter = "local"
-
-[cache]
-adapter = "memory"
-ttl_seconds = 60
-
-[auth]
-provider = "local"
-provider_token_issuer = "test-issuer"
-provider_token_ttl_seconds = 600
-"#);
+    write_toml(
+        dir.path(),
+        r#"[server]
+bind_addr = "127.0.0.1:5555"
+"#,
+    );
     let config_path = dir.path().join("shardline.toml");
     let toml = load_toml_config(Some(&config_path)).unwrap().unwrap();
-    let config = load_server_config_from_env_with_toml(&toml)
-        .unwrap_or_else(|e| panic!("config should load: {e:?}"));
-    assert_eq!(config.bind_addr().to_string(), "0.0.0.0:8080");
-    assert_eq!(config.public_base_url(), "https://cas.example.com");
-    assert_eq!(config.server_role().as_str(), "all");
-    assert!(!config.server_frontends().is_empty());
+    assert_eq!(
+        toml.server.as_ref().unwrap().bind_addr.as_deref(),
+        Some("127.0.0.1:5555")
+    );
+    assert!(toml.storage.is_none());
+    assert!(toml.index.is_none());
+    assert!(toml.cache.is_none());
+    assert!(toml.auth.is_none());
+}
+
+#[test]
+fn test_load_toml_config_full_storage_s3() {
+    let dir = TempDir::new().unwrap();
+    write_toml(
+        dir.path(),
+        r#"
+[storage]
+adapter = "s3"
+
+[storage.s3]
+endpoint = "https://s3.custom.com"
+region = "eu-west-1"
+bucket = "my-bucket"
+prefix = "staging/"
+virtual_hosted_style = true
+"#,
+    );
+    let config_path = dir.path().join("shardline.toml");
+    let toml = load_toml_config(Some(&config_path)).unwrap().unwrap();
+    let s3 = toml.storage.unwrap().s3.unwrap();
+    assert_eq!(s3.endpoint.unwrap(), "https://s3.custom.com");
+    assert_eq!(s3.region.unwrap(), "eu-west-1");
+    assert_eq!(s3.bucket.unwrap(), "my-bucket");
+    assert_eq!(s3.prefix.unwrap(), "staging/");
+    assert!(s3.virtual_hosted_style.unwrap());
+}
+
+#[test]
+fn test_load_toml_config_full_auth_jwks_oidc() {
+    let dir = TempDir::new().unwrap();
+    write_toml(
+        dir.path(),
+        r#"
+[auth]
+provider = "jwks"
+
+[auth.jwks]
+url = "https://auth.example.com/jwks"
+refresh_interval_seconds = 900
+
+[auth.oidc]
+issuer_url = "https://accounts.example.com"
+client_id = "shardline-app"
+"#,
+    );
+    let config_path = dir.path().join("shardline.toml");
+    let toml = load_toml_config(Some(&config_path)).unwrap().unwrap();
+    let auth = toml.auth.unwrap();
+    assert_eq!(auth.provider.unwrap(), "jwks");
+    assert_eq!(
+        auth.jwks.as_ref().unwrap().url.as_deref(),
+        Some("https://auth.example.com/jwks")
+    );
+    assert_eq!(
+        auth.jwks.as_ref().unwrap().refresh_interval_seconds,
+        Some(900)
+    );
+    assert_eq!(
+        auth.oidc.as_ref().unwrap().issuer_url.as_deref(),
+        Some("https://accounts.example.com")
+    );
+    assert_eq!(
+        auth.oidc.as_ref().unwrap().client_id.as_deref(),
+        Some("shardline-app")
+    );
+}
+
+#[test]
+fn test_load_toml_config_empty_document() {
+    let dir = TempDir::new().unwrap();
+    write_toml(dir.path(), "");
+    let config_path = dir.path().join("shardline.toml");
+    let toml = load_toml_config(Some(&config_path)).unwrap().unwrap();
+    assert!(toml.server.is_none());
+    assert!(toml.storage.is_none());
+    assert!(toml.index.is_none());
+    assert!(toml.cache.is_none());
+    assert!(toml.auth.is_none());
+}
+
+#[test]
+fn test_load_toml_config_cache_section() {
+    let dir = TempDir::new().unwrap();
+    write_toml(
+        dir.path(),
+        r#"
+[cache]
+adapter = "redis"
+ttl_seconds = 120
+"#,
+    );
+    let config_path = dir.path().join("shardline.toml");
+    let toml = load_toml_config(Some(&config_path)).unwrap().unwrap();
+    let cch = toml.cache.as_ref().unwrap();
+    assert_eq!(cch.adapter.as_deref(), Some("redis"));
+    assert_eq!(cch.ttl_seconds, Some(120));
+}
+
+#[test]
+fn test_load_toml_config_unknown_fields_ignored() {
+    // TOML with unknown fields should not cause errors (serde default behavior)
+    let dir = TempDir::new().unwrap();
+    write_toml(
+        dir.path(),
+        r#"
+[server]
+bind_addr = "0.0.0.0:8080"
+unknown_field = "should be ignored"
+
+[unknown_section]
+foo = "bar"
+"#,
+    );
+    let config_path = dir.path().join("shardline.toml");
+    let result = load_toml_config(Some(&config_path));
+    assert!(
+        result.is_ok(),
+        "unknown fields should be ignored: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_load_toml_config_utf8_bom() {
+    // TOML parsers handle UTF-8 BOM
+    let dir = TempDir::new().unwrap();
+    write_toml(
+        dir.path(),
+        "\u{feff}[server]\nbind_addr = \"0.0.0.0:6060\"\n",
+    );
+    let config_path = dir.path().join("shardline.toml");
+    let result = load_toml_config(Some(&config_path));
+    assert!(result.is_ok(), "UTF-8 BOM should be handled");
+    let toml = result.unwrap().unwrap();
+    assert_eq!(toml.server.unwrap().bind_addr.unwrap(), "0.0.0.0:6060");
+}
+
+#[test]
+fn test_load_toml_config_file_not_found_returns_none() {
+    let result = load_toml_config(None).unwrap();
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_load_toml_config_absolute_path_not_found() {
+    let result = load_toml_config(Some(Path::new("/etc/shardline/shardline.toml"))).unwrap();
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_load_toml_config_jwks_section() {
+    let dir = TempDir::new().unwrap();
+    write_toml(
+        dir.path(),
+        r#"
+[auth]
+provider = "jwks"
+
+[auth.jwks]
+url = "https://example.com/jwks.json"
+refresh_interval_seconds = 1800
+"#,
+    );
+    let config_path = dir.path().join("shardline.toml");
+    let toml = load_toml_config(Some(&config_path)).unwrap().unwrap();
+    let jwks = toml.auth.as_ref().unwrap().jwks.as_ref().unwrap();
+    assert_eq!(jwks.url.as_deref(), Some("https://example.com/jwks.json"));
+    assert_eq!(jwks.refresh_interval_seconds, Some(1800));
+}
+
+#[test]
+fn test_load_toml_config_invalid_server_role() {
+    let dir = TempDir::new().unwrap();
+    write_toml(
+        dir.path(),
+        r#"[server]
+server_role = "invalid_role"
+"#,
+    );
+    let config_path = dir.path().join("shardline.toml");
+    let toml = load_toml_config(Some(&config_path)).unwrap().unwrap();
+    // TOML parsing succeeds; validation happens at config load time
+    assert_eq!(toml.server.unwrap().server_role.unwrap(), "invalid_role");
 }

--- a/crates/shardline-server/tests/server_config_e2e.rs
+++ b/crates/shardline-server/tests/server_config_e2e.rs
@@ -12,10 +12,18 @@
     clippy::panic
 )]
 
-use std::num::NonZeroUsize;
+use std::{
+    io::Write,
+    num::NonZeroUsize,
+    path::Path,
+};
+
 
 use shardline_protocol::{RepositoryProvider, RepositoryScope, TokenClaims, TokenScope};
-use shardline_server::{ServerConfig, ServerConfigError, ServerFrontend, ServerRole, app};
+use shardline_server::{
+    ServerConfig, ServerConfigError, ServerFrontend, ServerRole, app,
+    load_server_config_from_env_with_toml, load_toml_config,
+};
 use shardline_server_core::{AuthProvider, auth::LocalHmacProvider};
 use tempfile::TempDir;
 use tower::ServiceExt;
@@ -133,4 +141,80 @@ fn test_server_with_no_frontends() {
         matches!(err, ServerConfigError::MissingServerFrontends),
         "expected MissingServerFrontends error, got: {err:?}"
     );
+}
+
+// ── TOML config file tests ──────────────────────────────────────────
+
+fn write_toml(dir: &Path, content: &str) -> std::path::PathBuf {
+    let path = dir.join("shardline.toml");
+    let mut file = std::fs::File::create(&path).unwrap();
+    write!(file, "{content}").unwrap();
+    path
+}
+
+#[test]
+fn test_load_toml_config_found() {
+    let dir = TempDir::new().unwrap();
+    write_toml(dir.path(), r#"[server]
+bind_addr = "127.0.0.1:9090"
+server_role = "api"
+frontends = ["xet", "oci"]
+"#);
+    let config_path = dir.path().join("shardline.toml");
+    let result = load_toml_config(Some(&config_path));
+    assert!(result.is_ok(), "should parse valid TOML: {:?}", result.err());
+    let toml = result.unwrap().unwrap();
+    let srv = toml.server.expect("server section should be present");
+    assert_eq!(srv.bind_addr.unwrap(), "127.0.0.1:9090");
+    assert_eq!(srv.server_role.unwrap(), "api");
+    assert_eq!(srv.frontends.unwrap(), vec!["xet", "oci"]);
+}
+
+#[test]
+fn test_load_toml_config_not_found() {
+    let result = load_toml_config(Some(Path::new("/nonexistent/path/shardline.toml")));
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_none());
+}
+
+#[test]
+fn test_load_toml_config_invalid_syntax() {
+    let dir = TempDir::new().unwrap();
+    write_toml(dir.path(), "[[[invalid]]]");
+    let config_path = dir.path().join("shardline.toml");
+    let result = load_toml_config(Some(&config_path));
+    assert!(result.is_err(), "invalid TOML should fail");
+}
+
+#[test]
+fn test_load_server_config_from_env_with_toml_integration() {
+    let dir = TempDir::new().unwrap();
+    write_toml(dir.path(), r#"
+[server]
+bind_addr = "0.0.0.0:8080"
+public_base_url = "https://cas.example.com"
+server_role = "all"
+frontends = ["xet"]
+root_dir = "/tmp/shardline-test"
+
+[storage]
+adapter = "local"
+
+[cache]
+adapter = "memory"
+ttl_seconds = 60
+
+[auth]
+provider = "local"
+provider_token_issuer = "test-issuer"
+provider_token_ttl_seconds = 600
+"#);
+    let config_path = dir.path().join("shardline.toml");
+    let toml = load_toml_config(Some(&config_path)).unwrap().unwrap();
+    let config = load_server_config_from_env_with_toml(&toml)
+        .unwrap_or_else(|e| panic!("config should load: {e:?}"));
+    assert_eq!(config.bind_addr().to_string(), "0.0.0.0:8080");
+    assert_eq!(config.public_base_url(), "https://cas.example.com");
+    assert_eq!(config.server_role().as_str(), "all");
+    assert!(!config.server_frontends().is_empty());
 }

--- a/crates/shardline-server/tests/server_config_e2e.rs
+++ b/crates/shardline-server/tests/server_config_e2e.rs
@@ -174,8 +174,7 @@ frontends = ["xet", "oci"]
 #[test]
 fn test_load_toml_config_not_found() {
     let result = load_toml_config(Some(Path::new("/nonexistent/path/shardline.toml")));
-    assert!(result.is_ok());
-    assert!(result.unwrap().is_none());
+    assert!(result.is_err());
 }
 
 #[test]
@@ -224,6 +223,7 @@ endpoint = "https://s3.custom.com"
 region = "eu-west-1"
 bucket = "my-bucket"
 prefix = "staging/"
+allow_http = true
 virtual_hosted_style = true
 "#,
     );
@@ -234,6 +234,7 @@ virtual_hosted_style = true
     assert_eq!(s3.region.unwrap(), "eu-west-1");
     assert_eq!(s3.bucket.unwrap(), "my-bucket");
     assert_eq!(s3.prefix.unwrap(), "staging/");
+    assert_eq!(s3.allow_http, Some(true));
     assert!(s3.virtual_hosted_style.unwrap());
 }
 
@@ -299,8 +300,7 @@ ttl_seconds = 120
 }
 
 #[test]
-fn test_load_toml_config_unknown_fields_ignored() {
-    // TOML with unknown fields should not cause errors (serde default behavior)
+fn test_load_toml_config_unknown_fields_rejected() {
     let dir = TempDir::new().unwrap();
     write_toml(
         dir.path(),
@@ -315,11 +315,7 @@ foo = "bar"
     );
     let config_path = dir.path().join("shardline.toml");
     let result = load_toml_config(Some(&config_path));
-    assert!(
-        result.is_ok(),
-        "unknown fields should be ignored: {:?}",
-        result.err()
-    );
+    assert!(result.is_err(), "unknown fields must be rejected");
 }
 
 #[test]
@@ -345,8 +341,8 @@ fn test_load_toml_config_file_not_found_returns_none() {
 
 #[test]
 fn test_load_toml_config_absolute_path_not_found() {
-    let result = load_toml_config(Some(Path::new("/etc/shardline/shardline.toml"))).unwrap();
-    assert!(result.is_none());
+    let result = load_toml_config(Some(Path::new("/etc/shardline/shardline.toml")));
+    assert!(result.is_err());
 }
 
 #[test]

--- a/crates/shardline-server/tests/server_config_e2e.rs
+++ b/crates/shardline-server/tests/server_config_e2e.rs
@@ -248,11 +248,9 @@ provider = "jwks"
 
 [auth.jwks]
 url = "https://auth.example.com/jwks"
-refresh_interval_seconds = 900
 
 [auth.oidc]
 issuer_url = "https://accounts.example.com"
-client_id = "shardline-app"
 "#,
     );
     let config_path = dir.path().join("shardline.toml");
@@ -264,16 +262,8 @@ client_id = "shardline-app"
         Some("https://auth.example.com/jwks")
     );
     assert_eq!(
-        auth.jwks.as_ref().unwrap().refresh_interval_seconds,
-        Some(900)
-    );
-    assert_eq!(
         auth.oidc.as_ref().unwrap().issuer_url.as_deref(),
         Some("https://accounts.example.com")
-    );
-    assert_eq!(
-        auth.oidc.as_ref().unwrap().client_id.as_deref(),
-        Some("shardline-app")
     );
 }
 
@@ -370,14 +360,12 @@ provider = "jwks"
 
 [auth.jwks]
 url = "https://example.com/jwks.json"
-refresh_interval_seconds = 1800
 "#,
     );
     let config_path = dir.path().join("shardline.toml");
     let toml = load_toml_config(Some(&config_path)).unwrap().unwrap();
     let jwks = toml.auth.as_ref().unwrap().jwks.as_ref().unwrap();
     assert_eq!(jwks.url.as_deref(), Some("https://example.com/jwks.json"));
-    assert_eq!(jwks.refresh_interval_seconds, Some(1800));
 }
 
 #[test]

--- a/crates/shardline-xet-adapter/src/shard_store.rs
+++ b/crates/shardline-xet-adapter/src/shard_store.rs
@@ -1,10 +1,8 @@
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
     io::{Cursor, Read},
-    mem::size_of,
 };
 
-use axum::body::Bytes;
 use shardline_index::{
     AsyncIndexStore, DedupeShardMapping, FileChunkRecord, FileRecord, parse_xet_hash_hex,
 };
@@ -19,12 +17,14 @@ use shardline_xet_core::{
     merklehash::{MerkleHash, compute_data_hash},
     metadata_shard::{
         MDBShardFileHeader,
-        file_structs::{FileDataSequenceHeader, MDBFileInfo, MDBFileInfoView},
+        file_structs::{
+            FileDataSequenceEntry, FileDataSequenceHeader, FileMetadataExt, FileVerificationEntry,
+            MDBFileInfo,
+        },
         hash_is_global_dedup_eligible,
-        shard_file::MDB_FILE_INFO_ENTRY_SIZE,
         shard_in_memory::MDBInMemoryShard,
         xorb_structs::{
-            MDB_CHUNK_WITH_GLOBAL_DEDUP_FLAG, MDBXorbInfo, MDBXorbInfoView, XorbChunkSequenceEntry,
+            MDB_CHUNK_WITH_GLOBAL_DEDUP_FLAG, MDBXorbInfo, XorbChunkSequenceEntry,
             XorbChunkSequenceHeader,
         },
     },
@@ -255,12 +255,33 @@ fn read_bounded_file_sections<R: Read>(
             limits.max_reconstruction_terms().get(),
         )?;
 
-        let followed_entries = file_section_followed_entries(&header, segment_count)?;
-        let followed_bytes = checked_mul(followed_entries, MDB_FILE_INFO_ENTRY_SIZE)?;
-        let file_view = read_file_info_view(reader, header, followed_bytes)?;
+        file_section_followed_entries(&header, segment_count)?;
+        let mut segments = Vec::with_capacity(segment_count);
+        for _ in 0..segment_count {
+            segments.push(
+                FileDataSequenceEntry::deserialize(reader, version)
+                    .map_err(|error| invalid_serialized_shard(&error))?,
+            );
+        }
+        let mut verification = Vec::with_capacity(segment_count);
+        if header.contains_verification() {
+            for _ in 0..segment_count {
+                verification.push(
+                    FileVerificationEntry::deserialize(reader, version)
+                        .map_err(|error| invalid_serialized_shard(&error))?,
+                );
+            }
+        }
+        let metadata_ext = header
+            .contains_metadata_ext()
+            .then(|| FileMetadataExt::deserialize(reader, version))
+            .transpose()
+            .map_err(|error| invalid_serialized_shard(&error))?;
 
         if segment_count > 0 {
-            let first_segment = file_view.entry(0);
+            let first_segment = segments
+                .first()
+                .ok_or(InvalidSerializedShardError::ParserRejectedMetadata)?;
             let first_index = usize::try_from(first_segment.chunk_index_start)?;
             file_start_entries
                 .entry(first_segment.xorb_hash)
@@ -268,7 +289,12 @@ fn read_bounded_file_sections<R: Read>(
                 .insert(first_index);
         }
 
-        file_infos.push(MDBFileInfo::from(&file_view));
+        file_infos.push(MDBFileInfo {
+            metadata: header,
+            segments,
+            verification,
+            metadata_ext,
+        });
     }
 }
 
@@ -296,11 +322,20 @@ fn read_bounded_xorb_sections<R: Read>(
 
         let chunk_count = usize::try_from(header.num_entries)?;
         xorb_chunks = checked_add_limit(xorb_chunks, chunk_count, limits.max_xorb_chunks().get())?;
-        let followed_bytes = checked_mul(chunk_count, size_of::<XorbChunkSequenceEntry>())?;
-        let xorb_view = read_xorb_info_view(reader, header, followed_bytes)?;
+        let mut chunks = Vec::with_capacity(chunk_count);
+        for _ in 0..chunk_count {
+            chunks.push(
+                XorbChunkSequenceEntry::deserialize(reader, version)
+                    .map_err(|error| invalid_serialized_shard(&error))?,
+            );
+        }
+        let xorb_info = MDBXorbInfo {
+            metadata: header,
+            chunks,
+        };
 
-        collect_dedupe_chunk_hashes(&xorb_view, file_start_entries, &mut dedupe_chunk_hashes);
-        xorb_infos.push(MDBXorbInfo::from(&xorb_view));
+        collect_dedupe_chunk_hashes(&xorb_info, file_start_entries, &mut dedupe_chunk_hashes);
+        xorb_infos.push(xorb_info);
     }
 }
 
@@ -321,64 +356,13 @@ fn file_section_followed_entries(
     )
 }
 
-fn read_file_info_view<R: Read>(
-    reader: &mut R,
-    header: FileDataSequenceHeader,
-    followed_bytes: usize,
-) -> Result<MDBFileInfoView, XetAdapterError> {
-    let total_bytes = checked_add(MDB_FILE_INFO_ENTRY_SIZE, followed_bytes)?;
-    let mut data = Vec::new();
-    data.try_reserve_exact(total_bytes)
-        .map_err(|_reserve_error| XetAdapterError::TooManyShardTerms)?;
-    header
-        .serialize(&mut data)
-        .map_err(|error| invalid_serialized_shard(&error))?;
-    read_exact_section(reader, followed_bytes, &mut data)?;
-    MDBFileInfoView::from_data_and_header(header, Bytes::from(data))
-        .map_err(|error| invalid_serialized_shard(&error))
-}
-
-fn read_xorb_info_view<R: Read>(
-    reader: &mut R,
-    header: XorbChunkSequenceHeader,
-    followed_bytes: usize,
-) -> Result<MDBXorbInfoView, XetAdapterError> {
-    let total_bytes = checked_add(size_of::<XorbChunkSequenceHeader>(), followed_bytes)?;
-    let mut data = Vec::new();
-    data.try_reserve_exact(total_bytes)
-        .map_err(|_reserve_error| XetAdapterError::TooManyShardTerms)?;
-    header
-        .serialize(&mut data)
-        .map_err(|error| invalid_serialized_shard(&error))?;
-    read_exact_section(reader, followed_bytes, &mut data)?;
-    MDBXorbInfoView::from_data_and_header(header, Bytes::from(data))
-        .map_err(|error| invalid_serialized_shard(&error))
-}
-
-fn read_exact_section<R: Read>(
-    reader: &mut R,
-    byte_count: usize,
-    output: &mut Vec<u8>,
-) -> Result<(), XetAdapterError> {
-    let start = output.len();
-    let end = checked_add(start, byte_count)?;
-    output.resize(end, 0);
-    let section = output
-        .get_mut(start..end)
-        .ok_or(XetAdapterError::Overflow)?;
-    reader
-        .read_exact(section)
-        .map_err(|error| invalid_serialized_shard(&error))
-}
-
 fn collect_dedupe_chunk_hashes(
-    xorb_view: &MDBXorbInfoView,
+    xorb_info: &MDBXorbInfo,
     file_start_entries: &HashMap<MerkleHash, HashSet<usize>>,
     dedupe_chunk_hashes: &mut BTreeSet<String>,
 ) {
-    let start_entries = file_start_entries.get(&xorb_view.xorb_hash());
-    for chunk_index in 0..xorb_view.num_entries() {
-        let chunk = xorb_view.chunk(chunk_index);
+    let start_entries = file_start_entries.get(&xorb_info.metadata.xorb_hash);
+    for (chunk_index, chunk) in xorb_info.chunks.iter().enumerate() {
         let is_file_start = start_entries.is_some_and(|entries| entries.contains(&chunk_index));
         if is_file_start
             || hash_is_global_dedup_eligible(&chunk.chunk_hash)
@@ -395,10 +379,6 @@ fn checked_add(left: usize, right: usize) -> Result<usize, XetAdapterError> {
 
 fn checked_increment(value: usize) -> Result<usize, XetAdapterError> {
     checked_add(value, 1)
-}
-
-fn checked_mul(left: usize, right: usize) -> Result<usize, XetAdapterError> {
-    left.checked_mul(right).ok_or(XetAdapterError::Overflow)
 }
 
 fn checked_add_limit(left: usize, right: usize, limit: usize) -> Result<usize, XetAdapterError> {
@@ -625,13 +605,18 @@ mod tests {
     use shardline_xet_core::{
         merklehash::{MerkleHash, compute_data_hash, file_hash, xorb_hash},
         metadata_shard::{
+            MDBShardFileHeader,
             file_structs::{
                 FileDataSequenceEntry, FileDataSequenceHeader, FileVerificationEntry, MDBFileInfo,
             },
             shard_format::MDBShardInfo,
             shard_in_memory::MDBInMemoryShard,
-            xorb_structs::{MDBXorbInfo, XorbChunkSequenceEntry, XorbChunkSequenceHeader},
+            xorb_structs::{
+                MDB_CHUNK_WITH_GLOBAL_DEDUP_FLAG, MDBXorbInfo, XorbChunkSequenceEntry,
+                XorbChunkSequenceHeader,
+            },
         },
+        utils::serialization_utils::{write_hash, write_u32, write_u64},
     };
 
     use super::{
@@ -895,6 +880,65 @@ mod tests {
         serialized
     }
 
+    fn serialize_v2_test_shard() -> (Vec<u8>, MerkleHash, MerkleHash) {
+        let first_chunk = compute_data_hash(b"v2-native-first");
+        let second_chunk = compute_data_hash(b"v2-native-second");
+        let xorb_hash = xorb_hash(&[(first_chunk, 8_u64), (second_chunk, 8_u64)]);
+        let file_hash = file_hash(&[(first_chunk, 8_u64), (second_chunk, 8_u64)]);
+        let mut bytes = Vec::new();
+        let shard_header = MDBShardFileHeader {
+            version: 2,
+            footer_size: 0,
+            ..MDBShardFileHeader::default()
+        };
+        shard_header.serialize(&mut bytes).unwrap();
+
+        write_hash(&mut bytes, &file_hash).unwrap();
+        write_u32(&mut bytes, 0).unwrap();
+        write_u32(&mut bytes, 1).unwrap();
+        write_u64(&mut bytes, 0).unwrap();
+        write_hash(&mut bytes, &xorb_hash).unwrap();
+        write_u32(&mut bytes, 0).unwrap();
+        write_u32(&mut bytes, 16).unwrap();
+        write_u32(&mut bytes, 0).unwrap();
+        write_u32(&mut bytes, 2).unwrap();
+        write_hash(&mut bytes, &[!0_u64; 4].into()).unwrap();
+        write_u32(&mut bytes, 0).unwrap();
+        write_u32(&mut bytes, 0).unwrap();
+        write_u64(&mut bytes, 0).unwrap();
+
+        write_hash(&mut bytes, &xorb_hash).unwrap();
+        write_u32(&mut bytes, 0).unwrap();
+        write_u32(&mut bytes, 2).unwrap();
+        write_u32(&mut bytes, 16).unwrap();
+        write_u32(&mut bytes, 16).unwrap();
+        for (hash, start, flags) in [
+            (first_chunk, 0, 0),
+            (second_chunk, 8, MDB_CHUNK_WITH_GLOBAL_DEDUP_FLAG),
+        ] {
+            write_hash(&mut bytes, &hash).unwrap();
+            write_u32(&mut bytes, start).unwrap();
+            write_u32(&mut bytes, 8).unwrap();
+            write_u32(&mut bytes, flags).unwrap();
+            write_u32(&mut bytes, 0).unwrap();
+        }
+        write_hash(&mut bytes, &[!0_u64; 4].into()).unwrap();
+        for _ in 0..4 {
+            write_u32(&mut bytes, 0).unwrap();
+        }
+
+        (bytes, first_chunk, second_chunk)
+    }
+
+    #[test]
+    fn bounded_parser_accepts_native_v2_shard_layout() {
+        let (shard, first_chunk, second_chunk) = serialize_v2_test_shard();
+        let hashes = retained_shard_chunk_hashes(&shard, DEFAULT_SHARD_METADATA_LIMITS).unwrap();
+
+        assert!(hashes.contains(&first_chunk.hex()));
+        assert!(hashes.contains(&second_chunk.hex()));
+    }
+
     // ── shard_hash_from_object_key_if_present edge cases ─────────────────
 
     #[test]
@@ -1125,16 +1169,6 @@ mod tests {
     #[test]
     fn checked_increment_overflow() {
         assert!(super::checked_increment(usize::MAX).is_err());
-    }
-
-    #[test]
-    fn checked_mul_ok() {
-        assert_eq!(super::checked_mul(7, 8).unwrap(), 56);
-    }
-
-    #[test]
-    fn checked_mul_overflow() {
-        assert!(super::checked_mul(usize::MAX, 2).is_err());
     }
 
     #[test]
@@ -1622,11 +1656,6 @@ mod tests {
     #[test]
     fn checked_increment_zero_works() {
         assert_eq!(super::checked_increment(0).unwrap(), 1);
-    }
-
-    #[test]
-    fn checked_mul_zero_works() {
-        assert_eq!(super::checked_mul(0, 100).unwrap(), 0);
     }
 
     #[test]

--- a/crates/shardline-xet-core/src/metadata_shard/file_structs.rs
+++ b/crates/shardline-xet-core/src/metadata_shard/file_structs.rs
@@ -16,6 +16,9 @@ pub const MDB_FILE_FLAG_METADATA_EXT_MASK: u32 = 1 << 30;
 
 pub type Sha256 = MerkleHash;
 
+const MDB_SHARD_FORMAT_V3: u64 = 3;
+const MDB_V2_INFO_ENTRY_SIZE: usize = 48;
+
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 #[repr(C)]
 pub struct FileDataSequenceHeader {
@@ -82,11 +85,23 @@ impl FileDataSequenceHeader {
         Ok(size_of::<FileDataSequenceHeader>())
     }
 
-    pub fn deserialize<R: Read>(reader: &mut R, _version: u64) -> Result<Self, std::io::Error> {
+    pub fn deserialize<R: Read>(reader: &mut R, version: u64) -> Result<Self, std::io::Error> {
+        if version < MDB_SHARD_FORMAT_V3 {
+            let mut v = [0u8; MDB_V2_INFO_ENTRY_SIZE];
+            reader.read_exact(&mut v)?;
+            let reader = &mut Cursor::new(v);
+            return Ok(Self {
+                file_hash: read_hash(reader)?,
+                file_flags: read_u32(reader)?,
+                num_entries: u64::from(read_u32(reader)?),
+                _unused: read_u64(reader)?,
+                _pad: 0,
+            });
+        }
+
         let mut v = [0u8; size_of::<Self>()];
-        reader.read_exact(&mut v[..])?;
-        let mut reader_curs = Cursor::new(&v);
-        let reader = &mut reader_curs;
+        reader.read_exact(&mut v)?;
+        let reader = &mut Cursor::new(v);
         Ok(Self {
             file_hash: read_hash(reader)?,
             file_flags: read_u32(reader)?,
@@ -173,11 +188,23 @@ impl FileDataSequenceEntry {
         Ok(size_of::<FileDataSequenceEntry>())
     }
 
-    pub fn deserialize<R: Read>(reader: &mut R, _version: u64) -> Result<Self, std::io::Error> {
+    pub fn deserialize<R: Read>(reader: &mut R, version: u64) -> Result<Self, std::io::Error> {
+        if version < MDB_SHARD_FORMAT_V3 {
+            let mut v = [0u8; MDB_V2_INFO_ENTRY_SIZE];
+            reader.read_exact(&mut v)?;
+            let reader = &mut Cursor::new(v);
+            return Ok(Self {
+                xorb_hash: read_hash(reader)?,
+                xorb_flags: read_u32(reader)?,
+                unpacked_segment_bytes: u64::from(read_u32(reader)?),
+                chunk_index_start: u64::from(read_u32(reader)?),
+                chunk_index_end: u64::from(read_u32(reader)?),
+            });
+        }
+
         let mut v = [0u8; size_of::<FileDataSequenceEntry>()];
-        reader.read_exact(&mut v[..])?;
-        let mut reader_curs = Cursor::new(&v);
-        let reader = &mut reader_curs;
+        reader.read_exact(&mut v)?;
+        let reader = &mut Cursor::new(v);
         Ok(Self {
             xorb_hash: read_hash(reader)?,
             xorb_flags: read_u32(reader)?,
@@ -215,11 +242,25 @@ impl FileVerificationEntry {
         Ok(size_of::<Self>())
     }
 
-    pub fn deserialize<R: Read>(reader: &mut R, _version: u64) -> Result<Self, std::io::Error> {
+    pub fn deserialize<R: Read>(reader: &mut R, version: u64) -> Result<Self, std::io::Error> {
+        if version < MDB_SHARD_FORMAT_V3 {
+            let mut v = [0u8; MDB_V2_INFO_ENTRY_SIZE];
+            reader.read_exact(&mut v)?;
+            let reader = &mut Cursor::new(v);
+            let mut unused = [0u64; 2];
+            return Ok(Self {
+                range_hash: read_hash(reader)?,
+                _unused: {
+                    read_u64s(reader, &mut unused)?;
+                    unused
+                },
+                _pad: [0; 2],
+            });
+        }
+
         let mut v = [0u8; size_of::<Self>()];
-        reader.read_exact(&mut v[..])?;
-        let mut reader_curs = Cursor::new(&v);
-        let reader = &mut reader_curs;
+        reader.read_exact(&mut v)?;
+        let reader = &mut Cursor::new(v);
         let mut unused = [0u64; 2];
         let mut pad = [0u64; 2];
         Ok(Self {
@@ -264,11 +305,25 @@ impl FileMetadataExt {
         Ok(size_of::<Self>())
     }
 
-    pub fn deserialize<R: Read>(reader: &mut R, _version: u64) -> Result<Self, std::io::Error> {
+    pub fn deserialize<R: Read>(reader: &mut R, version: u64) -> Result<Self, std::io::Error> {
+        if version < MDB_SHARD_FORMAT_V3 {
+            let mut v = [0u8; MDB_V2_INFO_ENTRY_SIZE];
+            reader.read_exact(&mut v)?;
+            let reader = &mut Cursor::new(v);
+            let mut unused = [0u64; 2];
+            return Ok(Self {
+                sha256: read_hash(reader)?,
+                _unused: {
+                    read_u64s(reader, &mut unused)?;
+                    unused
+                },
+                _pad: [0; 2],
+            });
+        }
+
         let mut v = [0u8; size_of::<Self>()];
-        reader.read_exact(&mut v[..])?;
-        let mut reader_curs = Cursor::new(&v);
-        let reader = &mut reader_curs;
+        reader.read_exact(&mut v)?;
+        let reader = &mut Cursor::new(v);
         let mut unused = [0u64; 2];
         let mut pad = [0u64; 2];
         Ok(Self {
@@ -550,6 +605,39 @@ mod tests {
         assert_eq!(h.file_hash, h2.file_hash);
         assert_eq!(h.file_flags, h2.file_flags);
         assert_eq!(h.num_entries, h2.num_entries);
+    }
+
+    #[test]
+    fn file_info_deserializes_v2_32_bit_layout() {
+        let file_hash = compute_data_hash(b"v2-file");
+        let xorb_hash = compute_data_hash(b"v2-xorb");
+        let mut bytes = Vec::new();
+        write_hash(&mut bytes, &file_hash).unwrap();
+        write_u32(&mut bytes, MDB_DEFAULT_FILE_FLAG).unwrap();
+        write_u32(&mut bytes, 1).unwrap();
+        write_u64(&mut bytes, 0).unwrap();
+        write_hash(&mut bytes, &xorb_hash).unwrap();
+        write_u32(&mut bytes, MDB_DEFAULT_FILE_FLAG).unwrap();
+        write_u32(&mut bytes, 123_456).unwrap();
+        write_u32(&mut bytes, 7).unwrap();
+        write_u32(&mut bytes, 11).unwrap();
+        write_hash(&mut bytes, &[!0_u64; 4].into()).unwrap();
+        write_u32(&mut bytes, 0).unwrap();
+        write_u32(&mut bytes, 0).unwrap();
+        write_u64(&mut bytes, 0).unwrap();
+
+        let mut reader = Cursor::new(bytes);
+        let info = MDBFileInfo::deserialize(&mut reader, 2)
+            .unwrap()
+            .expect("v2 file info");
+        assert_eq!(info.metadata.file_hash, file_hash);
+        assert_eq!(info.metadata.num_entries, 1);
+        assert_eq!(info.segments[0].xorb_hash, xorb_hash);
+        assert_eq!(info.segments[0].unpacked_segment_bytes, 123_456);
+        assert_eq!(info.segments[0].chunk_index_start, 7);
+        assert_eq!(info.segments[0].chunk_index_end, 11);
+        assert!(MDBFileInfo::deserialize(&mut reader, 2).unwrap().is_none());
+        assert_eq!(reader.position(), 3 * MDB_V2_INFO_ENTRY_SIZE as u64);
     }
 
     #[test]

--- a/crates/shardline-xet-core/src/metadata_shard/xorb_structs.rs
+++ b/crates/shardline-xet-core/src/metadata_shard/xorb_structs.rs
@@ -9,6 +9,9 @@ use crate::{merklehash::MerkleHash, utils::serialization_utils::*};
 pub const MDB_DEFAULT_XORB_FLAG: u32 = 0;
 pub const MDB_CHUNK_WITH_GLOBAL_DEDUP_FLAG: u32 = 1 << 31;
 
+const MDB_SHARD_FORMAT_V3: u64 = 3;
+const MDB_V2_INFO_ENTRY_SIZE: usize = 48;
+
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct XorbChunkSequenceHeader {
     pub xorb_hash: MerkleHash,
@@ -55,11 +58,23 @@ impl XorbChunkSequenceHeader {
         Ok(size_of::<Self>())
     }
 
-    pub fn deserialize<R: Read>(reader: &mut R, _version: u64) -> Result<Self, std::io::Error> {
+    pub fn deserialize<R: Read>(reader: &mut R, version: u64) -> Result<Self, std::io::Error> {
+        if version < MDB_SHARD_FORMAT_V3 {
+            let mut v = [0u8; MDB_V2_INFO_ENTRY_SIZE];
+            reader.read_exact(&mut v)?;
+            let reader = &mut Cursor::new(v);
+            return Ok(Self {
+                xorb_hash: read_hash(reader)?,
+                xorb_flags: read_u32(reader)?,
+                num_entries: u64::from(read_u32(reader)?),
+                num_bytes_in_xorb: u64::from(read_u32(reader)?),
+                num_bytes_on_disk: u64::from(read_u32(reader)?),
+            });
+        }
+
         let mut v = [0u8; size_of::<Self>()];
-        reader.read_exact(&mut v[..])?;
-        let mut reader_curs = Cursor::new(&v);
-        let reader = &mut reader_curs;
+        reader.read_exact(&mut v)?;
+        let reader = &mut Cursor::new(v);
         Ok(Self {
             xorb_hash: read_hash(reader)?,
             xorb_flags: read_u32(reader)?,
@@ -128,11 +143,23 @@ impl XorbChunkSequenceEntry {
         Ok(size_of::<XorbChunkSequenceEntry>())
     }
 
-    pub fn deserialize<R: Read>(reader: &mut R, _version: u64) -> Result<Self, std::io::Error> {
+    pub fn deserialize<R: Read>(reader: &mut R, version: u64) -> Result<Self, std::io::Error> {
+        if version < MDB_SHARD_FORMAT_V3 {
+            let mut v = [0u8; MDB_V2_INFO_ENTRY_SIZE];
+            reader.read_exact(&mut v)?;
+            let reader = &mut Cursor::new(v);
+            return Ok(Self {
+                chunk_hash: read_hash(reader)?,
+                chunk_byte_range_start: u64::from(read_u32(reader)?),
+                unpacked_segment_bytes: u64::from(read_u32(reader)?),
+                flags: read_u32(reader)?,
+                _unused: u64::from(read_u32(reader)?),
+            });
+        }
+
         let mut v = [0u8; size_of::<Self>()];
-        reader.read_exact(&mut v[..])?;
-        let mut reader_curs = Cursor::new(&v);
-        let reader = &mut reader_curs;
+        reader.read_exact(&mut v)?;
+        let reader = &mut Cursor::new(v);
         Ok(Self {
             chunk_hash: read_hash(reader)?,
             chunk_byte_range_start: read_u64(reader)?,
@@ -333,6 +360,42 @@ mod tests {
         assert_eq!(h.num_entries, h2.num_entries);
         assert_eq!(h.num_bytes_in_xorb, h2.num_bytes_in_xorb);
         assert_eq!(h.num_bytes_on_disk, h2.num_bytes_on_disk);
+    }
+
+    #[test]
+    fn xorb_info_deserializes_v2_32_bit_layout() {
+        let xorb_hash = compute_data_hash(b"v2-xorb");
+        let chunk_hash = compute_data_hash(b"v2-chunk");
+        let mut bytes = Vec::new();
+        write_hash(&mut bytes, &xorb_hash).unwrap();
+        write_u32(&mut bytes, MDB_DEFAULT_XORB_FLAG).unwrap();
+        write_u32(&mut bytes, 1).unwrap();
+        write_u32(&mut bytes, 65_536).unwrap();
+        write_u32(&mut bytes, 32_768).unwrap();
+        write_hash(&mut bytes, &chunk_hash).unwrap();
+        write_u32(&mut bytes, 4_096).unwrap();
+        write_u32(&mut bytes, 8_192).unwrap();
+        write_u32(&mut bytes, MDB_CHUNK_WITH_GLOBAL_DEDUP_FLAG).unwrap();
+        write_u32(&mut bytes, 0).unwrap();
+        write_hash(&mut bytes, &[!0_u64; 4].into()).unwrap();
+        for _ in 0..4 {
+            write_u32(&mut bytes, 0).unwrap();
+        }
+
+        let mut reader = Cursor::new(bytes);
+        let info = MDBXorbInfo::deserialize(&mut reader, 2)
+            .unwrap()
+            .expect("v2 xorb info");
+        assert_eq!(info.metadata.xorb_hash, xorb_hash);
+        assert_eq!(info.metadata.num_entries, 1);
+        assert_eq!(info.metadata.num_bytes_in_xorb, 65_536);
+        assert_eq!(info.metadata.num_bytes_on_disk, 32_768);
+        assert_eq!(info.chunks[0].chunk_hash, chunk_hash);
+        assert_eq!(info.chunks[0].chunk_byte_range_start, 4_096);
+        assert_eq!(info.chunks[0].unpacked_segment_bytes, 8_192);
+        assert_eq!(info.chunks[0].flags, MDB_CHUNK_WITH_GLOBAL_DEDUP_FLAG);
+        assert!(MDBXorbInfo::deserialize(&mut reader, 2).unwrap().is_none());
+        assert_eq!(reader.position(), 3 * MDB_V2_INFO_ENTRY_SIZE as u64);
     }
 
     #[test]

--- a/crates/shardline/Cargo.toml
+++ b/crates/shardline/Cargo.toml
@@ -32,6 +32,7 @@ path = "src/main.rs"
 [dependencies]
 bytes.workspace = true
 clap = { workspace = true, features = ["derive"] }
+dotenvy.workspace = true
 clap_complete.workspace = true
 clap_mangen.workspace = true
 hex.workspace = true

--- a/crates/shardline/src/backup.rs
+++ b/crates/shardline/src/backup.rs
@@ -32,7 +32,7 @@ pub async fn run_backup_manifest(
     root: Option<&Path>,
     output: &Path,
 ) -> Result<BackupManifestReport, BackupRuntimeError> {
-    let config = load_server_config(root)?;
+    let config = load_server_config(root, None)?;
     let mut manifest = Vec::new();
     let report = write_server_backup_manifest(config, &mut manifest).await?;
     write_output_bytes(output, &manifest, false)?;

--- a/crates/shardline/src/command/definition.rs
+++ b/crates/shardline/src/command/definition.rs
@@ -30,6 +30,11 @@ pub(crate) struct CliDefinition {
     /// available to the server and all subcommands.
     #[arg(long = "env-file", value_name = "PATH", global = true)]
     pub(crate) env_file: Option<PathBuf>,
+    /// Path to a shardline.toml configuration file.
+    /// When omitted, shardline.toml is auto-detected from the current
+    /// directory, ~/.config/shardline/, and /etc/shardline/.
+    #[arg(short = 'c', long = "config", value_name = "FILE", global = true)]
+    pub(crate) config: Option<PathBuf>,
     #[command(subcommand)]
     pub(crate) command: CliDefinitionCommand,
 }

--- a/crates/shardline/src/command/definition.rs
+++ b/crates/shardline/src/command/definition.rs
@@ -25,6 +25,11 @@ use super::help::{
     next_line_help = true
 )]
 pub(crate) struct CliDefinition {
+    /// Path to a .env file to load before resolving configuration.
+    /// Variables in this file are set as environment variables and are
+    /// available to the server and all subcommands.
+    #[arg(long = "env-file", value_name = "PATH", global = true)]
+    pub(crate) env_file: Option<PathBuf>,
     #[command(subcommand)]
     pub(crate) command: CliDefinitionCommand,
 }

--- a/crates/shardline/src/command/funcs.rs
+++ b/crates/shardline/src/command/funcs.rs
@@ -1,7 +1,7 @@
-use std::{ffi::OsString, num::NonZeroUsize, path::Path};
+use std::{ffi::OsString, num::NonZeroUsize};
 
 use clap::{CommandFactory, Parser, error::ErrorKind};
-use dotenvy::from_filename;
+use dotenvy::{from_filename, from_read_override};
 use shardline_protocol::{RepositoryProvider, TokenScope};
 use shardline_server::{
     DatabaseMigrationCommand, ObjectStorageAdapter, ServerFrontend, ServerRole,
@@ -39,11 +39,47 @@ impl CliCommand {
         // Load the --env-file into the process environment before any
         // configuration resolution, so env vars referenced in config files
         // or by the server are available.
+        // `gc schedule install --env-file` names the EnvironmentFile to emit
+        // into the unit; it is not an input dotenv file for this invocation.
+        let gc_schedule_install = matches!(
+            &definition.command,
+            CliDefinitionCommand::Gc(gc_args)
+                if matches!(gc_args.command, Some(GcSubcommand::Schedule(_)))
+        );
         if let Some(env_path) = &definition.env_file
-            && Path::new(env_path).is_file()
-            && let Err(error) = from_filename(env_path)
+            && !gc_schedule_install
         {
-            tracing::warn!(path = %env_path.display(), error = %error, "failed to load env file");
+            from_filename(env_path).map_err(|error| {
+                CliParseError::validation(
+                    ErrorKind::InvalidValue,
+                    format!("failed to load env file {}: {error}", env_path.display()),
+                )
+            })?;
+        }
+
+        // Preserve the explicit path for every configuration-consuming command.
+        // `load_server_config` consumes this internal marker before auto-detection.
+        // Clear a marker left by an earlier in-process parse before applying
+        // this invocation's optional override.
+        from_read_override(std::io::Cursor::new("SHARDLINE_CLI_CONFIG_FILE=\n")).map_err(
+            |error| {
+                CliParseError::validation(
+                    ErrorKind::InvalidValue,
+                    format!("failed to clear selected config file: {error}"),
+                )
+            },
+        )?;
+        if let Some(config_path) = &definition.config {
+            let encoded = format!("SHARDLINE_CLI_CONFIG_FILE={:?}\n", config_path);
+            from_read_override(std::io::Cursor::new(encoded)).map_err(|error| {
+                CliParseError::validation(
+                    ErrorKind::InvalidValue,
+                    format!(
+                        "failed to select config file {}: {error}",
+                        config_path.display()
+                    ),
+                )
+            })?;
         }
 
         // Load shardline.toml (--config or auto-detected) for direct

--- a/crates/shardline/src/command/funcs.rs
+++ b/crates/shardline/src/command/funcs.rs
@@ -1,8 +1,11 @@
 use std::{ffi::OsString, num::NonZeroUsize, path::Path};
 
+use std::io::Write;
+
 use clap::{CommandFactory, Parser, error::ErrorKind};
-use dotenvy::from_filename;
+use dotenvy::{from_filename, from_read};
 use shardline_protocol::{RepositoryProvider, TokenScope};
+use shardline_server::load_toml_env_overrides;
 use shardline_server::{
     DatabaseMigrationCommand, ObjectStorageAdapter, ServerFrontend, ServerRole,
 };
@@ -43,6 +46,20 @@ impl CliCommand {
             let env_path = env_path.as_os_str();
             if Path::new(env_path).is_file() {
                 let _ignored = from_filename(env_path);
+            }
+        }
+
+        // Load shardline.toml (--config or auto-detected) and apply its
+        // values as env vars. Already-set env vars take precedence.
+        if let Ok(Some(overrides)) = load_toml_env_overrides(definition.config.as_deref()) {
+            let mut env_content = Vec::new();
+            for (key, value) in &overrides {
+                if std::env::var(key).is_err() {
+                    writeln!(env_content, "{key}={value}").ok();
+                }
+            }
+            if !env_content.is_empty() {
+                let _ignored = from_read(std::io::Cursor::new(env_content));
             }
         }
 

--- a/crates/shardline/src/command/funcs.rs
+++ b/crates/shardline/src/command/funcs.rs
@@ -1,6 +1,7 @@
-use std::{ffi::OsString, num::NonZeroUsize};
+use std::{ffi::OsString, num::NonZeroUsize, path::Path};
 
 use clap::{CommandFactory, Parser, error::ErrorKind};
+use dotenvy::from_filename;
 use shardline_protocol::{RepositoryProvider, TokenScope};
 use shardline_server::{
     DatabaseMigrationCommand, ObjectStorageAdapter, ServerFrontend, ServerRole,
@@ -34,6 +35,17 @@ impl CliCommand {
         }
 
         let definition = CliDefinition::try_parse_from(args).map_err(CliParseError::from)?;
+
+        // Load the --env-file into the process environment before any
+        // configuration resolution, so env vars referenced in config files
+        // or by the server are available.
+        if let Some(env_path) = &definition.env_file {
+            let env_path = env_path.as_os_str();
+            if Path::new(env_path).is_file() {
+                let _ignored = from_filename(env_path);
+            }
+        }
+
         Self::try_from(definition)
     }
 

--- a/crates/shardline/src/command/funcs.rs
+++ b/crates/shardline/src/command/funcs.rs
@@ -39,11 +39,11 @@ impl CliCommand {
         // Load the --env-file into the process environment before any
         // configuration resolution, so env vars referenced in config files
         // or by the server are available.
-        if let Some(env_path) = &definition.env_file {
-            let env_path = env_path.as_os_str();
-            if Path::new(env_path).is_file() {
-                let _ignored = from_filename(env_path);
-            }
+        if let Some(env_path) = &definition.env_file
+            && Path::new(env_path).is_file()
+            && let Err(error) = from_filename(env_path)
+        {
+            tracing::warn!(path = %env_path.display(), error = %error, "failed to load env file");
         }
 
         // Load shardline.toml (--config or auto-detected) for direct

--- a/crates/shardline/src/command/funcs.rs
+++ b/crates/shardline/src/command/funcs.rs
@@ -1,11 +1,8 @@
 use std::{ffi::OsString, num::NonZeroUsize, path::Path};
 
-use std::io::Write;
-
 use clap::{CommandFactory, Parser, error::ErrorKind};
-use dotenvy::{from_filename, from_read};
+use dotenvy::from_filename;
 use shardline_protocol::{RepositoryProvider, TokenScope};
-use shardline_server::load_toml_env_overrides;
 use shardline_server::{
     DatabaseMigrationCommand, ObjectStorageAdapter, ServerFrontend, ServerRole,
 };
@@ -49,20 +46,9 @@ impl CliCommand {
             }
         }
 
-        // Load shardline.toml (--config or auto-detected) and apply its
-        // values as env vars. Already-set env vars take precedence.
-        if let Ok(Some(overrides)) = load_toml_env_overrides(definition.config.as_deref()) {
-            let mut env_content = Vec::new();
-            for (key, value) in &overrides {
-                if std::env::var(key).is_err() {
-                    writeln!(env_content, "{key}={value}").ok();
-                }
-            }
-            if !env_content.is_empty() {
-                let _ignored = from_read(std::io::Cursor::new(env_content));
-            }
-        }
-
+        // Load shardline.toml (--config or auto-detected) for direct
+        // struct deserialization. The TOML values are applied via
+        // load_server_config_from_env_with_toml later during config resolution.
         Self::try_from(definition)
     }
 

--- a/crates/shardline/src/config.rs
+++ b/crates/shardline/src/config.rs
@@ -58,6 +58,10 @@ pub fn load_server_config(
     root_override: Option<&Path>,
     config_override: Option<&Path>,
 ) -> Result<ServerConfig, ServerConfigError> {
+    let cli_config_override = var_os("SHARDLINE_CLI_CONFIG_FILE")
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from);
+    let config_override = config_override.or(cli_config_override.as_deref());
     let config =
         match load_toml_config(config_override).map_err(ServerConfigError::ConfigFileError)? {
             Some(toml) => load_server_config_from_env_with_toml(&toml)?,

--- a/crates/shardline/src/config.rs
+++ b/crates/shardline/src/config.rs
@@ -4,7 +4,8 @@ use std::{
 };
 
 use shardline_server::{
-    ConfigCheckReport, ServerConfig, ServerConfigError, ServerError, run_config_check,
+    ConfigCheckReport, ServerConfig, ServerConfigError, ServerError,
+    load_server_config_from_env_with_toml, load_toml_config, run_config_check,
 };
 use thiserror::Error;
 
@@ -43,11 +44,24 @@ pub async fn run_config_check_from_env() -> Result<ConfigCheckReport, ConfigRunt
 
 /// Loads the active Shardline server configuration and applies an optional deployment-root override.
 ///
+/// When a `shardline.toml` file is found (either auto-detected or explicitly
+/// provided via `--config`), its values are deserialized directly and merged
+/// with environment variables. Environment variables take precedence over TOML.
+///
+/// The `config_override` parameter specifies an explicit path to `shardline.toml`.
+/// When `None`, the file is auto-detected from standard paths.
+///
 /// # Errors
 ///
 /// Returns [`ServerConfigError`] when environment configuration cannot be parsed.
-pub fn load_server_config(root_override: Option<&Path>) -> Result<ServerConfig, ServerConfigError> {
-    let config = ServerConfig::from_env()?;
+pub fn load_server_config(
+    root_override: Option<&Path>,
+    config_override: Option<&Path>,
+) -> Result<ServerConfig, ServerConfigError> {
+    let config = match load_toml_config(config_override).unwrap_or(None) {
+        Some(toml) => load_server_config_from_env_with_toml(&toml)?,
+        None => ServerConfig::from_env()?,
+    };
     let root_dir = resolve_root_dir(root_override, config.root_dir());
     ensure_directory_path_components_are_not_symlinked(&root_dir)
         .map_err(ServerConfigError::RootDir)?;
@@ -60,7 +74,7 @@ pub fn load_server_config(root_override: Option<&Path>) -> Result<ServerConfig, 
 ///
 /// Returns [`ServerConfigError`] when environment configuration cannot be parsed.
 pub fn effective_root(root_override: Option<&Path>) -> Result<PathBuf, ServerConfigError> {
-    let config = load_server_config(root_override)?;
+    let config = load_server_config(root_override, None)?;
     Ok(config.root_dir().to_path_buf())
 }
 
@@ -250,7 +264,7 @@ mod tests {
         let linked = symlink(&target, &override_root);
         assert!(linked.is_ok());
 
-        let loaded = super::load_server_config(Some(&override_root));
+        let loaded = super::load_server_config(Some(&override_root), None);
 
         assert!(matches!(loaded, Err(ServerConfigError::RootDir(_))));
     }
@@ -259,7 +273,7 @@ mod tests {
     fn load_server_config_accepts_non_existent_root_override() {
         // A non-existent path with a real parent should succeed.
         let loaded =
-            super::load_server_config(Some(&PathBuf::from("/tmp/__shardline_test_void__")));
+            super::load_server_config(Some(&PathBuf::from("/tmp/__shardline_test_void__")), None);
         assert!(loaded.is_ok());
     }
 

--- a/crates/shardline/src/config.rs
+++ b/crates/shardline/src/config.rs
@@ -58,10 +58,11 @@ pub fn load_server_config(
     root_override: Option<&Path>,
     config_override: Option<&Path>,
 ) -> Result<ServerConfig, ServerConfigError> {
-    let config = match load_toml_config(config_override).unwrap_or(None) {
-        Some(toml) => load_server_config_from_env_with_toml(&toml)?,
-        None => ServerConfig::from_env()?,
-    };
+    let config =
+        match load_toml_config(config_override).map_err(ServerConfigError::ConfigFileError)? {
+            Some(toml) => load_server_config_from_env_with_toml(&toml)?,
+            None => ServerConfig::from_env()?,
+        };
     let root_dir = resolve_root_dir(root_override, config.root_dir());
     ensure_directory_path_components_are_not_symlinked(&root_dir)
         .map_err(ServerConfigError::RootDir)?;

--- a/crates/shardline/src/fsck.rs
+++ b/crates/shardline/src/fsck.rs
@@ -24,7 +24,7 @@ pub enum FsckRuntimeError {
 ///
 /// Returns [`FsckRuntimeError`] when the configured deployment cannot be scanned.
 pub async fn run_fsck(root: Option<&Path>) -> Result<LocalFsckReport, FsckRuntimeError> {
-    let config = load_server_config(root)?;
+    let config = load_server_config(root, None)?;
     Ok(run_server_fsck(config).await?)
 }
 

--- a/crates/shardline/src/gc.rs
+++ b/crates/shardline/src/gc.rs
@@ -82,7 +82,7 @@ pub async fn run_gc_diagnostics(
         // chunks on disk but not yet committed file records need a grace period.
         retention_seconds: retention_seconds.max(MINIMUM_GC_RETENTION_SECONDS),
     };
-    let config = load_server_config(root)?;
+    let config = load_server_config(root, None)?;
     let diagnostics = run_server_gc_diagnostics(config, options).await?;
     write_optional_artifact(retention_report_path, &diagnostics.retention_report)?;
     write_optional_artifact(orphan_inventory_path, &diagnostics.orphan_inventory)?;

--- a/crates/shardline/src/hold.rs
+++ b/crates/shardline/src/hold.rs
@@ -88,7 +88,7 @@ pub async fn run_hold_set(
     reason: &str,
     ttl_seconds: Option<u64>,
 ) -> Result<RetentionHold, HoldRuntimeError> {
-    let config = load_server_config(root)?;
+    let config = load_server_config(root, None)?;
     let object_key = ObjectKey::parse(object_key)?;
     let held_at_unix_seconds = unix_now_seconds_lossy();
     let release_after_unix_seconds = ttl_seconds
@@ -125,7 +125,7 @@ pub async fn run_hold_list(
     root: Option<&Path>,
     active_only: bool,
 ) -> Result<Vec<RetentionHold>, HoldRuntimeError> {
-    let config = load_server_config(root)?;
+    let config = load_server_config(root, None)?;
     let mut holds = if let Some(index_postgres_url) = config.index_postgres_url() {
         let store = postgres_index_store(index_postgres_url)?;
         store.list_retention_holds().await?
@@ -152,7 +152,7 @@ pub async fn run_hold_release(
     root: Option<&Path>,
     object_key: &str,
 ) -> Result<bool, HoldRuntimeError> {
-    let config = load_server_config(root)?;
+    let config = load_server_config(root, None)?;
     let object_key = ObjectKey::parse(object_key)?;
 
     if let Some(index_postgres_url) = config.index_postgres_url() {

--- a/crates/shardline/src/providerless.rs
+++ b/crates/shardline/src/providerless.rs
@@ -85,7 +85,7 @@ pub fn run_providerless_setup(
 pub fn load_runtime_server_config(
     root_override: Option<&Path>,
 ) -> Result<ServerConfig, ProviderlessRuntimeError> {
-    let config = load_server_config(root_override)?;
+    let config = load_server_config(root_override, None)?;
     apply_providerless_source_checkout_defaults(config)
 }
 

--- a/crates/shardline/src/rebuild.rs
+++ b/crates/shardline/src/rebuild.rs
@@ -27,7 +27,7 @@ pub enum RebuildRuntimeError {
 pub async fn run_index_rebuild(
     root: Option<&Path>,
 ) -> Result<LocalIndexRebuildReport, RebuildRuntimeError> {
-    let config = load_server_config(root)?;
+    let config = load_server_config(root, None)?;
     Ok(run_server_index_rebuild(config).await?)
 }
 

--- a/crates/shardline/src/repair.rs
+++ b/crates/shardline/src/repair.rs
@@ -149,7 +149,7 @@ pub async fn run_lifecycle_repair(
     let options = LifecycleRepairOptions {
         webhook_retention_seconds,
     };
-    let config = load_server_config(root)?;
+    let config = load_server_config(root, None)?;
     Ok(run_server_lifecycle_repair(config, options).await?)
 }
 
@@ -168,7 +168,7 @@ pub async fn run_repair(
     let options = LifecycleRepairOptions {
         webhook_retention_seconds,
     };
-    let config = load_server_config(root)?;
+    let config = load_server_config(root, None)?;
     let index_rebuild = run_server_index_rebuild(config.clone()).await?;
     let lifecycle_repair = run_server_lifecycle_repair(config.clone(), options).await?;
     let fsck = run_server_fsck(config).await?;

--- a/crates/shardline/tests/config_cli_e2e.rs
+++ b/crates/shardline/tests/config_cli_e2e.rs
@@ -1,0 +1,85 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::{env::var, fs, num::NonZeroUsize, process::Command};
+
+use shardline_server::LocalBackend;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn config_check_uses_explicit_config_path_with_spaces() {
+    let workspace = tempfile::tempdir().unwrap();
+    let root = workspace.path().join("runtime root");
+    LocalBackend::new(
+        root.clone(),
+        "http://127.0.0.1:8080".to_owned(),
+        NonZeroUsize::MIN,
+    )
+    .await
+    .unwrap();
+
+    let config_dir = workspace.path().join("config directory");
+    fs::create_dir(&config_dir).unwrap();
+    let config = config_dir.join("active config.toml");
+    let signing_key = workspace.path().join("token-signing-key");
+    fs::write(&signing_key, b"0123456789abcdef0123456789abcdef").unwrap();
+    fs::write(
+        &config,
+        format!(
+            "[server]\nroot_dir = {:?}\nbind_addr = \"127.0.0.1:9911\"\n\n[auth]\ntoken_signing_key_path = {:?}\n",
+            root, signing_key
+        ),
+    )
+    .unwrap();
+
+    let output = Command::new(shardline_binary())
+        .args(["--config", config.to_str().unwrap(), "config", "check"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "config check failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("status: ok"));
+}
+
+#[test]
+fn invalid_explicit_config_fails_through_cli_runtime() {
+    let workspace = tempfile::tempdir().unwrap();
+    let config = workspace.path().join("invalid config.toml");
+    fs::write(&config, "[[[not valid toml]]]").unwrap();
+
+    let output = Command::new(shardline_binary())
+        .args(["--config", config.to_str().unwrap(), "config", "check"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("TOML parse error"));
+}
+
+#[test]
+fn missing_or_invalid_env_file_fails_during_cli_parsing() {
+    let workspace = tempfile::tempdir().unwrap();
+    let missing = workspace.path().join("missing.env");
+    let missing_output = Command::new(shardline_binary())
+        .args(["--env-file", missing.to_str().unwrap(), "config", "check"])
+        .output()
+        .unwrap();
+    assert!(!missing_output.status.success());
+    assert!(String::from_utf8_lossy(&missing_output.stderr).contains("failed to load env file"));
+
+    let invalid = workspace.path().join("invalid.env");
+    fs::write(&invalid, "not a valid dotenv line =\n").unwrap();
+    let invalid_output = Command::new(shardline_binary())
+        .args(["--env-file", invalid.to_str().unwrap(), "config", "check"])
+        .output()
+        .unwrap();
+    assert!(!invalid_output.status.success());
+    assert!(String::from_utf8_lossy(&invalid_output.stderr).contains("failed to load env file"));
+}
+
+fn shardline_binary() -> String {
+    #[allow(clippy::expect_used)]
+    var("CARGO_BIN_EXE_shardline").expect("Cargo should provide the shardline binary path")
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -56,12 +56,27 @@ Write it to a file for packaging or system installation:
 shardline manpage --output ./shardline.1
 ```
 
+## Global Flags
+
+These flags are available on every command and must be placed before the
+subcommand:
+
+```text
+--env-file <PATH>   Load a .env file into the process environment before
+                    resolving configuration. Use for secrets and credentials.
+-c, --config <FILE> Path to a shardline.toml configuration file. When omitted,
+                    shardline.toml is auto-detected from the current directory,
+                    ~/.config/shardline/, and /etc/shardline/.
+```
+
 ## Common Commands
 
 Start the server:
 
 ```bash
 shardline serve
+shardline serve --env-file .env.production
+shardline serve --config /etc/shardline/shardline.toml
 shardline serve --role api
 shardline serve --role transfer
 ```
@@ -70,6 +85,7 @@ Validate configuration:
 
 ```bash
 shardline config check
+shardline config check --env-file .env.production --config shardline.toml
 ```
 
 Bootstrap a local providerless source-checkout deployment:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -241,7 +241,83 @@ cargo run -p shardline --bin shardline -- health --server http://127.0.0.1:18080
 
 ## Configuration
 
-Configuration supports a file plus environment overrides.
+Configuration supports a TOML file with environment variable overrides.
+Secrets and credentials belong in a `.env` file, not in the TOML config
+or in environment variables.
+
+### Configuration file (shardline.toml)
+
+Server settings can be declared in a `shardline.toml` file. The file is
+auto-detected from these locations (first found wins):
+
+1. `./shardline.toml` (current directory)
+2. `~/.config/shardline/shardline.toml` (user config)
+3. `/etc/shardline/shardline.toml` (global config)
+
+Use the `--config` flag to point at a specific path:
+
+```bash
+shardline serve --config /etc/shardline/shardline.toml
+```
+
+Values with `${VAR}` syntax are resolved from the process environment
+or from a `.env` file loaded with `--env-file`:
+
+```toml
+[server]
+bind_addr = "0.0.0.0:8080"
+public_base_url = "https://cas.example.com"
+server_role = "all"
+frontends = ["xet", "oci", "hub"]
+root_dir = "/var/lib/shardline"
+chunk_size_bytes = 65536
+
+[storage]
+adapter = "s3"
+
+[storage.s3]
+endpoint = "https://s3.example.com"
+region = "us-east-1"
+bucket = "shardline-data"
+access_key = "${S3_ACCESS_KEY}"
+secret_key = "${S3_SECRET_KEY}"
+
+[index]
+postgres_url = "${DATABASE_URL}"
+
+[cache]
+adapter = "memory"
+ttl_seconds = 30
+
+[auth]
+provider = "local-hmac"
+provider_token_issuer = "shardline"
+provider_token_ttl_seconds = 300
+```
+
+Place credentials in a separate `.env` file:
+
+```bash
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin
+DATABASE_URL=postgres://shardline:change-me@postgres:5432/shardline
+SHARDLINE_TOKEN_SIGNING_KEY=change-me-for-local-only
+```
+
+Load both together:
+
+```bash
+shardline serve --env-file .env.production --config shardline.toml
+```
+
+Environment variables already set in the shell take precedence over values
+in `shardline.toml`. The `.env` file is loaded before the TOML file is
+parsed, so `${VAR}` references resolve correctly.
+
+### Environment variables
+
+Configuration through environment variables remains fully supported and
+always takes precedence over TOML file values.
 
 Initial environment variables:
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -69,6 +69,27 @@ TOKEN="$(docker compose -f docker-compose.yml exec -T shardline \
 curl -H "Authorization: Bearer ${TOKEN}" http://127.0.0.1:18080/v1/stats
 ```
 
+For deployments using a `shardline.toml` config file, mount it and use the
+`--config` flag:
+
+```bash
+docker run -v /path/to/shardline.toml:/etc/shardline/shardline.toml:ro \
+  registry.example.com/shardline:latest \
+  --config /etc/shardline/shardline.toml serve
+```
+
+For Docker Compose, bind-mount the config file and add `--config` to the
+command in your `docker-compose.yml`:
+
+```yaml
+services:
+  shardline:
+    image: registry.example.com/shardline:latest
+    command: ["--config", "/etc/shardline/shardline.toml", "serve"]
+    volumes:
+      - ./shardline.toml:/etc/shardline/shardline.toml:ro
+```
+
 If you want to mint tokens on the host for the Compose server, pass the same signing key
 as an environment variable:
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -279,8 +279,6 @@ adapter = "s3"
 endpoint = "https://s3.example.com"
 region = "us-east-1"
 bucket = "shardline-data"
-access_key = "${S3_ACCESS_KEY}"
-secret_key = "${S3_SECRET_KEY}"
 
 [index]
 postgres_url = "${DATABASE_URL}"

--- a/docs/k8s/README.md
+++ b/docs/k8s/README.md
@@ -42,8 +42,8 @@ docs/k8s/production-scaled/
 ## Configuration
 
 Server settings are defined in `configmap.yaml` as a `shardline.toml` file
-mounted at `/etc/shardline/config/shardline.toml`. This replaces the previous
-approach of setting each `SHARDLINE_*` variable individually. Credentials and
+mounted at `/etc/shardline/shardline.toml`. Shardline automatically detects
+this path, so no `--config` flag is needed. Credentials and
 secrets remain in the runtime secret as env vars or mounted files.
 
 ```bash

--- a/docs/k8s/README.md
+++ b/docs/k8s/README.md
@@ -39,6 +39,24 @@ docs/k8s/production-scaled/
   kustomization.yaml
 ```
 
+## Configuration
+
+Server settings are defined in `configmap.yaml` as a `shardline.toml` file
+mounted at `/etc/shardline/config/shardline.toml`. This replaces the previous
+approach of setting each `SHARDLINE_*` variable individually. Credentials and
+secrets remain in the runtime secret as env vars or mounted files.
+
+```bash
+kubectl apply -f docs/k8s/production-scaled/configmap.yaml
+```
+
+Use `--config` and `--env-file` with the CLI locally to match the production
+configuration during development:
+
+```bash
+shardline --config docs/k8s/production-scaled/configmap.yaml serve
+```
+
 ## Prerequisites
 
 - a Kubernetes cluster with the `autoscaling/v2` API enabled

--- a/docs/k8s/production-scaled/api-deployment.yaml
+++ b/docs/k8s/production-scaled/api-deployment.yaml
@@ -43,10 +43,13 @@ spec:
         - name: config-check
           image: registry.example.com/shardline:1.0.1
           imagePullPolicy: IfNotPresent
-          command: ["shardline", "config", "check"]
+          command:
+            - shardline
+            - --config
+            - /etc/shardline/config/shardline.toml
+            - config
+            - check
           env:
-            - name: SHARDLINE_SERVER_ROLE
-              value: api
             - name: SHARDLINE_INDEX_POSTGRES_URL
               valueFrom:
                 secretKeyRef:
@@ -69,19 +72,16 @@ spec:
               value: /run/secrets/shardline/provider-api-key
             - name: SHARDLINE_PROVIDER_CONFIG_FILE
               value: /etc/shardline/providers/providers.json
-          envFrom:
-            - configMapRef:
-                name: shardline-config
           volumeMounts:
+            - name: config
+              mountPath: /etc/shardline/config
+              readOnly: true
             - name: root
               mountPath: /data/shardline
             - name: tmp
               mountPath: /tmp
             - name: runtime-secrets
               mountPath: /run/secrets/shardline
-              readOnly: true
-            - name: provider-catalog
-              mountPath: /etc/shardline/providers
               readOnly: true
           securityContext:
             allowPrivilegeEscalation: false
@@ -92,13 +92,16 @@ spec:
         - name: shardline
           image: registry.example.com/shardline:1.0.1
           imagePullPolicy: IfNotPresent
-          args: ["serve", "--role", "api"]
+          args:
+            - --config
+            - /etc/shardline/config/shardline.toml
+            - serve
+            - "--role"
+            - api
           ports:
             - name: http
               containerPort: 8080
           env:
-            - name: SHARDLINE_SERVER_ROLE
-              value: api
             - name: SHARDLINE_INDEX_POSTGRES_URL
               valueFrom:
                 secretKeyRef:
@@ -121,10 +124,10 @@ spec:
               value: /run/secrets/shardline/provider-api-key
             - name: SHARDLINE_PROVIDER_CONFIG_FILE
               value: /etc/shardline/providers/providers.json
-          envFrom:
-            - configMapRef:
-                name: shardline-config
           volumeMounts:
+            - name: config
+              mountPath: /etc/shardline/config
+              readOnly: true
             - name: root
               mountPath: /data/shardline
             - name: tmp
@@ -166,6 +169,9 @@ spec:
               drop: ["ALL"]
             readOnlyRootFilesystem: true
       volumes:
+        - name: config
+          configMap:
+            name: shardline-config
         - name: root
           emptyDir: {}
         - name: tmp

--- a/docs/k8s/production-scaled/api-deployment.yaml
+++ b/docs/k8s/production-scaled/api-deployment.yaml
@@ -45,8 +45,6 @@ spec:
           imagePullPolicy: IfNotPresent
           command:
             - shardline
-            - --config
-            - /etc/shardline/config/shardline.toml
             - config
             - check
           env:
@@ -74,7 +72,7 @@ spec:
               value: /etc/shardline/providers/providers.json
           volumeMounts:
             - name: config
-              mountPath: /etc/shardline/config
+              mountPath: /etc/shardline
               readOnly: true
             - name: root
               mountPath: /data/shardline
@@ -93,8 +91,6 @@ spec:
           image: registry.example.com/shardline:1.0.1
           imagePullPolicy: IfNotPresent
           args:
-            - --config
-            - /etc/shardline/config/shardline.toml
             - serve
             - "--role"
             - api
@@ -126,7 +122,7 @@ spec:
               value: /etc/shardline/providers/providers.json
           volumeMounts:
             - name: config
-              mountPath: /etc/shardline/config
+              mountPath: /etc/shardline
               readOnly: true
             - name: root
               mountPath: /data/shardline

--- a/docs/k8s/production-scaled/configmap.yaml
+++ b/docs/k8s/production-scaled/configmap.yaml
@@ -3,25 +3,30 @@ kind: ConfigMap
 metadata:
   name: shardline-config
 data:
-  SHARDLINE_BIND_ADDR: 0.0.0.0:8080
-  SHARDLINE_PUBLIC_BASE_URL: https://cas.example.com
-  SHARDLINE_ROOT_DIR: /data/shardline
-  SHARDLINE_OBJECT_STORAGE_ADAPTER: s3
-  SHARDLINE_S3_BUCKET: shardline
-  SHARDLINE_S3_REGION: us-east-1
-  SHARDLINE_S3_ENDPOINT: https://s3.example.com
-  SHARDLINE_S3_ALLOW_HTTP: "false"
-  SHARDLINE_S3_VIRTUAL_HOSTED_STYLE_REQUEST: "false"
-  SHARDLINE_CHUNK_SIZE_BYTES: "65536"
-  SHARDLINE_MAX_REQUEST_BODY_BYTES: "67108864"
-  SHARDLINE_MAX_SHARD_FILES: "16384"
-  SHARDLINE_MAX_SHARD_XORBS: "16384"
-  SHARDLINE_MAX_SHARD_RECONSTRUCTION_TERMS: "65536"
-  SHARDLINE_MAX_SHARD_XORB_CHUNKS: "65536"
-  SHARDLINE_UPLOAD_MAX_IN_FLIGHT_CHUNKS: "64"
-  SHARDLINE_TRANSFER_MAX_IN_FLIGHT_CHUNKS: "64"
-  SHARDLINE_RECONSTRUCTION_CACHE_ADAPTER: redis
-  SHARDLINE_RECONSTRUCTION_CACHE_TTL_SECONDS: "30"
-  SHARDLINE_RECONSTRUCTION_CACHE_MEMORY_MAX_ENTRIES: "4096"
-  SHARDLINE_PROVIDER_TOKEN_ISSUER: shardline-provider
-  SHARDLINE_PROVIDER_TOKEN_TTL_SECONDS: "300"
+  shardline.toml: |
+    [server]
+    bind_addr = "0.0.0.0:8080"
+    public_base_url = "https://cas.example.com"
+    root_dir = "/data/shardline"
+    chunk_size_bytes = 65536
+    max_request_body_bytes = 67108864
+    upload_max_in_flight_chunks = 64
+    transfer_max_in_flight_chunks = 64
+
+    [storage]
+    adapter = "s3"
+
+    [storage.s3]
+    endpoint = "https://s3.example.com"
+    region = "us-east-1"
+    bucket = "shardline"
+    virtual_hosted_style = false
+
+    [cache]
+    adapter = "redis"
+    ttl_seconds = 30
+
+    [auth]
+    provider = "local-hmac"
+    provider_token_issuer = "shardline-provider"
+    provider_token_ttl_seconds = 300

--- a/docs/k8s/production-scaled/runtime-secret.template.yaml
+++ b/docs/k8s/production-scaled/runtime-secret.template.yaml
@@ -1,3 +1,4 @@
+# These values can also be provided as SHARDLINE_* env vars
 apiVersion: v1
 kind: Secret
 metadata:

--- a/docs/k8s/production-scaled/transfer-deployment.yaml
+++ b/docs/k8s/production-scaled/transfer-deployment.yaml
@@ -43,10 +43,13 @@ spec:
         - name: config-check
           image: registry.example.com/shardline:1.0.1
           imagePullPolicy: IfNotPresent
-          command: ["shardline", "config", "check"]
+          command:
+            - shardline
+            - --config
+            - /etc/shardline/config/shardline.toml
+            - config
+            - check
           env:
-            - name: SHARDLINE_SERVER_ROLE
-              value: transfer
             - name: SHARDLINE_INDEX_POSTGRES_URL
               valueFrom:
                 secretKeyRef:
@@ -65,10 +68,10 @@ spec:
               value: /run/secrets/shardline/token-signing-key
             - name: SHARDLINE_METRICS_TOKEN_FILE
               value: /run/secrets/shardline/metrics-token
-          envFrom:
-            - configMapRef:
-                name: shardline-config
           volumeMounts:
+            - name: config
+              mountPath: /etc/shardline/config
+              readOnly: true
             - name: root
               mountPath: /data/shardline
             - name: tmp
@@ -85,7 +88,12 @@ spec:
         - name: shardline
           image: registry.example.com/shardline:1.0.1
           imagePullPolicy: IfNotPresent
-          args: ["serve", "--role", "transfer"]
+          args:
+            - --config
+            - /etc/shardline/config/shardline.toml
+            - serve
+            - "--role"
+            - transfer
           ports:
             - name: http
               containerPort: 8080
@@ -110,10 +118,10 @@ spec:
               value: /run/secrets/shardline/token-signing-key
             - name: SHARDLINE_METRICS_TOKEN_FILE
               value: /run/secrets/shardline/metrics-token
-          envFrom:
-            - configMapRef:
-                name: shardline-config
           volumeMounts:
+            - name: config
+              mountPath: /etc/shardline/config
+              readOnly: true
             - name: root
               mountPath: /data/shardline
             - name: tmp
@@ -152,6 +160,9 @@ spec:
               drop: ["ALL"]
             readOnlyRootFilesystem: true
       volumes:
+        - name: config
+          configMap:
+            name: shardline-config
         - name: root
           emptyDir: {}
         - name: tmp

--- a/docs/k8s/production-scaled/transfer-deployment.yaml
+++ b/docs/k8s/production-scaled/transfer-deployment.yaml
@@ -46,7 +46,7 @@ spec:
           command:
             - shardline
             - --config
-            - /etc/shardline/config/shardline.toml
+            - /etc/shardline/shardline.toml
             - config
             - check
           env:
@@ -70,7 +70,7 @@ spec:
               value: /run/secrets/shardline/metrics-token
           volumeMounts:
             - name: config
-              mountPath: /etc/shardline/config
+              mountPath: /etc/shardline
               readOnly: true
             - name: root
               mountPath: /data/shardline
@@ -90,7 +90,7 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - --config
-            - /etc/shardline/config/shardline.toml
+            - /etc/shardline/shardline.toml
             - serve
             - "--role"
             - transfer
@@ -120,7 +120,7 @@ spec:
               value: /run/secrets/shardline/metrics-token
           volumeMounts:
             - name: config
-              mountPath: /etc/shardline/config
+              mountPath: /etc/shardline
               readOnly: true
             - name: root
               mountPath: /data/shardline

--- a/e2e/.config/nextest.toml
+++ b/e2e/.config/nextest.toml
@@ -1,0 +1,4 @@
+[profile.default]
+# Never allow one stalled E2E process to consume the workflow's 45-minute
+# budget. Individual tests still report as slow every minute for diagnostics.
+slow-timeout = { period = "60s", terminate-after = 5 }

--- a/e2e/role_split_e2e.rs
+++ b/e2e/role_split_e2e.rs
@@ -26,7 +26,11 @@ use shardline_server::{
     ReadyResponse, ServerConfig, ServerError, ServerFrontend, ServerRole, serve_with_listener,
 };
 use support::ServerE2eInvariantError;
-use tokio::{net::TcpListener, spawn, time::sleep};
+use tokio::{
+    net::TcpListener,
+    spawn,
+    time::{sleep, timeout},
+};
 use xet_client::cas_client::auth::AuthConfig;
 use xet_data::processing::{
     FileDownloadSession, FileUploadSession, Sha256Policy, XetFileInfo,
@@ -86,12 +90,13 @@ async fn transfer_role_serves_transfer_routes_only() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn split_roles_support_native_xet_through_path_routed_proxy() {
-    let result = exercise_split_role_native_xet_flow().await;
-    let error = result.as_ref().err().map(ToString::to_string);
-    assert!(
-        result.is_ok(),
-        "split role native xet e2e failed: {error:?}"
-    );
+    match timeout(Duration::from_secs(60), exercise_split_role_native_xet_flow()).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => panic!("split role native xet e2e failed: {error}"),
+        Err(_elapsed) => panic!(
+            "split role native xet e2e exceeded 60 seconds; the native client or proxy flow stalled"
+        ),
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -167,6 +172,19 @@ async fn wait_for_health(client: &Client, base_url: &str) -> Result<(), Box<dyn 
     }
 
     Err(ServerE2eInvariantError::new("server did not become healthy").into())
+}
+
+async fn wait_for_ready(client: &Client, base_url: &str) -> Result<(), Box<dyn Error>> {
+    for _attempt in 0..100 {
+        if let Ok(response) = client.get(format!("{base_url}/readyz")).send().await
+            && response.status().is_success()
+        {
+            return Ok(());
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+
+    Err(ServerE2eInvariantError::new("server did not become ready").into())
 }
 
 async fn start_frontend_role_runtime(
@@ -312,6 +330,12 @@ async fn exercise_split_role_native_xet_flow() -> Result<(), Box<dyn Error>> {
     .with_token_signing_key(b"test-signing-key-32-bytes-long!!".to_vec())?;
     let api_server = spawn(async move { serve_with_listener(api_config, api_listener).await });
 
+    // Both roles initialize the same local SQLite metadata store. Complete
+    // API readiness before Transfer opens it to avoid racing first-use setup.
+    let client = Client::new();
+    wait_for_health(&client, &api_base_url).await?;
+    wait_for_ready(&client, &api_base_url).await?;
+
     let transfer_listener =
         TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)).await?;
     let transfer_addr = transfer_listener.local_addr()?;
@@ -327,9 +351,8 @@ async fn exercise_split_role_native_xet_flow() -> Result<(), Box<dyn Error>> {
     let transfer_server =
         spawn(async move { serve_with_listener(transfer_config, transfer_listener).await });
 
-    let client = Client::new();
-    wait_for_health(&client, &api_base_url).await?;
     wait_for_health(&client, &transfer_base_url).await?;
+    wait_for_ready(&client, &transfer_base_url).await?;
     let write_token = bearer_token(
         "operator-1",
         TokenScope::Write,

--- a/tests/k8s/kind/configmap.patch.yaml
+++ b/tests/k8s/kind/configmap.patch.yaml
@@ -3,7 +3,31 @@ kind: ConfigMap
 metadata:
   name: shardline-config
 data:
-  SHARDLINE_PUBLIC_BASE_URL: http://shardline-api:8080
-  SHARDLINE_S3_ENDPOINT: http://minio:9000
-  SHARDLINE_S3_ALLOW_HTTP: "true"
-  SHARDLINE_S3_VIRTUAL_HOSTED_STYLE_REQUEST: "false"
+  shardline.toml: |
+    [server]
+    bind_addr = "0.0.0.0:8080"
+    public_base_url = "http://shardline-api:8080"
+    root_dir = "/data/shardline"
+    chunk_size_bytes = 65536
+    max_request_body_bytes = 67108864
+    upload_max_in_flight_chunks = 64
+    transfer_max_in_flight_chunks = 64
+
+    [storage]
+    adapter = "s3"
+
+    [storage.s3]
+    endpoint = "http://minio:9000"
+    region = "us-east-1"
+    bucket = "shardline"
+    allow_http = true
+    virtual_hosted_style = false
+
+    [cache]
+    adapter = "redis"
+    ttl_seconds = 30
+
+    [auth]
+    provider = "local-hmac"
+    provider_token_issuer = "shardline-provider"
+    provider_token_ttl_seconds = 300


### PR DESCRIPTION
## Description

Adds configuration file support with two complementary sources: a
shardline.toml file for server configuration and a .env file for secrets.
The TOML file supports ${VAR} interpolation drawing from the .env file
or process environment. Closes #20.

## Changes

* **--env-file flag** (global, all commands): Loads a .env file into the
  process environment before configuration resolution. Secrets stay in
  .env, not in the TOML config. (Phase 1)

* **--config / -c flag** (global, all commands): Points at a specific
  shardline.toml. Auto-detection also checks ./shardline.toml,
  ~/.config/shardline/shardline.toml, and /etc/shardline/shardline.toml.
  (Phase 2)

* **shardline.toml format**: Full TOML structure covering [server],
  [storage], [storage.s3], [index], [cache], [auth], [auth.jwks],
  [auth.oidc]. Values with ${VAR} syntax are resolved from process env
  or .env file.

* **Direct struct deserialization**: Parsed ShardlineTomlConfig fields
  are applied to the environment for keys not already set. Env vars
  always take precedence over TOML values. No unsafe code.

* **Updated K8s manifests**: ConfigMap converted from 20 SHARDLINE_*
  env vars to a single shardline.toml file mounted at /etc/shardline/.
  Auto-detection picks it up without --config. Updated api-deployment,
  transfer-deployment, gc-cronjob.

* **Updated Docker docs**: Added examples for docker run and Docker
  Compose with --config and --env-file.

* **Test coverage**: 5 unit tests for TOML path resolution, 17
  integration tests for config file loading, 11 interpolation tests
  in env.rs, 3 CLI e2e tests for --config and --env-file.

## Motivation

Shardline previously required all configuration through SHARDLINE_*
environment variables. This forced operators to manage long env scripts
or wrapper scripts, mixed secrets with configuration, and made K8s
ConfigMaps unwieldy (20+ env vars). The config file approach separates
secrets from configuration, enables declarative deployment, and
simplifies operator workflows.

## Scope and impact

No breaking changes. Existing env-var-only configurations continue to
work. The TOML file is additive. No migration needed.

## Testing

* CI matrix passes (format, clippy, deny, 618 tests, release binary,
  migration sync)
* Manual verification of all precedence cases:
  - Shell env overrides .env file
  - .env file overrides shardline.toml
  - shardline.toml sets defaults
* Docker image builds and validates config check
* Kustomize build produces valid manifests