### PR TITLE
chore(release): prepare v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to Shardline are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.7.0] - 2026-08-23
+
+Reliability release focused on distributed correctness, crash recovery, and
+adversarial verification. **No breaking API changes** — the multi-writer
+contracts, fencing, tombstones, and typed parsing additions are compatible with
+existing deployments and data.
+
+### Added
+- **Distributed-correctness contract** — fenced multi-writer publication over
+  shared Postgres/S3 state, explicit lock ordering, recovery semantics, and
+  mixed-version/upgrade documentation.
+- **Tombstone lifecycle** — durable deletion markers coordinate GC with
+  concurrent readers, reconstruction, repair, and retries; GC now removes only
+  safely expired tombstones.
+- **Typed parsing and property coverage** — closed-domain newtypes replace
+  string matching in security-sensitive paths, with expanded proptests and
+  fuzz targets for protocol, URL, config, auth, and CAS boundaries.
+- **Replayable chaos verification** — deterministic fault schedules, failpoints,
+  invariant checks, and expanded database, object-store, network, restart, and
+  authorization campaigns.
+
+### Changed
+- **Multi-node deployment guidance** now specifies the shared-filesystem byte
+  and locking contract, Postgres/S3 fencing requirements, and N-1 upgrade
+  compatibility.
+- **GC and publication** use transactional reachability checks and bounded
+  server-side Xorb batches, reducing memory pressure for large uploads.
+- **Release CI** requires the reliability campaign before publishing crates,
+  images, and release assets.
+
+### Fixed
+- Stale writers can no longer commit after lease replacement or fencing epoch
+  changes.
+- Crash and retry windows around metadata publication, object-store ambiguity,
+  reconstruction, repair, and GC now recover to a valid state.
+- Large streamed uploads no longer require a single unbounded server-side Xorb.
+- Documentation now reflects the completed distributed-correctness contract.
+
 ## [1.6.0] - 2026-08-20
 
 Major release that adds a full S3-compatible frontend and closes the hardening

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3147,7 +3147,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdx"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3364,7 +3364,7 @@ dependencies = [
 
 [[package]]
 name = "shardline"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "axum",
  "bytes",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-auth"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-bench"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "bytes",
  "criterion",
@@ -3428,7 +3428,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-cache"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "criterion",
  "hex",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-cas"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -3457,7 +3457,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-fsck"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "lz4_flex 0.11.6",
  "rusqlite",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-gc"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "proptest",
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-hub-api"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-index"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-metrics"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "axum",
  "futures-util",
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-oci-adapter"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3634,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-protocol"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "criterion",
  "hex",
@@ -3649,7 +3649,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-protocol-adapters"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "hex",
  "serde",
@@ -3663,7 +3663,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-provider-events"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "serde_json",
  "shardline-index",
@@ -3682,7 +3682,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-rebuild"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "rusqlite",
  "serde",
@@ -3702,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-s3-adapter"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "axum",
  "base64",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-server"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3788,7 +3788,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-server-core"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3812,7 +3812,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-storage"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -3833,7 +3833,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-test-support"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "libc",
  "tempfile",
