### PR TITLE
docs: clarify production readiness and frontend semantics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
+      - name: Validate development deployment graph
+        run: docker compose config --quiet
+
       - name: Setup Rust CI toolchain and tools
         uses: ./.github/actions/rust-ci-setup
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ frontend supports them.**
 It accepts immutable object uploads, deduplicates content, and serves range-aware
 downloads. It is especially useful for large-file versioning when the selected frontend
 keeps revisions or commits, because unchanged content can be reused instead of uploaded
-repeatedly. Use the frontend that fits your workflow—Xet, OCI, Git LFS, S3, Hugging Face
+repeatedly. Use the frontend that fits your workflow: Xet, OCI, Git LFS, S3, Hugging Face
 Hub, cache clients, or the native API—or run it standalone for your own storage needs.
 Pair it with GitHub, GitLab, or Gitea when you want repository-scoped storage.
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![Status](https://img.shields.io/badge/status-stable-1f6feb)](docs/COMPATIBILITY_STATUS.md)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-green)](#license)
 
-**Shardline is a protocol-neutral content-addressed storage engine, optimized for
-deduplicated model, dataset, container and build-artifact distribution, with Xet, OCI,
-Git LFS, S3, HuggingFace Hub and cache-compatible frontends.**
+**Shardline is a self-hostable content-addressed storage backend for teams that need one
+deduplicated store for models, datasets, containers, source trees, and build artifacts
+across Xet, OCI, Git LFS, S3, Hugging Face Hub, and cache clients.**
 
 Shardline is a self-hostable content-addressed storage (CAS) server.
 It accepts immutable object uploads, deduplicates content, and serves range-aware
@@ -57,11 +57,20 @@ repository-scoped storage.
 
 ## Quick start
 
-```bash
-# Run with Docker
-docker compose -f docker-compose.yml up --build
+The recommended first run is the development Compose profile.
+It provisions the local Postgres and MinIO dependencies, applies migrations, and waits
+for them before starting Shardline:
 
-# Or build from source
+```bash
+docker compose -f docker-compose.yml up --build
+```
+
+See [Getting Started](docs/GETTING_STARTED.md) for readiness checks, token creation,
+state cleanup, and the boundary between the development and production profiles.
+
+For a host-native binary:
+
+```bash
 cargo build --release
 ./target/release/shardline serve
 ```
@@ -96,6 +105,7 @@ Provider integration is optional.
 | Guide | Description |
 | --- | --- |
 | [Deployment](docs/DEPLOYMENT.md) | Installation and configuration |
+| [Getting Started](docs/GETTING_STARTED.md) | One deterministic local path from checkout to a running server |
 | [Authentication](docs/AUTHENTICATION.md) | Pluggable auth providers (HMAC, Ed25519, OIDC, JWKS, passthrough) |
 | [HuggingFace Hub API](docs/HUGGINGFACE_HUB_API.md) | Hub API compatibility for huggingface-cli |
 | [S3 Frontend](docs/S3_FRONTEND.md) | S3-compatible object API for lakehouse and s3:// clients |

--- a/README.md
+++ b/README.md
@@ -3,14 +3,15 @@
 [![Status](https://img.shields.io/badge/status-stable-1f6feb)](docs/COMPATIBILITY_STATUS.md)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-green)](#license)
 
-**Shardline is a self-hostable content-addressed storage backend for anyone who wants
-durable, efficient versioning of large files.**
+**Shardline is a self-hostable content-addressed storage backend for anyone’s storage
+needs, with deduplication and durable versioning built in.**
 
-It accepts immutable object uploads, deduplicates unchanged content between versions,
-and serves range-aware downloads. Use it for your own storage needs with the frontend
-that fits your workflow—Xet, OCI, Git LFS, S3, Hugging Face Hub, cache clients, or the
-native API. Run it standalone, or pair it with GitHub, GitLab, or Gitea when you want
-repository-scoped storage.
+It accepts immutable object uploads, deduplicates content, and serves range-aware
+downloads. It is especially useful when versioning large files, where unchanged content
+can be reused instead of uploaded repeatedly. Use the frontend that fits your
+workflow—Xet, OCI, Git LFS, S3, Hugging Face Hub, cache clients, or the native API—or
+run it standalone for your own storage needs. Pair it with GitHub, GitLab, or Gitea when
+you want repository-scoped storage.
 
 ## Surface Maturity
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-green)](#license)
 
 **Shardline is a self-hostable content-addressed storage backend for anyone’s storage
-needs, with deduplication and durable versioning built in.**
+needs, with content deduplication at its core and version-aware workflows where the
+frontend supports them.**
 
 It accepts immutable object uploads, deduplicates content, and serves range-aware
-downloads. It is especially useful when versioning large files, where unchanged content
-can be reused instead of uploaded repeatedly. Use the frontend that fits your
-workflow—Xet, OCI, Git LFS, S3, Hugging Face Hub, cache clients, or the native API—or
-run it standalone for your own storage needs. Pair it with GitHub, GitLab, or Gitea when
-you want repository-scoped storage.
+downloads. It is especially useful for large-file versioning when the selected frontend
+keeps revisions or commits, because unchanged content can be reused instead of uploaded
+repeatedly. Use the frontend that fits your workflow—Xet, OCI, Git LFS, S3, Hugging Face
+Hub, cache clients, or the native API—or run it standalone for your own storage needs.
+Pair it with GitHub, GitLab, or Gitea when you want repository-scoped storage.
 
 ## Surface Maturity
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![Status](https://img.shields.io/badge/status-stable-1f6feb)](docs/COMPATIBILITY_STATUS.md)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-green)](#license)
 
-**Shardline is a self-hostable content-addressed storage backend for teams that need one
-deduplicated store for models, datasets, containers, source trees, and build artifacts
-across Xet, OCI, Git LFS, S3, Hugging Face Hub, and cache clients.**
+**Shardline is a self-hostable content-addressed storage backend for anyone who wants
+durable, efficient versioning of large files.**
 
-Shardline is a self-hostable content-addressed storage (CAS) server.
-It accepts immutable object uploads, deduplicates content, and serves range-aware
-downloads. Run it standalone or pair it with GitHub, GitLab, or Gitea for
+It accepts immutable object uploads, deduplicates unchanged content between versions,
+and serves range-aware downloads. Use it for your own storage needs with the frontend
+that fits your workflow—Xet, OCI, Git LFS, S3, Hugging Face Hub, cache clients, or the
+native API. Run it standalone, or pair it with GitHub, GitLab, or Gitea when you want
 repository-scoped storage.
 
 ## Surface Maturity

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,11 @@ services:
       POSTGRES_DB: shardline
     volumes:
       - shardline_postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U shardline -d shardline"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
 
   minio:
     image: quay.io/minio/minio:latest
@@ -51,8 +56,10 @@ services:
     stop_grace_period: 30s
     network_mode: host
     depends_on:
-      - postgres
-      - minio-init
+      db-migrate:
+        condition: service_completed_successfully
+      minio-init:
+        condition: service_completed_successfully
     environment:
       SHARDLINE_BIND_ADDR: 0.0.0.0:18080
       SHARDLINE_SERVER_ROLE: all
@@ -92,7 +99,8 @@ services:
     image: shardline:local
     network_mode: host
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     environment:
       SHARDLINE_INDEX_POSTGRES_URL: postgres://shardline:shardline-dev-password@127.0.0.1:5432/shardline
       SHARDLINE_TOKEN_SIGNING_KEY: ${SHARDLINE_TOKEN_SIGNING_KEY:-test-signing-key-32-bytes-long!!}

--- a/docs/COMPATIBILITY_STATUS.md
+++ b/docs/COMPATIBILITY_STATUS.md
@@ -41,6 +41,25 @@ version.
   interoperability may still change.
 - **Internal**: architectural component, not a user-facing promise.
 
+## Versioning and Deduplication Semantics
+
+The shared CAS core stores immutable content and reuses identical content whenever a
+new upload refers to it. That does not mean every frontend exposes the same version
+history. Version visibility and overwrite behavior belong to the frontend contract:
+
+| Frontend | User-visible version semantics |
+| --- | --- |
+| Xet | Revision-oriented workflows can address and retrieve older versions. |
+| Git LFS | Version history comes from Git commits and refs; the LFS object endpoint alone is a blob store. |
+| Hugging Face Hub | Repository revisions and commits expose historical states. |
+| OCI | Blobs and manifests are immutable by digest; tags are mutable pointers and have no tag-history API here. |
+| S3 | A `PUT` replaces the logical object key. S3 bucket versioning and `ListObjectVersions` are not implemented. |
+| Bazel HTTP cache | Digest-keyed cache entries have no user-facing version history. |
+
+When an overwrite makes a prior record unreachable, its unique chunks become GC
+candidates after the configured quarantine/retention period. Chunks shared by another
+reachable record remain protected.
+
 ## Validated Route Surface
 
 - Git LFS: batch negotiation plus direct object `GET`, `HEAD`, and `PUT`

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,92 @@
+# Getting Started
+
+This is the shortest supported path from a checkout to a working Shardline instance.
+It uses the development Docker Compose profile: Postgres and MinIO provide the durable
+backends, and the Compose graph waits for the database migration job before starting the
+server.
+
+For a production deployment, use [Deployment](DEPLOYMENT.md) and the
+[Kubernetes package](k8s/README.md) instead.
+The Compose file uses development credentials and is not a production topology.
+
+## Prerequisites
+
+- Docker Engine with the Compose plugin
+- at least 4 GiB of available memory
+
+## Start the local server
+
+From the repository root:
+
+```bash
+docker compose up --build
+```
+
+The first run builds the image, starts Postgres and MinIO, applies all pending database
+migrations, creates the `shardline` bucket, and then starts the server on
+`http://127.0.0.1:18080`.
+
+The default profile is intentionally local and development-only.
+Its credentials are visible in `docker-compose.yml`; replace them before using any
+shared environment.
+
+## Check readiness
+
+In another terminal:
+
+```bash
+curl -fsS http://127.0.0.1:18080/healthz
+curl -fsS http://127.0.0.1:18080/readyz
+```
+
+`/healthz` confirms that the process is answering.
+`/readyz` also checks the configured durable backends and is the useful gate before
+sending traffic.
+
+## Create a local token
+
+The Compose profile uses the local HMAC provider.
+Mint a repository-scoped token inside the running container:
+
+```bash
+TOKEN="$(docker compose exec -T shardline \
+  shardline admin token \
+  --issuer local \
+  --subject operator-1 \
+  --scope write \
+  --provider generic \
+  --owner team \
+  --repo assets \
+  --revision main \
+  --key-env SHARDLINE_TOKEN_SIGNING_KEY)"
+
+curl -fsS \
+  -H "Authorization: Bearer ${TOKEN}" \
+  http://127.0.0.1:18080/v1/stats
+```
+
+For client-specific setup, continue with
+[Client Configuration](CLIENT_CONFIGURATION.md).
+
+## Stop and remove local state
+
+Stop the services while keeping the named volumes:
+
+```bash
+docker compose down
+```
+
+Remove the local development data as well only when you intentionally want a fresh
+instance:
+
+```bash
+docker compose down --volumes
+```
+
+## Where to go next
+
+- [Deployment profiles](DEPLOYMENT.md) for a small or scaled production layout
+- [Operations](OPERATIONS.md) for backups, restore order, scaling, and incident work
+- [Compatibility status](COMPATIBILITY_STATUS.md) for protocol tiers and explicit limits
+- [Performance](PERFORMANCE.md) for reproducible benchmark commands
+- [Disaster recovery](DISASTER_RECOVERY.md) for failure-specific recovery procedures

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ docs that match your use case.
 
 ## Start Here
 
+- [Getting Started](GETTING_STARTED.md)
 - [Deployment](DEPLOYMENT.md)
 - [Operations](OPERATIONS.md)
 - [Architecture](ARCHITECTURE.md)


### PR DESCRIPTION
## Description

This PR makes Shardline’s primary value and deployment behavior easier to understand. It presents Shardline as broadly useful content-addressed storage, while explicitly explaining that version-history semantics depend on the selected frontend. It also makes the default Docker Compose path wait for its database migration before starting the server.

## Changes

- `README.md`: clarify Shardline’s broad storage use case, content deduplication, large-file versioning strengths, and frontend-specific semantics.
- `docs/GETTING_STARTED.md`: add a concise local deployment path with readiness checks, token creation, cleanup, and links to deeper operator documentation.
- `docker-compose.yml`: add a Postgres health check; require healthy Postgres for `db-migrate`; require successful migration and MinIO initialization before starting Shardline.
- `.github/workflows/ci.yml`: validate the Compose deployment graph on pull requests.
- `docs/COMPATIBILITY_STATUS.md`: document versioning behavior for Xet, Git LFS, Hugging Face Hub, OCI, S3, and Bazel.
- `docs/README.md`: link the new getting-started guide.

No crates, crate boundaries, runtime APIs, or database schemas changed.

## Motivation

Business or operator motivation:

- Give first-time users one reliable path from checkout to a running instance.
- Explain the value to users with different storage needs, without implying that every user must enable every frontend.
- Set accurate expectations about which frontends expose version history.

Technical motivation:

- The previous Compose dependency graph could start Shardline before migrations had completed.
- Frontend versioning semantics were distributed across protocol documentation rather than summarized in one place.

Alternative approaches considered:

- A broad crate consolidation or CAS application-layer redesign was not included; those require separate architectural and fault-injection work.

## Scope and impact

- Affected crates: None.
- Protocol or API changes: None.
- Backward compatibility: Fully backward compatible; documentation and local Compose ordering only.
- Performance impact: No application runtime change. Compose may wait for health/migration completion during startup.
- Security impact: No production security behavior changed. The guide explicitly identifies Compose credentials as development-only.
- Operational impact: Local Compose startup is deterministic and fails before serving if migrations fail.

## Testing

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual verification
- [ ] Performance checks (if applicable)
- [ ] Security checks (if applicable)

Commands/results:

```bash
docker compose config --quiet                    # passed
git diff --check                                 # passed
git show --check --oneline HEAD                  # passed
```

## Related issues and documentation

- Fixes: —
- Related: production-readiness and deployment usability follow-up
- Architecture docs: `docs/ARCHITECTURE.md`
- Protocol docs: `docs/PROTOCOLS.md`
- Security/invariants docs: `docs/SECURITY_AND_INVARIANTS.md`
- Operations/runbook updates: `docs/GETTING_STARTED.md`, `docs/COMPATIBILITY_STATUS.md`

## Reviewer checklist

- [x] Code follows project standards and crate-boundary constraints
- [ ] Tests added or updated and passing
- [x] Documentation updated where behavior or config changed
- [x] No undocumented breaking change
- [x] Performance trade-offs documented where relevant
- [x] Security considerations addressed where relevant

## Additional notes

This PR is intentionally a focused first slice of the production-readiness priorities. The existing compatibility, recovery, benchmark, and architecture documents remain the deeper contracts; this change adds the shortest route into them.