### PR TITLE
chore(release): prepare v1.2.1 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-07-27
+
+Patch release establishing recoverable upload lifecycles, shared chunk-backed storage,
+bounded runtime resource use, and hardened release and deployment boundaries. Public LFS,
+Bazel CAS, OCI, Hub, and Xet protocol surfaces remain compatible.
+
+### Changed
+
+- **Shared chunk-backed storage**: standard bulk-data frontends now use the shared CAS
+  coordinator and fixed-size chunks, while native Xet retains content-defined chunking.
+- **Authoritative upload lifecycle**: memory, SQLite, and PostgreSQL index stores persist
+  legal upload-intent transitions so incomplete writes can be reconciled deterministically.
+- **Bounded runtime behavior**: asynchronous object I/O, admission control, quotas, timeouts,
+  and explicit overload responses bound memory, blocking work, and request concurrency.
+
+### Fixed
+
+- **Visibility and recovery consistency**: file records now form the publication boundary,
+  and GC, FSCK, repair, and protocol handlers share the same reachability model.
+- **Legacy read compatibility**: existing whole-object records remain readable while new
+  writes use chunk-backed records.
+- **CI reliability**: database-gated coverage is included in the coverage ratchet, shared
+  backend assertions tolerate parallel test state, and Docker test identifiers are unique.
+
+### Security
+
+- Authentication and route policies fail closed, object and filesystem boundaries use typed
+  validation, and production containers run with non-root security defaults.
+- Release artifacts and container images are verified, provenance-attested, and published
+  through restartable release steps with expiring dependency exceptions.
+
+### Operations
+
+- Apply migration `20260721000000_upload_intents` before accepting writes with this version.
+- Roll API and transfer roles together. Preserve database and object-store backups if an
+  emergency rollback is required after new chunk-backed records have been published.
+
 ## [1.2.0] - 2026-07-24
 
 Minor release adding Ed25519 asymmetric token verification, Hub authentication coverage,
@@ -264,7 +301,8 @@ There are no intentional breaking API or configuration changes from `1.0.0`.
 - Documented async storage TOCTOU races with 1.2M-run fuzz validation (`40ef000`)
 - Updated all architecture, deployment, and Hub API docs for 20-crate structure (`1203d8e`)
 
-[Unreleased]: https://github.com/STEXS-Technologies/shardline/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/STEXS-Technologies/shardline/compare/v1.2.1...HEAD
+[1.2.1]: https://github.com/STEXS-Technologies/shardline/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/STEXS-Technologies/shardline/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/STEXS-Technologies/shardline/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/STEXS-Technologies/shardline/compare/v1.0.0...v1.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3243,7 +3243,7 @@ dependencies = [
 
 [[package]]
 name = "shardline"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "bytes",
  "clap",
@@ -3273,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-auth"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-bench"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "criterion",
  "libc",
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-cache"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "criterion",
  "hex",
@@ -3315,7 +3315,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-cas"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "blake3",
@@ -3329,7 +3329,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-fsck"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "rusqlite",
  "serde_json",
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-gc"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3395,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-hub-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "axum",
  "base64",
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-index"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-metrics"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "axum",
  "futures-util",
@@ -3472,7 +3472,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-oci-adapter"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "blake3",
  "bytes",
@@ -3492,7 +3492,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-protocol"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "criterion",
  "hex",
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-protocol-adapters"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "hex",
  "serde",
@@ -3521,7 +3521,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-provider-events"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "serde_json",
  "shardline-index",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-rebuild"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "rusqlite",
  "serde",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-server"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3619,7 +3619,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-server-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "blake3",
@@ -3640,7 +3640,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-storage"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "blake3",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-test-support"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "libc",
  "tempfile",
