### PR TITLE
chore: bump workspace version to v1.1.0 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3177,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "shardline"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "bytes",
  "clap",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-auth"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "hex",
  "serde_json",
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-bench"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "criterion",
  "libc",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-cache"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "criterion",
  "hex",
@@ -3247,7 +3247,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-cas"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "blake3",
  "shardline-index",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-fsck"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "rusqlite",
  "serde_json",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-gc"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-hub-api"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "axum",
  "base64",
@@ -3359,7 +3359,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-index"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-metrics"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "axum",
  "futures-util",
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-oci-adapter"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-protocol"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "criterion",
  "hex",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-protocol-adapters"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "hex",
  "serde",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-provider-events"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "serde_json",
  "shardline-index",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-rebuild"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "rusqlite",
  "serde",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-server"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-server-core"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "blake3",
  "criterion",
@@ -3567,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-storage"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-test-support"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "libc",
  "tempfile",
@@ -3597,14 +3597,14 @@ dependencies = [
 
 [[package]]
 name = "shardline-validation"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "shardline-vcs"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "hex",
  "hmac",
@@ -3617,7 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-xet-adapter"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "axum",
  "criterion",
@@ -3635,7 +3635,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-xet-core"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "blake3",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = ["crates/*"]
 # - getrandom: duplicate (0.3 workspace, older via xet ecosystem) — NOT FIXABLE.
 
 [workspace.package]
-version = "1.0.1"
+version = "1.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/STEXS-Technologies/shardline"


### PR DESCRIPTION
## Description

Bumps all production crate versions from 1.0.1 to 1.1.0 via the workspace-level `workspace.package.version` field. This is a pure version bump with no behavioral changes - it prepares the crate graph for the v1.1.0 release tag.

The v1.1.0 release incorporates config file support (shardline.toml + .env), governance documentation, documentation drift fixes, and CI/publish pipeline hardening (PRs #22, #23).

## Changes

- `Cargo.toml` - `workspace.package.version` changed from `"1.0.1"` to `"1.1.0"`
- `Cargo.lock` - auto-updated by cargo for workspace consistency

No source, test, docs, or config changes. No crate-boundary or runtime impact.

## Motivation

- **Business**: Published crate versions must match the release they ship in. v1.0.1 was released July 22; v1.1.0 collects the config-file feature, governance docs, and pipeline hardening.
- **Technical**: Single-point version definition (`workspace.package.version`) means one edit propagates to all 19 production crates automatically.

## Scope and impact

- **Affected crates**: All 19 production crates (via `version.workspace = true`). Excluded: `fuzz` (0.0.0), `loom-tests` (0.1.0), `bench` (version.workspace but dev-only).
- **Protocol or API changes**: None.
- **Backward compatibility**: Full - no API or behavior change.
- **Performance impact**: None.
- **Security impact**: None.
- **Operational impact**: None - version string in `shardline --version` output changes from `1.0.1` to `1.1.0`.

## Testing

- [x] Unit tests
- [x] Integration tests
- [x] Manual verification
- [ ] Performance checks (not applicable)
- [ ] Security checks (not applicable)

Commands/results:

```bash
cargo make ci       # passes: lint, clippy, tests, release binary, migration sync
cargo check         # all crates report v1.1.0
```

## Related issues and documentation

- Related: #23 (config file feature), #22 (governance docs), #20 (config file issue)
- Tracking: v1.1.0 release
- Architecture docs: `docs/ARCHITECTURE.md`
- Protocol docs: `docs/PROTOCOL_CONFORMANCE.md`
- Security/invariants docs: `docs/SECURITY_AND_INVARIANTS.md`

## Additional notes

After merge, tag `v1.1.0` on main with release notes summarizing the changes since v1.0.1.
