### PR TITLE
chore(release): prepare v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.2.2] - 2026-07-28
+
+Patch release fixing Xet protocol uploads broken by stubbed BG4 compression.
+
+### Fixed
+
+- **Xet BG4 compression**: shardline-xet-core stubbed ByteGrouping4LZ4 as plain LZ4,
+  causing all xet-data client uploads to fail with HTTP 400. Delegates to upstream
+  xet-core-structures for correct BG4 interleaving/deinterleaving.
+- **CI license check**: MPL-2.0 added to deny.toml allow list for xet-core-structures
+  transitive dependencies.
+
+### Testing
+
+- Added 23 BG4 compression unit tests (roundtrips, panic safety, cross-scheme, proptest).
+- Added adapter integration test for BG4 xorb validate/decode roundtrip.
+- Added missing validate_xorb_object call to existing BG4 integration test.
+
 ## [1.2.1] - 2026-07-27
 
 Patch release establishing recoverable upload lifecycles, shared chunk-backed storage,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = ["crates/*"]
 # - getrandom: duplicate (0.3 workspace, older via xet ecosystem) — NOT FIXABLE.
 
 [workspace.package]
-version = "1.2.1"
+version = "1.2.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/STEXS-Technologies/shardline"


### PR DESCRIPTION
## Description

Patch release fixing Xet protocol uploads broken by stubbed BG4 compression. Version bump to 1.2.2.

## Changes

- Cargo.toml: version 1.2.1 to 1.2.2
- CHANGELOG.md: added 1.2.2 release notes

## Motivation

The BG4 compression fix (PR #30) unblocks all xet-data client uploads. This release packages that fix for crates.io and container image consumers.

## Scope and impact

- Affected crates: all workspace crates (version bump only)
- Protocol or API changes: none
- Backward compatibility: fully compatible
- Performance impact: none
- Security impact: none
- Operational impact: none

## Testing

- [x] cargo make ci passes
- [x] Version matches tag expectation