@@ -3670,14 +3670,14 @@ dependencies = [
 
 [[package]]
 name = "shardline-validation"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "shardline-vcs"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "hex",
  "hmac",
@@ -3690,7 +3690,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-xet-adapter"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "axum",
  "criterion",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-xet-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "blake3",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = ["crates/*"]
 # - getrandom: duplicate (0.3 workspace, older via xet ecosystem) — NOT FIXABLE.
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/STEXS-Technologies/shardline"

--- a/e2e/Cargo.lock
+++ b/e2e/Cargo.lock
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-auth"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -2868,7 +2868,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-cache"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "hex",
  "redis",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-cas"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "shardline-index",
@@ -2926,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-fsck"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "serde_json",
  "shardline-cas",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-gc"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2960,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-hub-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "axum",
  "base64",
@@ -2989,7 +2989,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-index"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3009,7 +3009,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-metrics"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "axum",
  "futures-util",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-oci-adapter"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "blake3",
  "bytes",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-protocol"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "hex",
  "hmac",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-protocol-adapters"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "hex",
  "serde",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-provider-events"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "serde_json",
  "shardline-index",
@@ -3082,7 +3082,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-rebuild"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-server"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "axum",
  "base64",
@@ -3145,7 +3145,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-server-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "blake3",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-storage"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "blake3",
@@ -3177,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-test-support"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "libc",
  "tempfile",
@@ -3186,14 +3186,14 @@ dependencies = [
 
 [[package]]
 name = "shardline-validation"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "shardline-vcs"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "hex",
  "hmac",
@@ -3206,7 +3206,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-xet-adapter"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "axum",
  "serde",
@@ -3222,7 +3222,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-xet-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "blake3",
  "bytes",


### PR DESCRIPTION
## Description

Prepares Shardline `v1.2.1` by updating the workspace package version, regenerating
the main and standalone E2E lockfiles, and publishing release notes for the production
hardening included since `v1.2.0`.

This keeps the release tag, published crate versions, generated lockfiles, and changelog
comparison links coherent.

## Changes

- `Cargo.toml`: bump the inherited workspace package version from `1.2.0` to `1.2.1`.
- `Cargo.lock`: update all workspace package entries to `1.2.1`.
- `e2e/Cargo.lock`: update all path-based Shardline package entries to `1.2.1`.
- `CHANGELOG.md`: add the `1.2.1` release notes and update release comparison links.

For cross-crate or runtime changes:

- Affected crates: every published Shardline workspace crate inherits version `1.2.1`,
  including `shardline-protocol`, `shardline-storage`, `shardline-index`,
  `shardline-cas`, `shardline-cache`, `shardline-vcs`, `shardline-server`, and
  `shardline`.
- Cross-crate interaction changes: none in this PR. This change only aligns package and
  release metadata for the already merged implementation.
- Migration or rollout requirements: apply migration
  `20260721000000_upload_intents` before accepting writes, and roll API and transfer
  roles together.

## Motivation

Business or operator motivation:

The patch release needs a single authoritative version across crates, lockfiles,
release notes, tags, and published artifacts.

Technical motivation:

The release workflow validates that the tag matches the `shardline` package version.
Updating both lockfiles also prevents stale `1.2.0` path-package metadata in local and
standalone E2E builds.

Alternative approaches considered:

Updating only `Cargo.toml` was rejected because both generated lockfiles would retain
stale workspace package versions. Omitting the changelog update was rejected because
operators need migration, rollout, compatibility, and security notes before tagging.

## Scope and impact

- Affected crates: all published workspace crates through `workspace.package.version`.
- Protocol or API changes: none in this PR.
- Backward compatibility: no additional compatibility change. Release notes preserve
  the existing legacy whole-object read guarantee.
- Performance impact: none.
- Security impact: none in this metadata-only PR. The changelog records the previously
  merged runtime and release security hardening.
- Operational impact: operators must follow the documented migration and coordinated
  rollout notes for `v1.2.1`.

## Testing

- [x] Unit tests
- [x] Integration tests
- [x] Manual verification
- [ ] Performance checks (if applicable)
- [x] Security checks (if applicable)

Commands/results:

```bash
cargo check --workspace --all-features
# PASS

cargo check --manifest-path e2e/Cargo.toml --tests
# PASS

cargo make ci
# PASS in 261 seconds: formatting, clippy, dependency policy, workspace tests,
# release binary verification, and all 14 migrations synchronized.

cargo pkgid -p shardline
# path+file:///.../crates/shardline#1.2.1
```

Cargo metadata confirms all published workspace packages and all path-based Shardline
packages in the standalone E2E workspace resolve as `1.2.1`.

## Related issues and documentation

- Fixes: N/A
- Related: PR #27
- Architecture docs: `docs/ARCHITECTURE.md`
- Protocol docs: `docs/PROTOCOL_CONFORMANCE.md`
- Security/invariants docs: `docs/SECURITY_AND_INVARIANTS.md`
- Operations/runbook updates: release and rollout notes are included in `CHANGELOG.md`.

## Reviewer checklist

- [x] Code follows project standards and crate-boundary constraints
- [x] Tests added or updated and passing
- [x] Documentation updated where behavior or config changed
- [x] No undocumented breaking change
- [x] Performance trade-offs documented where relevant
- [x] Security considerations addressed where relevant

## Additional notes

After merge, create tag `v1.2.1` from the resulting commit on `main`. The release
workflow will verify that the tag matches the Cargo package version before publishing.