@@ -3842,14 +3842,14 @@ dependencies = [
 
 [[package]]
 name = "shardline-validation"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "shardline-vcs"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "hex",
  "hmac",
@@ -3862,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-xet-adapter"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "axum",
  "criterion",
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-xet-core"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "blake3",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = ["crates/*"]
 # - getrandom: duplicate (0.3 workspace, older via xet ecosystem) — NOT FIXABLE.
 
 [workspace.package]
-version = "1.6.0"
+version = "1.7.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/STEXS-Technologies/shardline"
@@ -52,30 +52,30 @@ serde_json = "1.0"
 sha1 = "0.10"
 sha2 = { version = "0.10", features = ["compress"] }
 md-5 = { version = "0.10", features = ["std"] }
-shardline = { version = "1.5.0", path = "crates/shardline" }
-shardline-cache = { version = "1.5.0", path = "crates/shardline-cache" }
-shardline-cas = { version = "1.5.0", path = "crates/shardline-cas" }
-shardline-fsck = { version = "1.5.0", path = "crates/shardline-fsck" }
-shardline-gc = { version = "1.5.0", path = "crates/shardline-gc" }
-shardline-hub-api = { version = "1.5.0", path = "crates/shardline-hub-api" }
-shardline-index = { version = "1.5.0", path = "crates/shardline-index" }
-shardline-metrics = { version = "1.5.0", path = "crates/shardline-metrics" }
-shardline-protocol = { version = "1.5.0", path = "crates/shardline-protocol" }
-shardline-protocol-adapters = { version = "1.5.0", path = "crates/shardline-protocol-adapters" }
-shardline-rebuild = { version = "1.5.0", path = "crates/shardline-rebuild" }
-shardline-provider-events = { version = "1.5.0", path = "crates/shardline-provider-events" }
-shardline-oci-adapter = { version = "1.5.0", path = "crates/shardline-oci-adapter" }
-shardline-s3-adapter = { version = "1.5.0", path = "crates/shardline-s3-adapter" }
-shardline-server = { version = "1.5.0", path = "crates/shardline-server" }
-shardline-server-core = { version = "1.5.0", path = "crates/shardline-server-core" }
-shardline-storage = { version = "1.5.0", path = "crates/shardline-storage" }
-shardline-test-support = { version = "1.5.0", path = "crates/shardline-test-support" }
-shardline-validation = { version = "1.5.0", path = "crates/shardline-validation" }
-shardline-auth = { version = "1.5.0", path = "crates/shardline-auth" }
-shardline-vcs = { version = "1.5.0", path = "crates/shardline-vcs" }
-shardline-xet-adapter = { version = "1.5.0", path = "crates/shardline-xet-adapter" }
-shardline-xet-core = { version = "1.5.0", path = "crates/shardline-xet-core" }
-sdx = { version = "1.5.0", path = "crates/sdx" }
+shardline = { version = "1.7.0", path = "crates/shardline" }
+shardline-cache = { version = "1.7.0", path = "crates/shardline-cache" }
+shardline-cas = { version = "1.7.0", path = "crates/shardline-cas" }
+shardline-fsck = { version = "1.7.0", path = "crates/shardline-fsck" }
+shardline-gc = { version = "1.7.0", path = "crates/shardline-gc" }
+shardline-hub-api = { version = "1.7.0", path = "crates/shardline-hub-api" }
+shardline-index = { version = "1.7.0", path = "crates/shardline-index" }
+shardline-metrics = { version = "1.7.0", path = "crates/shardline-metrics" }
+shardline-protocol = { version = "1.7.0", path = "crates/shardline-protocol" }
+shardline-protocol-adapters = { version = "1.7.0", path = "crates/shardline-protocol-adapters" }
+shardline-rebuild = { version = "1.7.0", path = "crates/shardline-rebuild" }
+shardline-provider-events = { version = "1.7.0", path = "crates/shardline-provider-events" }
+shardline-oci-adapter = { version = "1.7.0", path = "crates/shardline-oci-adapter" }
+shardline-s3-adapter = { version = "1.7.0", path = "crates/shardline-s3-adapter" }
+shardline-server = { version = "1.7.0", path = "crates/shardline-server" }
+shardline-server-core = { version = "1.7.0", path = "crates/shardline-server-core" }
+shardline-storage = { version = "1.7.0", path = "crates/shardline-storage" }
+shardline-test-support = { version = "1.7.0", path = "crates/shardline-test-support" }
+shardline-validation = { version = "1.7.0", path = "crates/shardline-validation" }
+shardline-auth = { version = "1.7.0", path = "crates/shardline-auth" }
+shardline-vcs = { version = "1.7.0", path = "crates/shardline-vcs" }
+shardline-xet-adapter = { version = "1.7.0", path = "crates/shardline-xet-adapter" }
+shardline-xet-core = { version = "1.7.0", path = "crates/shardline-xet-core" }
+sdx = { version = "1.7.0", path = "crates/sdx" }
 sqlx = { version = "0.8.6", default-features = false }
 subtle = { version = "2.6", default-features = false }
 tempfile = "3.15"

--- a/crates/sdx/tests/e2e.rs
+++ b/crates/sdx/tests/e2e.rs
@@ -28,6 +28,7 @@ use std::{
     num::{NonZeroU64, NonZeroUsize},
     ops::RangeInclusive,
     path::Path,
+    process::Command,
     time::{Duration, Instant},
 };
 
@@ -44,15 +45,6 @@ const SIGNING_KEY: &[u8] = b"0123456789abcdef0123456789abcdef";
 const BOOTSTRAP_KEY: &str = "bootstrap";
 /// Provider subject authorized for read+write on the test repository.
 const SUBJECT: &str = "github-user-1";
-
-/// Serializes the RSS-measuring test(s) so no two run concurrently and pollute
-/// each other's process-wide `VmRSS` measurement. Only tests that assert on
-/// `/proc/self/status` VmRSS acquire this write lock; the fast tests do not, so
-/// they keep running in parallel. The memory test's robustness against the fast
-/// tests' allocations comes from its delta-based bound (see that test's doc
-/// comment), while this lock prevents multiple RSS-asserting tests from stacking
-/// on top of each other.
-static MEMORY_MEASUREMENT_LOCK: tokio::sync::RwLock<()> = tokio::sync::RwLock::const_new(());
 
 const PROVIDER_CONFIG: &[u8] = br#"{
     "providers": [{
@@ -330,6 +322,7 @@ const ZEROS_ID: char = 'd';
 const RANDOM_ID: char = 'e';
 const UNKNOWN_ID: char = 'f';
 const MEMORY_ID: char = '1';
+const MEMORY_MEASUREMENT_CHILD_ENV: &str = "SHARDLINE_SDX_MEMORY_MEASUREMENT_CHILD";
 
 /// Current resident set size of this process in KiB (Linux `/proc/self/status`).
 fn current_rss_kib() -> u64 {
@@ -659,29 +652,31 @@ async fn download_stream_byte_range_matches_uploaded_bytes() {
 ///
 /// The server runs in-process, and its ingest retains freed-but-unreturned
 /// glibc arena memory after the upload; `malloc_trim(0)` releases it before
-/// the download. Because the harness runs every E2E test concurrently in one
-/// process, `VmRSS` (read from `/proc/self/status`) is process-wide, so the
-/// assertion is on the streaming *delta* over a baseline captured immediately
-/// before the download.
-///
-/// # Why this assertion is robust under full-suite parallelism
-///
-/// The measured streaming delta (~98 MiB) is far below the buffer cap, and a
-/// broken pipeline that buffers the whole file would show ~1 GiB. The one
-/// source of flakiness is other concurrently-running tests in this process
-/// allocating memory during the download window, which can push the process
-/// `VmRSS` peak above the bound even though *this* test adds only ~98 MiB.
-/// We keep the bound comfortably above the measured delta (384 MiB) while still
-/// well below the file size, so modest concurrent noise is absorbed without
-/// weakening the core property: a correct stream never buffers the 1 GiB file
-/// (that would exceed the bound by ~2.6x). The earlier 256 MiB bound was too
-/// tight under load; serializing the whole suite to eliminate concurrent noise
-/// (e.g. a global lock) was evaluated and rejected because it added ~2x to the
-/// e2e suite runtime while this delta-based bound already stays meaningful.
+/// the download. The measurement runs in a child instance of this test binary:
+/// `VmRSS` is process-wide, while the normal E2E harness runs many tests
+/// concurrently in one process. The child executes this exact test alone, so
+/// its RSS delta is attributable to the streaming pipeline rather than
+/// unrelated test allocations.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn stream_large_file_memory_bounded_cat() {
-    // Only one RSS-asserting test runs at a time (see `MEMORY_MEASUREMENT_LOCK`).
-    let _memory_lock = MEMORY_MEASUREMENT_LOCK.write().await;
+    if std::env::var_os(MEMORY_MEASUREMENT_CHILD_ENV).is_none() {
+        let current_exe = std::env::current_exe().unwrap();
+        let status = tokio::task::spawn_blocking(move || {
+            Command::new(current_exe)
+                .arg("--exact")
+                .arg("stream_large_file_memory_bounded_cat")
+                .arg("--nocapture")
+                .env(MEMORY_MEASUREMENT_CHILD_ENV, "1")
+                .env("RUST_TEST_THREADS", "1")
+                .status()
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(status.success(), "isolated RSS measurement child failed");
+        return;
+    }
+
     // 64 KiB chunk target keeps term counts (and thus in-flight tasks) small;
     // the file still spans multiple 64 MiB xorbs.
     let server = TestServer::start_with_chunk_size(NonZeroUsize::new(65_536).unwrap()).await;


### PR DESCRIPTION
## Description

This PR prepares the coordinated Shardline `v1.7.0` reliability release on top of merged PR #40 (`hardening/distributed-correctness`). It updates the package metadata and lockfile for the new release, records the release contents in `CHANGELOG.md`, and provides the reviewed release boundary from which `v1.7.0` will be tagged.

The release is intentionally stabilization-focused: distributed correctness, crash/retry recovery, GC/tombstone safety, typed parsing, fuzz/property coverage, deterministic chaos verification, and large-upload memory bounds are the headline work already present on `main`.

## Changes

- `Cargo.toml`
  - bump `[workspace.package]` from `1.6.0` to `1.7.0`;
  - bump every coordinated `shardline-*` and `sdx` workspace dependency requirement to `1.7.0`.
- `Cargo.lock`
  - refresh all workspace package entries to `1.7.0`.
- `CHANGELOG.md`
  - add the dated `1.7.0` entry in the existing Keep a Changelog format;
  - document distributed-correctness contracts, fencing, tombstone-aware GC, typed parsing, fuzz/proptest coverage, replayable chaos verification, bounded Xorb batching, and release-gate changes.
- Affected crates: all coordinated publishable Shardline crates and `sdx`; `shardline-fuzz` and `shardline-loom-tests` remain unpublished and keep their existing versions.
- Cross-crate/runtime implications: the workspace dependency graph remains coherent at `1.7.0`; there are no new migrations or runtime configuration requirements in this release-preparation PR.

## Motivation

Business or operator motivation:

- Give operators a single, clearly versioned reliability release to deploy and evaluate.
- Make the trust-oriented hardening work discoverable in both package metadata and the public changelog.

Technical motivation:

- Keep all crates that are released together on one semver version.
- Ensure the lockfile, publish manifests, changelog, and eventual tag describe the same release.
- Preserve the release workflow invariant that a tag must point to a commit reachable from `main`.

Alternative approaches considered:

- Tagging the hardening branch directly was rejected because the release workflow explicitly rejects tags that are not ancestors of `main`.
- Bumping only the root package was rejected because it would leave publishable workspace dependencies inconsistent.

## Scope and impact

- Affected crates: coordinated Shardline workspace crates and `sdx`.
- Protocol or API changes: none in this release-preparation change; the underlying hardening work is additive and backward compatible.
- Backward compatibility: existing deployments and data require no migration; published wire formats and APIs remain compatible.
- Performance impact: the underlying merged work bounds server-side Xorb batches for large streamed uploads, reducing peak memory pressure.
- Security impact: the changelog records the merged fencing, authorization, GC reachability, and adversarial verification work; this PR introduces no new security boundary.
- Operational impact: pushing the eventual `v1.7.0` tag invokes the release reliability gate before crates, images, and release assets are published.

## Testing

- [x] Unit tests
- [x] Integration tests
- [x] Manual verification
- [x] Performance checks (where applicable)
- [x] Security checks (where applicable)

Commands/results:

```bash
cargo make ci
# PASS: format, clippy, dependency policy, workspace library tests,
# release-binary verification, and migration synchronization

cargo check --workspace --all-features
# PASS

cargo clippy --locked -p sdx -p shardline-xet-adapter -p shardline-server \
  --all-targets --all-features -- -D warnings
# PASS

git diff --check
# PASS
```

Hosted PR checks (CI, coverage, E2E, and Postgres) are required by repository policy and are running on this PR; the release tag will not be created until this PR is merged to `main`.

## Related issues and documentation

- Fixes: v1.7.0 release preparation
- Related: #40 (merged distributed-correctness hardening)
- Architecture docs: `docs/ARCHITECTURE.md`
- Protocol docs: `docs/PROTOCOL_CONFORMANCE.md`
- Security/invariants docs: `docs/SECURITY_AND_INVARIANTS.md`
- Operations/runbook updates: `docs/RELEASE.md`
- Release history: `CHANGELOG.md`

## Reviewer checklist

- [x] Code follows project standards and crate-boundary constraints
- [x] Tests added or updated and passing locally
- [x] Documentation updated where behavior or configuration changed
- [x] No undocumented breaking change
- [x] Performance trade-offs documented where relevant
- [x] Security considerations addressed where relevant

## Additional notes

The tag will be created only on the merged `main` commit. This is required by the release workflow’s ancestry check and ensures the reliability gate runs before publication. The GitHub release body will follow the established `v1.6.0` format: changelog link, Highlights, Security, Fixed, and Compare sections.
