### PR TITLE
feat(server): add read-only administration API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   GC, integrity, node, task, replication, metrics, and future plugin status.
   The surface uses a dedicated constant-time bearer-token boundary, honest
   authoritative/process/external state semantics, admission control, no-store
-  responses, and is available on every runtime role for external dashboards.
+  responses, bounded cursor pagination and typed collection filtering, and is
+  available on every runtime role for external dashboards. The complete field,
+  pagination, failure, compatibility, and applicable-threat contract is
+  documented for API clients. Wire models live in an explicit v1 DTO module;
+  page limits, filters, cursor tokens, cursor keys, and cursor state are typed
+  instead of being passed through as unstructured primitives.
   The Postgres-kill deployment drill now verifies degraded/recovered status and
-  fail-closed authorization while the durable metadata dependency is unavailable;
-  the strict TOML schema has property and fuzz coverage for the new secret-file setting.
+  fail-closed authorization/query handling plus sanitized errors while the durable
+  metadata dependency is unavailable; cancellation/restart regressions verify
+  polling cannot mutate inventory, and dedicated property and fuzz targets cover
+  both the strict TOML secret-file setting and administration query parser plus
+  versioned cursor DTO/newtype deserialization.
 - Extend storage statistics with authoritative total object count and physical
   object bytes while preserving the existing CAS chunk/file counters.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- Add a disabled-by-default, versioned read-only administration API for storage,
+  GC, integrity, node, task, replication, metrics, and future plugin status.
+  The surface uses a dedicated constant-time bearer-token boundary, honest
+  authoritative/process/external state semantics, admission control, no-store
+  responses, and is available on every runtime role for external dashboards.
+  The Postgres-kill deployment drill now verifies degraded/recovered status and
+  fail-closed authorization while the durable metadata dependency is unavailable;
+  the strict TOML schema has property and fuzz coverage for the new secret-file setting.
+- Extend storage statistics with authoritative total object count and physical
+  object bytes while preserving the existing CAS chunk/file counters.
+
 ## [1.8.0] - 2026-08-25
 
 Stateless multi-replica hardening release. Eliminates the shared filesystem

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ frontends over the same hardened storage core.
 - **Pluggable auth** — local HMAC, Ed25519, OIDC, JWKS, or passthrough provider adapters
 - **Self-hosted or cloud** — local filesystem, S3-compatible storage, Postgres metadata
 - **Operational tooling** — health checks, migrations, integrity verification, garbage
-  collection, backups
+  collection, backups, and a token-gated read-only API for external dashboards
 - **Provider integration** — optional webhooks and token issuance for GitHub, GitLab,
   Gitea, Codeberg
 
@@ -117,6 +117,7 @@ Provider integration is optional.
 | [HuggingFace Hub API](docs/HUGGINGFACE_HUB_API.md) | Hub API compatibility for huggingface-cli |
 | [S3 Frontend](docs/S3_FRONTEND.md) | S3-compatible object API for lakehouse and s3:// clients |
 | [Operations](docs/OPERATIONS.md) | Day-to-day operations runbook |
+| [Read-Only Administration API](docs/ADMIN_READ_API.md) | Stable operational data for dashboards and operators |
 | [CLI Reference](docs/CLI.md) | All commands and flags |
 | [Compatibility Status](docs/COMPATIBILITY_STATUS.md) | Surface maturity tiers and validated route coverage |
 | [Architecture](docs/ARCHITECTURE.md) | System design and runtime shape |

--- a/crates/fuzz/Cargo.toml
+++ b/crates/fuzz/Cargo.toml
@@ -342,5 +342,17 @@ path = "fuzz_targets/shardline/local_publication_faults.rs"
 test = false
 doc = false
 
+[[bin]]
+name = "shardline_admin_api_query"
+path = "fuzz_targets/shardline/admin_api_query.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "shardline_admin_api_v1_cursor"
+path = "fuzz_targets/shardline/admin_api_v1_cursor.rs"
+test = false
+doc = false
+
 [lints]
 workspace = true

--- a/crates/fuzz/Cargo.toml
+++ b/crates/fuzz/Cargo.toml
@@ -265,6 +265,12 @@ test = false
 doc = false
 
 [[bin]]
+name = "shardline_server_config_toml"
+path = "fuzz_targets/shardline/server_config_toml.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "shardline_auth_ed25519"
 path = "fuzz_targets/shardline/auth_ed25519.rs"
 test = false

--- a/crates/fuzz/fuzz_targets/shardline/admin_api_query.rs
+++ b/crates/fuzz/fuzz_targets/shardline/admin_api_query.rs
@@ -1,0 +1,12 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use shardline_server::fuzz_admin_api_query;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(query) = std::str::from_utf8(data) {
+        let first = fuzz_admin_api_query(query);
+        let second = fuzz_admin_api_query(query);
+        assert_eq!(format!("{first:?}"), format!("{second:?}"));
+    }
+});

--- a/crates/fuzz/fuzz_targets/shardline/admin_api_v1_cursor.rs
+++ b/crates/fuzz/fuzz_targets/shardline/admin_api_v1_cursor.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use shardline_server::fuzz_admin_api_cursor;
+
+fuzz_target!(|data: &[u8]| {
+    let first = fuzz_admin_api_cursor(data);
+    let second = fuzz_admin_api_cursor(data);
+    assert_eq!(format!("{first:?}"), format!("{second:?}"));
+});

--- a/crates/fuzz/fuzz_targets/shardline/server_config_toml.rs
+++ b/crates/fuzz/fuzz_targets/shardline/server_config_toml.rs
@@ -1,0 +1,16 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+const MAX_INPUT: usize = 1 << 20;
+
+fuzz_target!(|data: &[u8]| {
+    let data = data.get(..data.len().min(MAX_INPUT)).unwrap_or(data);
+    let Ok(raw) = std::str::from_utf8(data) else {
+        return;
+    };
+
+    let first = shardline_server::parse_toml_config_for_fuzzing(raw);
+    let second = shardline_server::parse_toml_config_for_fuzzing(raw);
+    assert_eq!(first, second);
+});

--- a/crates/shardline-server/src/app.rs
+++ b/crates/shardline-server/src/app.rs
@@ -1,3 +1,4 @@
+mod admin_api;
 mod metadata_routes;
 mod operational;
 mod protocol_routes;
@@ -61,6 +62,11 @@ use crate::{
         XET_PATH_ROUTE, XET_READ_TOKEN_ROUTE, XET_REVISION_ROUTE, XET_REVISIONS_ROUTE,
         XET_TREE_ROUTE, XET_WRITE_TOKEN_ROUTE, XORB_TRANSFER_ROUTE,
     },
+};
+use admin_api::{
+    gc as admin_gc, integrity as admin_integrity, metrics as admin_metrics, nodes as admin_nodes,
+    plugins as admin_plugins, replication as admin_replication, status as admin_status,
+    storage as admin_storage, tasks as admin_tasks,
 };
 use metadata_routes::{
     create_revision, delete_path, delete_revision, list_revisions, register_path, tree_lookup,
@@ -341,6 +347,15 @@ pub async fn router(config: ServerConfig) -> Result<Router, ServerError> {
         .route("/healthz", get(health))
         .route("/readyz", get(ready))
         .route("/metrics", get(metrics))
+        .route("/api/v1/status", get(admin_status))
+        .route("/api/v1/storage", get(admin_storage))
+        .route("/api/v1/gc", get(admin_gc))
+        .route("/api/v1/integrity", get(admin_integrity))
+        .route("/api/v1/nodes", get(admin_nodes))
+        .route("/api/v1/tasks", get(admin_tasks))
+        .route("/api/v1/metrics", get(admin_metrics))
+        .route("/api/v1/plugins", get(admin_plugins))
+        .route("/api/v1/replication", get(admin_replication))
         .layer(MetricsLayer)
         .layer(middleware::from_fn(request_timeout_middleware))
         .layer(middleware::from_fn(security_headers_middleware));

--- a/crates/shardline-server/src/app.rs
+++ b/crates/shardline-server/src/app.rs
@@ -68,6 +68,8 @@ use admin_api::{
     plugins as admin_plugins, replication as admin_replication, status as admin_status,
     storage as admin_storage, tasks as admin_tasks,
 };
+#[cfg(feature = "fuzzing")]
+pub(crate) use admin_api::{parse_admin_cursor_for_fuzzing, parse_admin_query_for_fuzzing};
 use metadata_routes::{
     create_revision, delete_path, delete_revision, list_revisions, register_path, tree_lookup,
 };
@@ -948,6 +950,7 @@ pub(super) async fn security_headers_middleware(
     request: axum::extract::Request,
     next: Next,
 ) -> axum::response::Response {
+    let is_admin_api = request.uri().path().starts_with("/api/v1/");
     let response = next.run(request).await;
     let (mut parts, body) = response.into_parts();
     let headers = &mut parts.headers;
@@ -973,6 +976,16 @@ pub(super) async fn security_headers_middleware(
         headers.insert(
             header::REFERRER_POLICY,
             header::HeaderValue::from_static("strict-origin-when-cross-origin"),
+        );
+    }
+    if is_admin_api {
+        headers.insert(
+            header::CACHE_CONTROL,
+            header::HeaderValue::from_static("no-store"),
+        );
+        headers.insert(
+            header::CONTENT_SECURITY_POLICY,
+            header::HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'"),
         );
     }
     axum::response::Response::from_parts(parts, body)

--- a/crates/shardline-server/src/app/admin_api.rs
+++ b/crates/shardline-server/src/app/admin_api.rs
@@ -1,171 +1,172 @@
 use std::sync::Arc;
 
+mod v1;
+
 use axum::{
     Json,
-    extract::State,
-    http::{HeaderMap, HeaderValue, header::CACHE_CONTROL},
+    extract::{RawQuery, State},
+    http::{
+        HeaderMap, HeaderValue,
+        header::{CACHE_CONTROL, CONTENT_SECURITY_POLICY, X_CONTENT_TYPE_OPTIONS},
+    },
 };
-use serde::Serialize;
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     ServerError, admission::weights, app::AppState, auth::authorize_static_bearer_token,
-    clock::unix_now_seconds_checked, model::ServerStatsResponse,
+    clock::unix_now_seconds_checked,
 };
 
-const ADMIN_API_VERSION: &str = "v1";
+use self::v1::{
+    API_VERSION as ADMIN_API_VERSION, GcResponse as AdminGcResponse,
+    IntegrityResponse as AdminIntegrityResponse, MetricsResponse as AdminMetricsResponse,
+    Node as AdminNode, NodesResponse as AdminNodesResponse, OperationalState, Page as AdminPage,
+    Plugin as AdminPlugin, PluginsResponse as AdminPluginsResponse, Replica as AdminReplica,
+    ReplicationResponse as AdminReplicationResponse, StatusResponse as AdminStatusResponse,
+    StorageProcessCounters as AdminStorageProcessCounters, StorageResponse as AdminStorageResponse,
+    Task as AdminTask, TasksResponse as AdminTasksResponse,
+};
+
 const NO_STORE: HeaderValue = HeaderValue::from_static("no-store");
+const NOSNIFF: HeaderValue = HeaderValue::from_static("nosniff");
+const API_CONTENT_SECURITY_POLICY: HeaderValue =
+    HeaderValue::from_static("default-src 'none'; frame-ancestors 'none'");
+const DEFAULT_PAGE_LIMIT: usize = 100;
+const MAX_PAGE_LIMIT: usize = 1_000;
+const MAX_ADMIN_QUERY_BYTES: usize = 4_096;
+const MAX_ADMIN_FILTER_BYTES: usize = 128;
+const MAX_ADMIN_CURSOR_BYTES: usize = 1_024;
 
 type AdminJson<T> = (HeaderMap, Json<T>);
 
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-enum OperationalState {
-    Ready,
-    Degraded,
-    External,
-    Unsupported,
+impl OperationalState {
+    fn parse(value: &str) -> Result<Self, ServerError> {
+        match value {
+            "ready" => Ok(Self::Ready),
+            "degraded" => Ok(Self::Degraded),
+            "external" => Ok(Self::External),
+            "unsupported" => Ok(Self::Unsupported),
+            _ => Err(ServerError::InvalidAdminQuery),
+        }
+    }
 }
 
-#[derive(Debug, Serialize, PartialEq, Eq)]
-pub(super) struct AdminStatusResponse {
-    api_version: &'static str,
-    shardline_version: &'static str,
-    observed_at_unix_seconds: u64,
-    state: OperationalState,
-    durable_storage_state: OperationalState,
-    cache_state: OperationalState,
-    server_role: String,
-    server_frontends: Vec<String>,
-    metadata_backend: String,
-    object_backend: String,
-    cache_backend: String,
-    plugin_registry: OperationalState,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct AdminPageLimit(usize);
+
+impl AdminPageLimit {
+    fn parse(value: &str) -> Result<Self, ServerError> {
+        let value = value
+            .parse::<usize>()
+            .map_err(|_error| ServerError::InvalidAdminQuery)?;
+        if !(1..=MAX_PAGE_LIMIT).contains(&value) {
+            return Err(ServerError::InvalidAdminQuery);
+        }
+        Ok(Self(value))
+    }
+
+    const fn get(self) -> usize {
+        self.0
+    }
 }
 
-#[derive(Debug, Serialize, PartialEq, Eq)]
-pub(super) struct AdminStorageResponse {
-    api_version: &'static str,
-    observed_at_unix_seconds: u64,
-    authoritative: ServerStatsResponse,
-    process_lifetime: AdminStorageProcessCounters,
-    deduplication_ratio_state: OperationalState,
-    deduplication_ratio: Option<AdminRatio>,
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(transparent)]
+struct AdminPrefix(String);
+
+impl AdminPrefix {
+    fn new(value: String) -> Result<Self, ServerError> {
+        if value.len() > MAX_ADMIN_FILTER_BYTES || value.chars().any(char::is_control) {
+            return Err(ServerError::InvalidAdminQuery);
+        }
+        Ok(Self(value))
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
-#[derive(Debug, Serialize, PartialEq, Eq)]
-struct AdminStorageProcessCounters {
-    objects_written: u64,
-    object_bytes_written: u64,
-    xorbs_written: u64,
-    xorb_bytes_written: u64,
-    shards_written: i64,
-    deduplicated_bytes: u64,
-    compression_saved_bytes: u64,
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(transparent)]
+struct AdminCapability(String);
+
+impl AdminCapability {
+    fn new(value: String) -> Result<Self, ServerError> {
+        if value.is_empty()
+            || value.len() > MAX_ADMIN_FILTER_BYTES
+            || value.chars().any(char::is_control)
+        {
+            return Err(ServerError::InvalidAdminQuery);
+        }
+        Ok(Self(value))
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
-#[derive(Debug, Serialize, PartialEq, Eq)]
-struct AdminRatio {
-    numerator_bytes: u64,
-    denominator_bytes: u64,
-    basis_points: u64,
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AdminCursorToken(String);
+
+impl AdminCursorToken {
+    fn new(value: String) -> Result<Self, ServerError> {
+        if value.is_empty() || value.len() > MAX_ADMIN_CURSOR_BYTES {
+            return Err(ServerError::InvalidAdminQuery);
+        }
+        Ok(Self(value))
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
-#[derive(Debug, Serialize, PartialEq, Eq)]
-pub(super) struct AdminGcResponse {
-    api_version: &'static str,
-    observed_at_unix_seconds: u64,
-    state: OperationalState,
-    execution: OperationalState,
-    runs_observed_by_process: u64,
-    objects_collected_by_process: u64,
-    bytes_collected_by_process: u64,
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(transparent)]
+struct AdminItemKey(String);
+
+impl AdminItemKey {
+    fn new(value: String) -> Result<Self, ServerError> {
+        if value.is_empty()
+            || value.len() > MAX_ADMIN_FILTER_BYTES
+            || value.chars().any(char::is_control)
+        {
+            return Err(ServerError::InvalidAdminQuery);
+        }
+        Ok(Self(value))
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
-#[derive(Debug, Serialize, PartialEq, Eq)]
-pub(super) struct AdminIntegrityResponse {
-    api_version: &'static str,
-    observed_at_unix_seconds: u64,
-    state: OperationalState,
-    execution: OperationalState,
-    fsck_runs_observed_by_process: u64,
-    errors_observed_by_process: u64,
+#[derive(Debug, Default, PartialEq, Eq)]
+struct AdminCollectionQuery {
+    limit: Option<AdminPageLimit>,
+    cursor: Option<AdminCursorToken>,
+    state: Option<OperationalState>,
+    prefix: Option<AdminPrefix>,
+    capability: Option<AdminCapability>,
 }
 
-#[derive(Debug, Serialize, PartialEq, Eq)]
-pub(super) struct AdminNodesResponse {
-    api_version: &'static str,
-    observed_at_unix_seconds: u64,
-    discovery: OperationalState,
-    nodes: Vec<AdminNode>,
+#[derive(Debug, Clone, Copy)]
+struct AllowedFilters {
+    state: bool,
+    prefix: bool,
+    capability: bool,
 }
 
-#[derive(Debug, Serialize, PartialEq, Eq)]
-struct AdminNode {
-    scope: &'static str,
-    state: OperationalState,
-    server_role: String,
-    server_frontends: Vec<String>,
-}
-
-#[derive(Debug, Serialize, PartialEq, Eq)]
-pub(super) struct AdminTasksResponse {
-    api_version: &'static str,
-    observed_at_unix_seconds: u64,
-    scheduler: OperationalState,
-    tasks: Vec<AdminTask>,
-}
-
-#[derive(Debug, Serialize, PartialEq, Eq)]
-struct AdminTask {
-    id: String,
-    state: OperationalState,
-}
-
-#[derive(Debug, Serialize, PartialEq, Eq)]
-pub(super) struct AdminMetricsResponse {
-    api_version: &'static str,
-    observed_at_unix_seconds: u64,
-    prometheus_path: &'static str,
-    active_connections: i64,
-    admitted_requests: u64,
-    queued_requests: u64,
-    rejected_requests: u64,
-    upload_requests: u64,
-    upload_bytes: u64,
-    download_requests: u64,
-    download_bytes: u64,
-    range_requests: u64,
-}
-
-#[derive(Debug, Serialize, PartialEq, Eq)]
-pub(super) struct AdminPluginsResponse {
-    api_version: &'static str,
-    observed_at_unix_seconds: u64,
-    registry: OperationalState,
-    plugins: Vec<AdminPlugin>,
-}
-
-#[derive(Debug, Serialize, PartialEq, Eq)]
-pub(super) struct AdminReplicationResponse {
-    api_version: &'static str,
-    observed_at_unix_seconds: u64,
-    state: OperationalState,
-    coordinator: OperationalState,
-    replicas: Vec<AdminReplica>,
-}
-
-#[derive(Debug, Serialize, PartialEq, Eq)]
-struct AdminReplica {
-    id: String,
-    state: OperationalState,
-}
-
-#[derive(Debug, Serialize, PartialEq, Eq)]
-struct AdminPlugin {
-    id: String,
-    version: String,
-    state: OperationalState,
-    capabilities: Vec<String>,
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct AdminCursor {
+    version: u8,
+    after: AdminItemKey,
+    state: Option<OperationalState>,
+    prefix: Option<AdminPrefix>,
+    capability: Option<AdminCapability>,
 }
 
 fn authorize_admin(state: &AppState, headers: &HeaderMap) -> Result<(), ServerError> {
@@ -183,7 +184,206 @@ fn observed_at() -> Result<u64, ServerError> {
 fn admin_json<T>(value: T) -> AdminJson<T> {
     let mut headers = HeaderMap::new();
     headers.insert(CACHE_CONTROL, NO_STORE);
+    headers.insert(X_CONTENT_TYPE_OPTIONS, NOSNIFF);
+    headers.insert(CONTENT_SECURITY_POLICY, API_CONTENT_SECURITY_POLICY);
     (headers, Json(value))
+}
+
+fn validate_raw_query(raw_query: Option<&str>) -> Result<&str, ServerError> {
+    let raw_query = raw_query.unwrap_or_default();
+    if raw_query.len() > MAX_ADMIN_QUERY_BYTES {
+        return Err(ServerError::RequestQueryTooLarge);
+    }
+    let bytes = raw_query.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut encoded = bytes.iter().copied();
+    while let Some(byte) = encoded.next() {
+        if byte == b'%' {
+            let Some(high_byte) = encoded.next() else {
+                return Err(ServerError::InvalidAdminQuery);
+            };
+            let Some(low_byte) = encoded.next() else {
+                return Err(ServerError::InvalidAdminQuery);
+            };
+            let high = (high_byte as char)
+                .to_digit(16)
+                .ok_or(ServerError::InvalidAdminQuery)?;
+            let low = (low_byte as char)
+                .to_digit(16)
+                .ok_or(ServerError::InvalidAdminQuery)?;
+            decoded.push(
+                u8::try_from((high << 4) | low).map_err(|_error| ServerError::InvalidAdminQuery)?,
+            );
+        } else {
+            decoded.push(byte);
+        }
+    }
+    std::str::from_utf8(&decoded).map_err(|_error| ServerError::InvalidAdminQuery)?;
+    Ok(raw_query)
+}
+
+fn reject_query(raw_query: Option<&str>) -> Result<(), ServerError> {
+    if validate_raw_query(raw_query)?.is_empty() {
+        Ok(())
+    } else {
+        Err(ServerError::InvalidAdminQuery)
+    }
+}
+
+fn parse_collection_query(
+    raw_query: Option<&str>,
+    allowed: AllowedFilters,
+) -> Result<AdminCollectionQuery, ServerError> {
+    let raw_query = validate_raw_query(raw_query)?;
+    let mut query = AdminCollectionQuery::default();
+    let mut seen = std::collections::HashSet::new();
+    for (name, value) in url::form_urlencoded::parse(raw_query.as_bytes()) {
+        if name.is_empty() || !seen.insert(name.to_string()) {
+            return Err(ServerError::InvalidAdminQuery);
+        }
+        if value.chars().any(char::is_control) {
+            return Err(ServerError::InvalidAdminQuery);
+        }
+        match name.as_ref() {
+            "limit" => {
+                query.limit = Some(AdminPageLimit::parse(&value)?);
+            }
+            "cursor" => {
+                query.cursor = Some(AdminCursorToken::new(value.into_owned())?);
+            }
+            "state" if allowed.state => query.state = Some(OperationalState::parse(&value)?),
+            "prefix" if allowed.prefix => {
+                query.prefix = Some(AdminPrefix::new(value.into_owned())?);
+            }
+            "capability" if allowed.capability => {
+                query.capability = Some(AdminCapability::new(value.into_owned())?);
+            }
+            _ => return Err(ServerError::InvalidAdminQuery),
+        }
+    }
+    Ok(query)
+}
+
+#[cfg(feature = "fuzzing")]
+pub(crate) fn parse_admin_query_for_fuzzing(raw_query: &str) -> Result<(), ServerError> {
+    let query = parse_collection_query(
+        Some(raw_query),
+        AllowedFilters {
+            state: true,
+            prefix: true,
+            capability: true,
+        },
+    )?;
+    if let Some(cursor) = query.cursor.as_ref() {
+        decode_cursor(cursor.as_str(), &query)?;
+    }
+    Ok(())
+}
+
+#[cfg(feature = "fuzzing")]
+pub(crate) fn parse_admin_cursor_for_fuzzing(bytes: &[u8]) -> Result<(), ServerError> {
+    if bytes.len() > MAX_ADMIN_CURSOR_BYTES {
+        return Err(ServerError::InvalidAdminQuery);
+    }
+    let encoded = URL_SAFE_NO_PAD.encode(bytes);
+    let query = AdminCollectionQuery::default();
+    decode_cursor(&encoded, &query).map(|_cursor| ())
+}
+
+fn encode_cursor(after: &str, query: &AdminCollectionQuery) -> Result<String, ServerError> {
+    let cursor = AdminCursor {
+        version: 1,
+        after: AdminItemKey::new(after.to_owned())?,
+        state: query.state,
+        prefix: query.prefix.clone(),
+        capability: query.capability.clone(),
+    };
+    let bytes = serde_json::to_vec(&cursor)?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+fn decode_cursor(encoded: &str, query: &AdminCollectionQuery) -> Result<AdminCursor, ServerError> {
+    if encoded.len() > MAX_ADMIN_CURSOR_BYTES {
+        return Err(ServerError::InvalidAdminQuery);
+    }
+    let bytes = URL_SAFE_NO_PAD
+        .decode(encoded)
+        .map_err(|_error| ServerError::InvalidAdminQuery)?;
+    if bytes.len() > MAX_ADMIN_CURSOR_BYTES {
+        return Err(ServerError::InvalidAdminQuery);
+    }
+    let cursor: AdminCursor =
+        serde_json::from_slice(&bytes).map_err(|_error| ServerError::InvalidAdminQuery)?;
+    if cursor.version != 1
+        || AdminItemKey::new(cursor.after.0.clone()).is_err()
+        || cursor.state != query.state
+        || cursor.prefix != query.prefix
+        || cursor.capability != query.capability
+        || cursor
+            .prefix
+            .as_ref()
+            .is_some_and(|value| AdminPrefix::new(value.0.clone()).is_err())
+        || cursor
+            .capability
+            .as_ref()
+            .is_some_and(|value| AdminCapability::new(value.0.clone()).is_err())
+    {
+        return Err(ServerError::InvalidAdminQuery);
+    }
+    Ok(cursor)
+}
+
+fn paginate<T, Key, State, Capability>(
+    mut items: Vec<T>,
+    query: &AdminCollectionQuery,
+    key: Key,
+    state: State,
+    has_capability: Capability,
+) -> Result<(Vec<T>, AdminPage), ServerError>
+where
+    Key: Fn(&T) -> &str,
+    State: Fn(&T) -> OperationalState,
+    Capability: Fn(&T, &str) -> bool,
+{
+    items.retain(|item| {
+        query.state.is_none_or(|expected| state(item) == expected)
+            && query
+                .prefix
+                .as_ref()
+                .is_none_or(|prefix| key(item).starts_with(prefix.as_str()))
+            && query
+                .capability
+                .as_ref()
+                .is_none_or(|capability| has_capability(item, capability.as_str()))
+    });
+    items.sort_by(|left, right| key(left).cmp(key(right)));
+
+    let after = query
+        .cursor
+        .as_ref()
+        .map(|cursor| decode_cursor(cursor.as_str(), query))
+        .transpose()?
+        .map(|cursor| cursor.after);
+    let start = after.as_ref().map_or(0, |after| {
+        items.partition_point(|item| key(item) <= after.as_str())
+    });
+    let limit = query.limit.map_or(DEFAULT_PAGE_LIMIT, AdminPageLimit::get);
+    let has_more = items.len().saturating_sub(start) > limit;
+    let page_items: Vec<T> = items.into_iter().skip(start).take(limit).collect();
+    let next_cursor = if has_more {
+        page_items
+            .last()
+            .map(|item| encode_cursor(key(item), query))
+            .transpose()?
+    } else {
+        None
+    };
+    let page = AdminPage {
+        limit,
+        returned: page_items.len(),
+        next_cursor,
+    };
+    Ok((page_items, page))
 }
 
 fn frontends(state: &AppState) -> Vec<String> {
@@ -198,8 +398,10 @@ fn frontends(state: &AppState) -> Vec<String> {
 pub(super) async fn status(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    RawQuery(raw_query): RawQuery,
 ) -> Result<AdminJson<AdminStatusResponse>, ServerError> {
     authorize_admin(&state, &headers)?;
+    reject_query(raw_query.as_deref())?;
     let ready = state.backend.ready().await.is_ok();
     let cache_ready =
         !state.role.uses_reconstruction_cache() || state.reconstruction_cache.ready().await.is_ok();
@@ -234,8 +436,10 @@ pub(super) async fn status(
 pub(super) async fn storage(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    RawQuery(raw_query): RawQuery,
 ) -> Result<AdminJson<AdminStorageResponse>, ServerError> {
     authorize_admin(&state, &headers)?;
+    reject_query(raw_query.as_deref())?;
     let _permit = state
         .admission
         .try_acquire(weights::STATS)
@@ -266,8 +470,10 @@ pub(super) async fn storage(
 pub(super) async fn gc(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    RawQuery(raw_query): RawQuery,
 ) -> Result<AdminJson<AdminGcResponse>, ServerError> {
     authorize_admin(&state, &headers)?;
+    reject_query(raw_query.as_deref())?;
     let metrics = shardline_metrics::metrics();
     Ok(admin_json(AdminGcResponse {
         api_version: ADMIN_API_VERSION,
@@ -283,8 +489,10 @@ pub(super) async fn gc(
 pub(super) async fn integrity(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    RawQuery(raw_query): RawQuery,
 ) -> Result<AdminJson<AdminIntegrityResponse>, ServerError> {
     authorize_admin(&state, &headers)?;
+    reject_query(raw_query.as_deref())?;
     let metrics = shardline_metrics::metrics();
     Ok(admin_json(AdminIntegrityResponse {
         api_version: ADMIN_API_VERSION,
@@ -299,14 +507,20 @@ pub(super) async fn integrity(
 pub(super) async fn nodes(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    RawQuery(raw_query): RawQuery,
 ) -> Result<AdminJson<AdminNodesResponse>, ServerError> {
     authorize_admin(&state, &headers)?;
+    let query = parse_collection_query(
+        raw_query.as_deref(),
+        AllowedFilters {
+            state: true,
+            prefix: true,
+            capability: false,
+        },
+    )?;
     let ready = state.backend.ready().await.is_ok();
-    Ok(admin_json(AdminNodesResponse {
-        api_version: ADMIN_API_VERSION,
-        observed_at_unix_seconds: observed_at()?,
-        discovery: OperationalState::Unsupported,
-        nodes: vec![AdminNode {
+    let (nodes, page) = paginate(
+        vec![AdminNode {
             scope: "current_process",
             state: if ready {
                 OperationalState::Ready
@@ -316,27 +530,57 @@ pub(super) async fn nodes(
             server_role: state.role.as_str().to_owned(),
             server_frontends: frontends(&state),
         }],
+        &query,
+        |node| node.scope,
+        |node| node.state,
+        |_node, _capability| false,
+    )?;
+    Ok(admin_json(AdminNodesResponse {
+        api_version: ADMIN_API_VERSION,
+        observed_at_unix_seconds: observed_at()?,
+        discovery: OperationalState::Unsupported,
+        nodes,
+        page,
     }))
 }
 
 pub(super) async fn tasks(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    RawQuery(raw_query): RawQuery,
 ) -> Result<AdminJson<AdminTasksResponse>, ServerError> {
     authorize_admin(&state, &headers)?;
+    let query = parse_collection_query(
+        raw_query.as_deref(),
+        AllowedFilters {
+            state: true,
+            prefix: true,
+            capability: false,
+        },
+    )?;
+    let (tasks, page) = paginate(
+        Vec::new(),
+        &query,
+        |task: &AdminTask| task.id.as_str(),
+        |task| task.state,
+        |_task, _capability| false,
+    )?;
     Ok(admin_json(AdminTasksResponse {
         api_version: ADMIN_API_VERSION,
         observed_at_unix_seconds: observed_at()?,
         scheduler: OperationalState::External,
-        tasks: Vec::new(),
+        tasks,
+        page,
     }))
 }
 
 pub(super) async fn metrics(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    RawQuery(raw_query): RawQuery,
 ) -> Result<AdminJson<AdminMetricsResponse>, ServerError> {
     authorize_admin(&state, &headers)?;
+    reject_query(raw_query.as_deref())?;
     let metrics = shardline_metrics::metrics();
     Ok(admin_json(AdminMetricsResponse {
         api_version: ADMIN_API_VERSION,
@@ -357,21 +601,59 @@ pub(super) async fn metrics(
 pub(super) async fn plugins(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    RawQuery(raw_query): RawQuery,
 ) -> Result<AdminJson<AdminPluginsResponse>, ServerError> {
     authorize_admin(&state, &headers)?;
+    let query = parse_collection_query(
+        raw_query.as_deref(),
+        AllowedFilters {
+            state: true,
+            prefix: true,
+            capability: true,
+        },
+    )?;
+    let (plugins, page) = paginate(
+        Vec::new(),
+        &query,
+        |plugin: &AdminPlugin| plugin.id.as_str(),
+        |plugin| plugin.state,
+        |plugin, capability| {
+            plugin
+                .capabilities
+                .iter()
+                .any(|candidate| candidate == capability)
+        },
+    )?;
     Ok(admin_json(AdminPluginsResponse {
         api_version: ADMIN_API_VERSION,
         observed_at_unix_seconds: observed_at()?,
         registry: OperationalState::Unsupported,
-        plugins: Vec::new(),
+        plugins,
+        page,
     }))
 }
 
 pub(super) async fn replication(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    RawQuery(raw_query): RawQuery,
 ) -> Result<AdminJson<AdminReplicationResponse>, ServerError> {
     authorize_admin(&state, &headers)?;
+    let query = parse_collection_query(
+        raw_query.as_deref(),
+        AllowedFilters {
+            state: true,
+            prefix: true,
+            capability: false,
+        },
+    )?;
+    let (replicas, page) = paginate(
+        Vec::new(),
+        &query,
+        |replica: &AdminReplica| replica.id.as_str(),
+        |replica| replica.state,
+        |_replica, _capability| false,
+    )?;
     Ok(admin_json(AdminReplicationResponse {
         api_version: ADMIN_API_VERSION,
         observed_at_unix_seconds: observed_at()?,
@@ -380,7 +662,8 @@ pub(super) async fn replication(
         // reported authoritatively, so keep this surface explicit and empty.
         state: OperationalState::External,
         coordinator: OperationalState::External,
-        replicas: Vec::new(),
+        replicas,
+        page,
     }))
 }
 
@@ -392,6 +675,7 @@ mod tests {
         body::{Body, to_bytes},
         http::{Method, Request, StatusCode, header::AUTHORIZATION},
     };
+    use proptest::prelude::*;
     use serde_json::Value;
     use tempfile::TempDir;
     use tower::ServiceExt;
@@ -411,6 +695,29 @@ mod tests {
         "/api/v1/plugins",
         "/api/v1/replication",
     ];
+
+    proptest! {
+        #[test]
+        fn arbitrary_collection_queries_are_deterministic_and_never_panic(raw in any::<String>()) {
+            let allowed = AllowedFilters {
+                state: true,
+                prefix: true,
+                capability: true,
+            };
+            let first = parse_collection_query(Some(&raw), allowed);
+            let second = parse_collection_query(Some(&raw), allowed);
+            prop_assert_eq!(format!("{first:?}"), format!("{second:?}"));
+        }
+
+        #[test]
+        fn arbitrary_v1_cursor_dtos_are_deterministic_and_never_panic(bytes in proptest::collection::vec(any::<u8>(), 0..=MAX_ADMIN_CURSOR_BYTES)) {
+            let encoded = URL_SAFE_NO_PAD.encode(bytes);
+            let query = AdminCollectionQuery::default();
+            let first = decode_cursor(&encoded, &query);
+            let second = decode_cursor(&encoded, &query);
+            prop_assert_eq!(format!("{first:?}"), format!("{second:?}"));
+        }
+    }
 
     async fn app_with_config(
         admin_token: Option<&str>,
@@ -502,6 +809,33 @@ mod tests {
             );
             let body = json_body(get_response).await;
             assert_eq!(body["api_version"], ADMIN_API_VERSION, "{path}");
+            if [
+                "/api/v1/nodes",
+                "/api/v1/tasks",
+                "/api/v1/plugins",
+                "/api/v1/replication",
+            ]
+            .contains(&path)
+            {
+                assert_eq!(body["page"]["limit"], DEFAULT_PAGE_LIMIT, "{path}");
+                assert!(body["page"]["returned"].is_number(), "{path}");
+                assert!(body["page"]["next_cursor"].is_null(), "{path}");
+            }
+
+            let head_response = app
+                .clone()
+                .oneshot(request(Method::HEAD, path, Some(ADMIN_TOKEN)))
+                .await
+                .expect("HEAD response");
+            assert_eq!(head_response.status(), StatusCode::OK, "{path}");
+            assert_eq!(head_response.headers().get(CACHE_CONTROL), Some(&NO_STORE));
+            assert!(
+                to_bytes(head_response.into_body(), 1)
+                    .await
+                    .expect("HEAD body")
+                    .is_empty(),
+                "{path} HEAD must not return a body"
+            );
 
             for method in [Method::POST, Method::PUT, Method::PATCH, Method::DELETE] {
                 let mutation_response = app
@@ -696,5 +1030,313 @@ mod tests {
                 "unexpected bounded-poll status {status}"
             );
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn polling_and_cancelled_polls_do_not_mutate_durable_inventory() {
+        let temp = TempDir::new().expect("temp dir");
+        let make_config = || {
+            ServerConfig::new(
+                "127.0.0.1:0".parse().expect("bind address"),
+                "http://127.0.0.1:8080".to_owned(),
+                temp.path().to_path_buf(),
+                NonZeroUsize::new(65_536).expect("chunk size"),
+            )
+            .with_server_frontends([ServerFrontend::Xet])
+            .expect("frontends")
+            .with_admin_read_token(ADMIN_TOKEN.as_bytes().to_vec())
+            .expect("admin token")
+        };
+        let app = router(make_config()).await.expect("first router");
+        let before = json_body(
+            app.clone()
+                .oneshot(request(Method::GET, "/api/v1/storage", Some(ADMIN_TOKEN)))
+                .await
+                .expect("initial inventory"),
+        )
+        .await["authoritative"]
+            .clone();
+
+        let mut polls = tokio::task::JoinSet::new();
+        for index in 0..256 {
+            let app = app.clone();
+            let path = ADMIN_PATHS[index % ADMIN_PATHS.len()];
+            polls.spawn(async move {
+                app.oneshot(request(Method::GET, path, Some(ADMIN_TOKEN)))
+                    .await
+            });
+        }
+        for _ in 0..64 {
+            polls.abort_all();
+            tokio::task::yield_now().await;
+        }
+        while polls.join_next().await.is_some() {}
+
+        drop(app);
+        let restarted = router(make_config()).await.expect("restarted router");
+        let after = json_body(
+            restarted
+                .oneshot(request(Method::GET, "/api/v1/storage", Some(ADMIN_TOKEN)))
+                .await
+                .expect("inventory after restart"),
+        )
+        .await["authoritative"]
+            .clone();
+        assert_eq!(
+            after, before,
+            "read-only polling must not mutate durable state"
+        );
+    }
+
+    #[tokio::test]
+    async fn collection_filters_are_bounded_typed_and_not_reflected() {
+        let (app, _temp) = app(Some(ADMIN_TOKEN)).await;
+        let matching = app
+            .clone()
+            .oneshot(request(
+                Method::GET,
+                "/api/v1/nodes?limit=1&state=ready&prefix=current",
+                Some(ADMIN_TOKEN),
+            ))
+            .await
+            .expect("matching response");
+        assert_eq!(matching.status(), StatusCode::OK);
+        let body = json_body(matching).await;
+        assert_eq!(body["nodes"].as_array().map(Vec::len), Some(1));
+        assert_eq!(body["page"]["limit"], 1);
+        assert_eq!(body["page"]["returned"], 1);
+
+        let injection = "%27%20OR%201%3D1%20--%3Cscript%3E";
+        let filtered = app
+            .clone()
+            .oneshot(request(
+                Method::GET,
+                &format!("/api/v1/nodes?prefix={injection}"),
+                Some(ADMIN_TOKEN),
+            ))
+            .await
+            .expect("filtered response");
+        assert_eq!(filtered.status(), StatusCode::OK);
+        let body = json_body(filtered).await;
+        assert_eq!(body["nodes"].as_array().map(Vec::len), Some(0));
+        assert!(!body.to_string().contains("<script>"));
+
+        let unsupported_filter = app
+            .oneshot(request(
+                Method::GET,
+                "/api/v1/nodes?capability=storage.read",
+                Some(ADMIN_TOKEN),
+            ))
+            .await
+            .expect("unsupported-filter response");
+        assert_eq!(unsupported_filter.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn query_validation_happens_after_concealment_and_authentication() {
+        let malformed_path = "/api/v1/nodes?limit=invalid&limit=2";
+        let (disabled, _temp) = app(None).await;
+        let disabled_response = disabled
+            .oneshot(request(Method::GET, malformed_path, Some(ADMIN_TOKEN)))
+            .await
+            .expect("disabled response");
+        assert_eq!(disabled_response.status(), StatusCode::NOT_FOUND);
+
+        let (enabled, _temp) = app(Some(ADMIN_TOKEN)).await;
+        let unauthorized = enabled
+            .clone()
+            .oneshot(request(Method::GET, malformed_path, None))
+            .await
+            .expect("unauthorized response");
+        assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+        let authorized = enabled
+            .oneshot(request(Method::GET, malformed_path, Some(ADMIN_TOKEN)))
+            .await
+            .expect("authorized response");
+        assert_eq!(authorized.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn malformed_oversized_and_polluted_queries_fail_closed() {
+        let (app, _temp) = app(Some(ADMIN_TOKEN)).await;
+        for path in [
+            "/api/v1/nodes?limit=0",
+            "/api/v1/nodes?limit=1001",
+            "/api/v1/nodes?state=unknown",
+            "/api/v1/nodes?unknown=value",
+            "/api/v1/nodes?prefix=%ZZ",
+            "/api/v1/nodes?prefix=%FF",
+            "/api/v1/nodes?prefix=%0d%0aInjected%3Ayes",
+            "/api/v1/nodes?cursor=not-base64",
+            "/api/v1/status?limit=1",
+        ] {
+            let response = app
+                .clone()
+                .oneshot(request(Method::GET, path, Some(ADMIN_TOKEN)))
+                .await
+                .expect("response");
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{path}");
+        }
+
+        let oversized = format!("/api/v1/nodes?prefix={}", "a".repeat(MAX_ADMIN_QUERY_BYTES));
+        let response = app
+            .oneshot(request(Method::GET, &oversized, Some(ADMIN_TOKEN)))
+            .await
+            .expect("oversized response");
+        assert_eq!(response.status(), StatusCode::URI_TOO_LONG);
+    }
+
+    #[tokio::test]
+    async fn security_headers_cover_success_auth_failure_and_disabled_responses() {
+        for (configured, token, expected) in [
+            (Some(ADMIN_TOKEN), Some(ADMIN_TOKEN), StatusCode::OK),
+            (Some(ADMIN_TOKEN), Some("wrong"), StatusCode::UNAUTHORIZED),
+            (None, Some(ADMIN_TOKEN), StatusCode::NOT_FOUND),
+        ] {
+            let (app, _temp) = app(configured).await;
+            let response = app
+                .oneshot(request(Method::GET, "/api/v1/status", token))
+                .await
+                .expect("response");
+            assert_eq!(response.status(), expected);
+            assert_eq!(response.headers().get(CACHE_CONTROL), Some(&NO_STORE));
+            assert_eq!(
+                response.headers().get(X_CONTENT_TYPE_OPTIONS),
+                Some(&NOSNIFF)
+            );
+            assert_eq!(
+                response.headers().get(CONTENT_SECURITY_POLICY),
+                Some(&API_CONTENT_SECURITY_POLICY)
+            );
+            assert!(
+                response
+                    .headers()
+                    .get("access-control-allow-credentials")
+                    .is_none()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn method_confusion_never_reaches_a_mutation_handler() {
+        let (app, _temp) = app(Some(ADMIN_TOKEN)).await;
+        for method in [
+            Method::POST,
+            Method::PUT,
+            Method::PATCH,
+            Method::DELETE,
+            Method::CONNECT,
+            Method::TRACE,
+        ] {
+            let response = app
+                .clone()
+                .oneshot(request(method.clone(), "/api/v1/status", Some(ADMIN_TOKEN)))
+                .await
+                .expect("response");
+            assert_eq!(
+                response.status(),
+                StatusCode::METHOD_NOT_ALLOWED,
+                "{method}"
+            );
+        }
+
+        let preflight = Request::builder()
+            .method(Method::OPTIONS)
+            .uri("/api/v1/status")
+            .header("origin", "https://dashboard.example")
+            .header("access-control-request-method", "GET")
+            .body(Body::empty())
+            .expect("preflight request");
+        let response = app.oneshot(preflight).await.expect("preflight response");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(
+            response
+                .headers()
+                .get("access-control-allow-credentials")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn keyset_cursor_pages_stably_and_is_bound_to_filters() {
+        let query = AdminCollectionQuery {
+            limit: Some(AdminPageLimit(2)),
+            state: Some(OperationalState::External),
+            ..AdminCollectionQuery::default()
+        };
+        let tasks = vec![
+            AdminTask {
+                id: "task-c".to_owned(),
+                state: OperationalState::External,
+            },
+            AdminTask {
+                id: "task-a".to_owned(),
+                state: OperationalState::External,
+            },
+            AdminTask {
+                id: "task-b".to_owned(),
+                state: OperationalState::External,
+            },
+        ];
+        let (first, first_page) = paginate(
+            tasks.clone(),
+            &query,
+            |task| task.id.as_str(),
+            |task| task.state,
+            |_task, _capability| false,
+        )
+        .expect("first page");
+        assert_eq!(
+            first
+                .iter()
+                .map(|task| task.id.as_str())
+                .collect::<Vec<_>>(),
+            ["task-a", "task-b"]
+        );
+        let mut second_query = query;
+        second_query.cursor = first_page
+            .next_cursor
+            .map(AdminCursorToken::new)
+            .transpose()
+            .expect("valid generated cursor");
+        let (second, second_page) = paginate(
+            tasks,
+            &second_query,
+            |task| task.id.as_str(),
+            |task| task.state,
+            |_task, _capability| false,
+        )
+        .expect("second page");
+        assert_eq!(
+            second
+                .iter()
+                .map(|task| task.id.as_str())
+                .collect::<Vec<_>>(),
+            ["task-c"]
+        );
+        assert!(second_page.next_cursor.is_none());
+
+        second_query.prefix = Some(AdminPrefix::new("different".to_owned()).expect("valid prefix"));
+        assert!(matches!(
+            paginate(
+                vec![AdminTask {
+                    id: "task-c".to_owned(),
+                    state: OperationalState::External,
+                }],
+                &second_query,
+                |task| task.id.as_str(),
+                |task| task.state,
+                |_task, _capability| false,
+            ),
+            Err(ServerError::InvalidAdminQuery)
+        ));
+
+        let invalid_newtype_cursor = URL_SAFE_NO_PAD.encode(
+            br#"{"version":1,"after":"task-c","state":null,"prefix":"\u0000","capability":null}"#,
+        );
+        assert!(matches!(
+            decode_cursor(&invalid_newtype_cursor, &AdminCollectionQuery::default()),
+            Err(ServerError::InvalidAdminQuery)
+        ));
     }
 }

--- a/crates/shardline-server/src/app/admin_api.rs
+++ b/crates/shardline-server/src/app/admin_api.rs
@@ -1,0 +1,700 @@
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    extract::State,
+    http::{HeaderMap, HeaderValue, header::CACHE_CONTROL},
+};
+use serde::Serialize;
+
+use crate::{
+    ServerError, admission::weights, app::AppState, auth::authorize_static_bearer_token,
+    clock::unix_now_seconds_checked, model::ServerStatsResponse,
+};
+
+const ADMIN_API_VERSION: &str = "v1";
+const NO_STORE: HeaderValue = HeaderValue::from_static("no-store");
+
+type AdminJson<T> = (HeaderMap, Json<T>);
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum OperationalState {
+    Ready,
+    Degraded,
+    External,
+    Unsupported,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(super) struct AdminStatusResponse {
+    api_version: &'static str,
+    shardline_version: &'static str,
+    observed_at_unix_seconds: u64,
+    state: OperationalState,
+    durable_storage_state: OperationalState,
+    cache_state: OperationalState,
+    server_role: String,
+    server_frontends: Vec<String>,
+    metadata_backend: String,
+    object_backend: String,
+    cache_backend: String,
+    plugin_registry: OperationalState,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(super) struct AdminStorageResponse {
+    api_version: &'static str,
+    observed_at_unix_seconds: u64,
+    authoritative: ServerStatsResponse,
+    process_lifetime: AdminStorageProcessCounters,
+    deduplication_ratio_state: OperationalState,
+    deduplication_ratio: Option<AdminRatio>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct AdminStorageProcessCounters {
+    objects_written: u64,
+    object_bytes_written: u64,
+    xorbs_written: u64,
+    xorb_bytes_written: u64,
+    shards_written: i64,
+    deduplicated_bytes: u64,
+    compression_saved_bytes: u64,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct AdminRatio {
+    numerator_bytes: u64,
+    denominator_bytes: u64,
+    basis_points: u64,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(super) struct AdminGcResponse {
+    api_version: &'static str,
+    observed_at_unix_seconds: u64,
+    state: OperationalState,
+    execution: OperationalState,
+    runs_observed_by_process: u64,
+    objects_collected_by_process: u64,
+    bytes_collected_by_process: u64,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(super) struct AdminIntegrityResponse {
+    api_version: &'static str,
+    observed_at_unix_seconds: u64,
+    state: OperationalState,
+    execution: OperationalState,
+    fsck_runs_observed_by_process: u64,
+    errors_observed_by_process: u64,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(super) struct AdminNodesResponse {
+    api_version: &'static str,
+    observed_at_unix_seconds: u64,
+    discovery: OperationalState,
+    nodes: Vec<AdminNode>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct AdminNode {
+    scope: &'static str,
+    state: OperationalState,
+    server_role: String,
+    server_frontends: Vec<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(super) struct AdminTasksResponse {
+    api_version: &'static str,
+    observed_at_unix_seconds: u64,
+    scheduler: OperationalState,
+    tasks: Vec<AdminTask>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct AdminTask {
+    id: String,
+    state: OperationalState,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(super) struct AdminMetricsResponse {
+    api_version: &'static str,
+    observed_at_unix_seconds: u64,
+    prometheus_path: &'static str,
+    active_connections: i64,
+    admitted_requests: u64,
+    queued_requests: u64,
+    rejected_requests: u64,
+    upload_requests: u64,
+    upload_bytes: u64,
+    download_requests: u64,
+    download_bytes: u64,
+    range_requests: u64,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(super) struct AdminPluginsResponse {
+    api_version: &'static str,
+    observed_at_unix_seconds: u64,
+    registry: OperationalState,
+    plugins: Vec<AdminPlugin>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(super) struct AdminReplicationResponse {
+    api_version: &'static str,
+    observed_at_unix_seconds: u64,
+    state: OperationalState,
+    coordinator: OperationalState,
+    replicas: Vec<AdminReplica>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct AdminReplica {
+    id: String,
+    state: OperationalState,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct AdminPlugin {
+    id: String,
+    version: String,
+    state: OperationalState,
+    capabilities: Vec<String>,
+}
+
+fn authorize_admin(state: &AppState, headers: &HeaderMap) -> Result<(), ServerError> {
+    let token = state
+        .config
+        .admin_read_token()
+        .ok_or(ServerError::NotFound)?;
+    authorize_static_bearer_token(headers, token)
+}
+
+fn observed_at() -> Result<u64, ServerError> {
+    unix_now_seconds_checked()
+}
+
+fn admin_json<T>(value: T) -> AdminJson<T> {
+    let mut headers = HeaderMap::new();
+    headers.insert(CACHE_CONTROL, NO_STORE);
+    (headers, Json(value))
+}
+
+fn frontends(state: &AppState) -> Vec<String> {
+    state
+        .config
+        .server_frontends()
+        .iter()
+        .map(|frontend| frontend.as_str().to_owned())
+        .collect()
+}
+
+pub(super) async fn status(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<AdminJson<AdminStatusResponse>, ServerError> {
+    authorize_admin(&state, &headers)?;
+    let ready = state.backend.ready().await.is_ok();
+    let cache_ready =
+        !state.role.uses_reconstruction_cache() || state.reconstruction_cache.ready().await.is_ok();
+    Ok(admin_json(AdminStatusResponse {
+        api_version: ADMIN_API_VERSION,
+        shardline_version: env!("CARGO_PKG_VERSION"),
+        observed_at_unix_seconds: observed_at()?,
+        state: if ready {
+            OperationalState::Ready
+        } else {
+            OperationalState::Degraded
+        },
+        durable_storage_state: if ready {
+            OperationalState::Ready
+        } else {
+            OperationalState::Degraded
+        },
+        cache_state: if cache_ready {
+            OperationalState::Ready
+        } else {
+            OperationalState::Degraded
+        },
+        server_role: state.role.as_str().to_owned(),
+        server_frontends: frontends(&state),
+        metadata_backend: state.backend.backend_name().to_owned(),
+        object_backend: state.backend.object_backend_name().to_owned(),
+        cache_backend: state.reconstruction_cache.backend_name().to_owned(),
+        plugin_registry: OperationalState::Unsupported,
+    }))
+}
+
+pub(super) async fn storage(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<AdminJson<AdminStorageResponse>, ServerError> {
+    authorize_admin(&state, &headers)?;
+    let _permit = state
+        .admission
+        .try_acquire(weights::STATS)
+        .ok_or(ServerError::WorkQueueSaturated)?;
+    let authoritative = state.backend.stats().await?;
+    let metrics = shardline_metrics::metrics();
+    Ok(admin_json(AdminStorageResponse {
+        api_version: ADMIN_API_VERSION,
+        observed_at_unix_seconds: observed_at()?,
+        authoritative,
+        process_lifetime: AdminStorageProcessCounters {
+            objects_written: metrics.storage.objects_total.get().try_into()?,
+            object_bytes_written: metrics.storage.objects_bytes_total.get(),
+            xorbs_written: metrics.storage.xorbs_total.get().try_into()?,
+            xorb_bytes_written: metrics.storage.xorbs_bytes_total.get(),
+            shards_written: metrics.storage.shards_total.get(),
+            deduplicated_bytes: metrics.storage.dedup_saves_bytes_total.get(),
+            compression_saved_bytes: metrics.storage.compression_saved_bytes_total.get(),
+        },
+        deduplication_ratio_state: OperationalState::Unsupported,
+        // Exact logical bytes are not currently retained as an authoritative
+        // aggregate. Returning null is safer than deriving a misleading ratio
+        // from process-lifetime counters after restarts or across replicas.
+        deduplication_ratio: None,
+    }))
+}
+
+pub(super) async fn gc(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<AdminJson<AdminGcResponse>, ServerError> {
+    authorize_admin(&state, &headers)?;
+    let metrics = shardline_metrics::metrics();
+    Ok(admin_json(AdminGcResponse {
+        api_version: ADMIN_API_VERSION,
+        observed_at_unix_seconds: observed_at()?,
+        state: OperationalState::External,
+        execution: OperationalState::External,
+        runs_observed_by_process: metrics.gc.runs.get(),
+        objects_collected_by_process: metrics.gc.objects_collected.get(),
+        bytes_collected_by_process: metrics.gc.bytes_collected.get(),
+    }))
+}
+
+pub(super) async fn integrity(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<AdminJson<AdminIntegrityResponse>, ServerError> {
+    authorize_admin(&state, &headers)?;
+    let metrics = shardline_metrics::metrics();
+    Ok(admin_json(AdminIntegrityResponse {
+        api_version: ADMIN_API_VERSION,
+        observed_at_unix_seconds: observed_at()?,
+        state: OperationalState::External,
+        execution: OperationalState::External,
+        fsck_runs_observed_by_process: metrics.fsck.runs.get(),
+        errors_observed_by_process: metrics.fsck.errors_found.get(),
+    }))
+}
+
+pub(super) async fn nodes(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<AdminJson<AdminNodesResponse>, ServerError> {
+    authorize_admin(&state, &headers)?;
+    let ready = state.backend.ready().await.is_ok();
+    Ok(admin_json(AdminNodesResponse {
+        api_version: ADMIN_API_VERSION,
+        observed_at_unix_seconds: observed_at()?,
+        discovery: OperationalState::Unsupported,
+        nodes: vec![AdminNode {
+            scope: "current_process",
+            state: if ready {
+                OperationalState::Ready
+            } else {
+                OperationalState::Degraded
+            },
+            server_role: state.role.as_str().to_owned(),
+            server_frontends: frontends(&state),
+        }],
+    }))
+}
+
+pub(super) async fn tasks(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<AdminJson<AdminTasksResponse>, ServerError> {
+    authorize_admin(&state, &headers)?;
+    Ok(admin_json(AdminTasksResponse {
+        api_version: ADMIN_API_VERSION,
+        observed_at_unix_seconds: observed_at()?,
+        scheduler: OperationalState::External,
+        tasks: Vec::new(),
+    }))
+}
+
+pub(super) async fn metrics(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<AdminJson<AdminMetricsResponse>, ServerError> {
+    authorize_admin(&state, &headers)?;
+    let metrics = shardline_metrics::metrics();
+    Ok(admin_json(AdminMetricsResponse {
+        api_version: ADMIN_API_VERSION,
+        observed_at_unix_seconds: observed_at()?,
+        prometheus_path: "/metrics",
+        active_connections: metrics.system.active_connections.get(),
+        admitted_requests: metrics.system.admitted_total.get(),
+        queued_requests: metrics.system.queued_total.get(),
+        rejected_requests: metrics.system.rejected_total.get(),
+        upload_requests: metrics.transfer.upload_requests.get(),
+        upload_bytes: metrics.transfer.upload_bytes.get(),
+        download_requests: metrics.transfer.download_requests.get(),
+        download_bytes: metrics.transfer.download_bytes.get(),
+        range_requests: metrics.transfer.range_requests.get(),
+    }))
+}
+
+pub(super) async fn plugins(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<AdminJson<AdminPluginsResponse>, ServerError> {
+    authorize_admin(&state, &headers)?;
+    Ok(admin_json(AdminPluginsResponse {
+        api_version: ADMIN_API_VERSION,
+        observed_at_unix_seconds: observed_at()?,
+        registry: OperationalState::Unsupported,
+        plugins: Vec::new(),
+    }))
+}
+
+pub(super) async fn replication(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<AdminJson<AdminReplicationResponse>, ServerError> {
+    authorize_admin(&state, &headers)?;
+    Ok(admin_json(AdminReplicationResponse {
+        api_version: ADMIN_API_VERSION,
+        observed_at_unix_seconds: observed_at()?,
+        // Shardline coordinates writers over shared durable state. It does not
+        // own an asynchronous replication controller whose lag could be
+        // reported authoritatively, so keep this surface explicit and empty.
+        state: OperationalState::External,
+        coordinator: OperationalState::External,
+        replicas: Vec::new(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use axum::{
+        body::{Body, to_bytes},
+        http::{Method, Request, StatusCode, header::AUTHORIZATION},
+    };
+    use serde_json::Value;
+    use tempfile::TempDir;
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::{DeploymentMode, ServerConfig, ServerFrontend, ServerRole, app::router};
+
+    const ADMIN_TOKEN: &str = "admin-read-secret";
+    const ADMIN_PATHS: [&str; 9] = [
+        "/api/v1/status",
+        "/api/v1/storage",
+        "/api/v1/gc",
+        "/api/v1/integrity",
+        "/api/v1/nodes",
+        "/api/v1/tasks",
+        "/api/v1/metrics",
+        "/api/v1/plugins",
+        "/api/v1/replication",
+    ];
+
+    async fn app_with_config(
+        admin_token: Option<&str>,
+        metrics_token: Option<&str>,
+        role: ServerRole,
+    ) -> (axum::Router, TempDir) {
+        let temp = TempDir::new().expect("temp dir");
+        let mut config = ServerConfig::new(
+            "127.0.0.1:0".parse().expect("bind address"),
+            "http://127.0.0.1:8080".to_owned(),
+            temp.path().to_path_buf(),
+            NonZeroUsize::new(65_536).expect("chunk size"),
+        )
+        .with_server_frontends([ServerFrontend::Xet])
+        .expect("frontends")
+        .with_server_role(role);
+        if let Some(token) = metrics_token {
+            config = config
+                .with_metrics_token(token.as_bytes().to_vec())
+                .expect("metrics token");
+        }
+        if let Some(token) = admin_token {
+            config = config
+                .with_admin_read_token(token.as_bytes().to_vec())
+                .expect("admin token");
+        }
+        (router(config).await.expect("router"), temp)
+    }
+
+    async fn app(admin_token: Option<&str>) -> (axum::Router, TempDir) {
+        app_with_config(admin_token, None, ServerRole::All).await
+    }
+
+    fn request(method: Method, path: &str, token: Option<&str>) -> Request<Body> {
+        let mut builder = Request::builder().method(method).uri(path);
+        if let Some(token) = token {
+            builder = builder.header(AUTHORIZATION, format!("Bearer {token}"));
+        }
+        builder.body(Body::empty()).expect("request")
+    }
+
+    async fn json_body(response: axum::response::Response) -> Value {
+        let bytes = to_bytes(response.into_body(), 1_048_576)
+            .await
+            .expect("response body");
+        serde_json::from_slice(&bytes).expect("JSON response")
+    }
+
+    #[tokio::test]
+    async fn disabled_admin_api_hides_every_endpoint() {
+        let (app, _temp) = app(None).await;
+        for path in ADMIN_PATHS {
+            let response = app
+                .clone()
+                .oneshot(request(Method::GET, path, Some(ADMIN_TOKEN)))
+                .await
+                .expect("response");
+            assert_eq!(response.status(), StatusCode::NOT_FOUND, "{path}");
+        }
+    }
+
+    #[tokio::test]
+    async fn admin_api_rejects_missing_and_wrong_credentials() {
+        let (app, _temp) = app(Some(ADMIN_TOKEN)).await;
+        for token in [None, Some("wrong-token")] {
+            let response = app
+                .clone()
+                .oneshot(request(Method::GET, ADMIN_PATHS[0], token))
+                .await
+                .expect("response");
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        }
+    }
+
+    #[tokio::test]
+    async fn every_admin_endpoint_is_read_only_and_returns_versioned_json() {
+        let (app, _temp) = app(Some(ADMIN_TOKEN)).await;
+        for path in ADMIN_PATHS {
+            let get_response = app
+                .clone()
+                .oneshot(request(Method::GET, path, Some(ADMIN_TOKEN)))
+                .await
+                .expect("GET response");
+            assert_eq!(get_response.status(), StatusCode::OK, "{path}");
+            assert_eq!(
+                get_response.headers().get(CACHE_CONTROL),
+                Some(&NO_STORE),
+                "{path} must not be cached"
+            );
+            let body = json_body(get_response).await;
+            assert_eq!(body["api_version"], ADMIN_API_VERSION, "{path}");
+
+            for method in [Method::POST, Method::PUT, Method::PATCH, Method::DELETE] {
+                let mutation_response = app
+                    .clone()
+                    .oneshot(request(method.clone(), path, Some(ADMIN_TOKEN)))
+                    .await
+                    .expect("mutation response");
+                assert_eq!(
+                    mutation_response.status(),
+                    StatusCode::METHOD_NOT_ALLOWED,
+                    "{path} must not expose {method}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn admin_api_rejects_ambiguous_authorization_headers() {
+        let (app, _temp) = app(Some(ADMIN_TOKEN)).await;
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri("/api/v1/status")
+            .header(AUTHORIZATION, format!("Bearer {ADMIN_TOKEN}"))
+            .header(AUTHORIZATION, format!("Bearer {ADMIN_TOKEN}"))
+            .body(Body::empty())
+            .expect("request");
+        let response = app.oneshot(request).await.expect("response");
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn admin_and_metrics_tokens_are_not_interchangeable() {
+        let metrics_token = "metrics-only-secret";
+        let (app, _temp) =
+            app_with_config(Some(ADMIN_TOKEN), Some(metrics_token), ServerRole::All).await;
+
+        let admin_with_metrics_token = app
+            .clone()
+            .oneshot(request(Method::GET, "/api/v1/status", Some(metrics_token)))
+            .await
+            .expect("admin response");
+        assert_eq!(admin_with_metrics_token.status(), StatusCode::UNAUTHORIZED);
+
+        let metrics_with_admin_token = app
+            .oneshot(request(Method::GET, "/metrics", Some(ADMIN_TOKEN)))
+            .await
+            .expect("metrics response");
+        assert_eq!(metrics_with_admin_token.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn admin_api_is_available_on_each_runtime_role() {
+        for role in [ServerRole::All, ServerRole::Api, ServerRole::Transfer] {
+            let (app, _temp) = app_with_config(Some(ADMIN_TOKEN), None, role).await;
+            let response = app
+                .oneshot(request(Method::GET, "/api/v1/status", Some(ADMIN_TOKEN)))
+                .await
+                .expect("response");
+            assert_eq!(response.status(), StatusCode::OK, "role={role:?}");
+            let body = json_body(response).await;
+            assert_eq!(body["server_role"], role.as_str());
+        }
+    }
+
+    #[tokio::test]
+    async fn readiness_failure_is_reported_as_degraded_without_internal_details() {
+        let (app, temp) = app(Some(ADMIN_TOKEN)).await;
+        tokio::fs::remove_file(temp.path().join("metadata.sqlite3"))
+            .await
+            .expect("remove metadata database");
+        tokio::fs::create_dir(temp.path().join("metadata.sqlite3"))
+            .await
+            .expect("replace metadata database with directory");
+
+        let response = app
+            .oneshot(request(Method::GET, "/api/v1/status", Some(ADMIN_TOKEN)))
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = json_body(response).await;
+        assert_eq!(body["state"], "degraded");
+        assert_eq!(body["durable_storage_state"], "degraded");
+        let encoded = body.to_string();
+        assert!(!encoded.contains("sqlite"));
+        assert!(!encoded.contains("metadata.sqlite3"));
+    }
+
+    #[tokio::test]
+    async fn admin_status_reports_current_runtime_without_secret_material() {
+        let (app, _temp) = app(Some(ADMIN_TOKEN)).await;
+        let response = app
+            .oneshot(request(Method::GET, "/api/v1/status", Some(ADMIN_TOKEN)))
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = json_body(response).await;
+        assert_eq!(body["state"], "ready");
+        assert_eq!(body["durable_storage_state"], "ready");
+        assert_eq!(body["cache_state"], "ready");
+        assert_eq!(body["server_role"], "all");
+        assert_eq!(body["server_frontends"], serde_json::json!(["xet"]));
+        assert_eq!(body["plugin_registry"], "unsupported");
+        assert!(!body.to_string().contains(ADMIN_TOKEN));
+    }
+
+    #[tokio::test]
+    async fn storage_reports_authoritative_physical_usage_and_honest_ratio_availability() {
+        let (app, _temp) = app(Some(ADMIN_TOKEN)).await;
+        let response = app
+            .oneshot(request(Method::GET, "/api/v1/storage", Some(ADMIN_TOKEN)))
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = json_body(response).await;
+        assert_eq!(body["authoritative"]["objects"], 0);
+        assert_eq!(body["authoritative"]["object_bytes"], 0);
+        assert_eq!(body["authoritative"]["chunks"], 0);
+        assert_eq!(body["authoritative"]["files"], 0);
+        assert_eq!(body["deduplication_ratio_state"], "unsupported");
+        assert!(body["deduplication_ratio"].is_null());
+    }
+
+    #[tokio::test]
+    async fn externally_owned_operations_never_claim_in_process_progress() {
+        let (app, _temp) = app(Some(ADMIN_TOKEN)).await;
+        for path in ["/api/v1/gc", "/api/v1/integrity"] {
+            let response = app
+                .clone()
+                .oneshot(request(Method::GET, path, Some(ADMIN_TOKEN)))
+                .await
+                .expect("response");
+            let body = json_body(response).await;
+            assert_eq!(body["state"], "external", "{path}");
+            assert_eq!(body["execution"], "external", "{path}");
+        }
+        for path in ["/api/v1/tasks", "/api/v1/replication"] {
+            let response = app
+                .clone()
+                .oneshot(request(Method::GET, path, Some(ADMIN_TOKEN)))
+                .await
+                .expect("response");
+            let body = json_body(response).await;
+            assert_eq!(
+                body.get("scheduler").or_else(|| body.get("coordinator")),
+                Some(&Value::String("external".to_owned())),
+                "{path}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn admin_routes_coexist_with_hub_catch_all_routes() {
+        let temp = TempDir::new().expect("temp dir");
+        let config = ServerConfig::new(
+            "127.0.0.1:0".parse().expect("bind address"),
+            "http://127.0.0.1:8080".to_owned(),
+            temp.path().to_path_buf(),
+            NonZeroUsize::new(65_536).expect("chunk size"),
+        )
+        .with_server_frontends([ServerFrontend::Hub])
+        .expect("frontends")
+        .with_deployment_mode(DeploymentMode::Insecure)
+        .with_admin_read_token(ADMIN_TOKEN.as_bytes().to_vec())
+        .expect("admin token");
+        let app = router(config).await.expect("router");
+
+        let response = app
+            .oneshot(request(Method::GET, "/api/v1/status", Some(ADMIN_TOKEN)))
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(json_body(response).await["api_version"], "v1");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_admin_polling_remains_bounded_and_successful() {
+        let (app, _temp) = app(Some(ADMIN_TOKEN)).await;
+        let mut requests = tokio::task::JoinSet::new();
+        for index in 0..128 {
+            let app = app.clone();
+            let path = ADMIN_PATHS[index % ADMIN_PATHS.len()];
+            requests.spawn(async move {
+                app.oneshot(request(Method::GET, path, Some(ADMIN_TOKEN)))
+                    .await
+                    .map(|response| response.status())
+            });
+        }
+        while let Some(response) = requests.join_next().await {
+            let status = response.expect("poll task").expect("poll response");
+            assert!(
+                status == StatusCode::OK || status == StatusCode::SERVICE_UNAVAILABLE,
+                "unexpected bounded-poll status {status}"
+            );
+        }
+    }
+}

--- a/crates/shardline-server/src/app/admin_api/v1.rs
+++ b/crates/shardline-server/src/app/admin_api/v1.rs
@@ -1,0 +1,169 @@
+//! Version 1 wire DTOs for the read-only administration API.
+
+use serde::{Deserialize, Serialize};
+
+use crate::model::ServerStatsResponse;
+
+pub(crate) const API_VERSION: &str = "v1";
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum OperationalState {
+    Ready,
+    Degraded,
+    External,
+    Unsupported,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) struct Page {
+    pub(super) limit: usize,
+    pub(super) returned: usize,
+    pub(super) next_cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) struct StatusResponse {
+    pub(super) api_version: &'static str,
+    pub(super) shardline_version: &'static str,
+    pub(super) observed_at_unix_seconds: u64,
+    pub(super) state: OperationalState,
+    pub(super) durable_storage_state: OperationalState,
+    pub(super) cache_state: OperationalState,
+    pub(super) server_role: String,
+    pub(super) server_frontends: Vec<String>,
+    pub(super) metadata_backend: String,
+    pub(super) object_backend: String,
+    pub(super) cache_backend: String,
+    pub(super) plugin_registry: OperationalState,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) struct StorageResponse {
+    pub(super) api_version: &'static str,
+    pub(super) observed_at_unix_seconds: u64,
+    pub(super) authoritative: ServerStatsResponse,
+    pub(super) process_lifetime: StorageProcessCounters,
+    pub(super) deduplication_ratio_state: OperationalState,
+    pub(super) deduplication_ratio: Option<Ratio>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) struct StorageProcessCounters {
+    pub(super) objects_written: u64,
+    pub(super) object_bytes_written: u64,
+    pub(super) xorbs_written: u64,
+    pub(super) xorb_bytes_written: u64,
+    pub(super) shards_written: i64,
+    pub(super) deduplicated_bytes: u64,
+    pub(super) compression_saved_bytes: u64,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) struct Ratio {
+    pub(super) numerator_bytes: u64,
+    pub(super) denominator_bytes: u64,
+    pub(super) basis_points: u64,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) struct GcResponse {
+    pub(super) api_version: &'static str,
+    pub(super) observed_at_unix_seconds: u64,
+    pub(super) state: OperationalState,
+    pub(super) execution: OperationalState,
+    pub(super) runs_observed_by_process: u64,
+    pub(super) objects_collected_by_process: u64,
+    pub(super) bytes_collected_by_process: u64,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) struct IntegrityResponse {
+    pub(super) api_version: &'static str,
+    pub(super) observed_at_unix_seconds: u64,
+    pub(super) state: OperationalState,
+    pub(super) execution: OperationalState,
+    pub(super) fsck_runs_observed_by_process: u64,
+    pub(super) errors_observed_by_process: u64,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) struct NodesResponse {
+    pub(super) api_version: &'static str,
+    pub(super) observed_at_unix_seconds: u64,
+    pub(super) discovery: OperationalState,
+    pub(super) nodes: Vec<Node>,
+    pub(super) page: Page,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct Node {
+    pub(super) scope: &'static str,
+    pub(super) state: OperationalState,
+    pub(super) server_role: String,
+    pub(super) server_frontends: Vec<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) struct TasksResponse {
+    pub(super) api_version: &'static str,
+    pub(super) observed_at_unix_seconds: u64,
+    pub(super) scheduler: OperationalState,
+    pub(super) tasks: Vec<Task>,
+    pub(super) page: Page,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct Task {
+    pub(super) id: String,
+    pub(super) state: OperationalState,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) struct MetricsResponse {
+    pub(super) api_version: &'static str,
+    pub(super) observed_at_unix_seconds: u64,
+    pub(super) prometheus_path: &'static str,
+    pub(super) active_connections: i64,
+    pub(super) admitted_requests: u64,
+    pub(super) queued_requests: u64,
+    pub(super) rejected_requests: u64,
+    pub(super) upload_requests: u64,
+    pub(super) upload_bytes: u64,
+    pub(super) download_requests: u64,
+    pub(super) download_bytes: u64,
+    pub(super) range_requests: u64,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) struct PluginsResponse {
+    pub(super) api_version: &'static str,
+    pub(super) observed_at_unix_seconds: u64,
+    pub(super) registry: OperationalState,
+    pub(super) plugins: Vec<Plugin>,
+    pub(super) page: Page,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct Plugin {
+    pub(super) id: String,
+    pub(super) version: String,
+    pub(super) state: OperationalState,
+    pub(super) capabilities: Vec<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub(crate) struct ReplicationResponse {
+    pub(super) api_version: &'static str,
+    pub(super) observed_at_unix_seconds: u64,
+    pub(super) state: OperationalState,
+    pub(super) coordinator: OperationalState,
+    pub(super) replicas: Vec<Replica>,
+    pub(super) page: Page,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct Replica {
+    pub(super) id: String,
+    pub(super) state: OperationalState,
+}

--- a/crates/shardline-server/src/auth.rs
+++ b/crates/shardline-server/src/auth.rs
@@ -121,6 +121,9 @@ pub(crate) fn authorize_static_bearer_token(
     headers: &HeaderMap,
     expected_token: &[u8],
 ) -> Result<(), ServerError> {
+    if headers.get_all(AUTHORIZATION).iter().count() > 1 {
+        return Err(ServerError::InvalidAuthorizationHeader);
+    }
     let header = headers
         .get(AUTHORIZATION)
         .ok_or(ServerError::MissingAuthorization)?;

--- a/crates/shardline-server/src/backend.rs
+++ b/crates/shardline-server/src/backend.rs
@@ -1805,6 +1805,7 @@ fn server_error_to_oci(error: ServerError) -> shardline_oci_adapter::OciAdapterE
         ref other @ (ServerError::RequestBodyRead(_)
         | ServerError::RequestBodyTooLarge
         | ServerError::RequestQueryTooLarge
+        | ServerError::InvalidAdminQuery
         | ServerError::RequestBodyFrameOutOfBounds
         | ServerError::HashParse(_)
         | ServerError::ObjectStore(

--- a/crates/shardline-server/src/config/env.rs
+++ b/crates/shardline-server/src/config/env.rs
@@ -21,9 +21,9 @@ use super::{
     DEFAULT_S3_MIN_PART_BYTES, DEFAULT_S3_UPLOAD_MAX_ACTIVE_PART_FILES,
     DEFAULT_S3_UPLOAD_MAX_ACTIVE_SESSIONS, DEFAULT_S3_UPLOAD_SESSION_MAX_BYTES,
     DEFAULT_S3_UPLOAD_SESSION_TTL_SECONDS, DEFAULT_S3_UPLOAD_TOTAL_MAX_BYTES, DeploymentMode,
-    HUB_WEBHOOK_SECRET_KEY_BYTES, MAX_ED25519_KEY_BYTES, MAX_METRICS_TOKEN_BYTES,
-    MAX_TOKEN_SIGNING_KEY_BYTES, ObjectStorageAdapter, ServerConfig, ServerConfigError,
-    ShardMetadataLimits, default_transfer_max_in_flight_chunks,
+    HUB_WEBHOOK_SECRET_KEY_BYTES, MAX_ADMIN_READ_TOKEN_BYTES, MAX_ED25519_KEY_BYTES,
+    MAX_METRICS_TOKEN_BYTES, MAX_TOKEN_SIGNING_KEY_BYTES, ObjectStorageAdapter, ServerConfig,
+    ServerConfigError, ShardMetadataLimits, default_transfer_max_in_flight_chunks,
     default_upload_max_in_flight_chunks, parse_byte_size,
 };
 use crate::{
@@ -387,6 +387,25 @@ pub(super) fn load_server_config_from_env() -> Result<ServerConfig, ServerConfig
             observed_bytes: observed,
         },
     )?;
+    let admin_read_token = load_secret_from_env_or_file_with_conflict_check(
+        (
+            "SHARDLINE_ADMIN_READ_TOKEN",
+            "SHARDLINE_ADMIN_READ_TOKEN_FILE",
+        ),
+        MAX_ADMIN_READ_TOKEN_BYTES,
+        false,
+        ServerConfigError::EmptyAdminReadToken,
+        |env, file_env| ServerConfigError::SecretSourceConflict { env, file_env },
+        ServerConfigError::AdminReadToken,
+        |observed, maximum| ServerConfigError::AdminReadTokenTooLarge {
+            observed_bytes: observed,
+            maximum_bytes: maximum,
+        },
+        |expected, observed| ServerConfigError::AdminReadTokenLengthMismatch {
+            expected_bytes: expected,
+            observed_bytes: observed,
+        },
+    )?;
     let provider_config_path = var("SHARDLINE_PROVIDER_CONFIG_FILE")
         .ok()
         .map(PathBuf::from);
@@ -546,6 +565,9 @@ pub(super) fn load_server_config_from_env() -> Result<ServerConfig, ServerConfig
     }
     if let Some(metrics_token) = metrics_token {
         config = config.with_metrics_token(metrics_token)?;
+    }
+    if let Some(admin_read_token) = admin_read_token {
+        config = config.with_admin_read_token(admin_read_token)?;
     }
 
     if let Some(deployment_mode) = deployment_mode_from_env()? {
@@ -843,6 +865,12 @@ pub fn load_server_config_from_env_with_toml(
             "SHARDLINE_TRANSFER_MAX_IN_FLIGHT_CHUNKS",
             srv.transfer_max_in_flight_chunks.map(|v| v.to_string()),
         );
+        if var("SHARDLINE_ADMIN_READ_TOKEN").is_err() {
+            set_if_unset(
+                "SHARDLINE_ADMIN_READ_TOKEN_FILE",
+                srv.admin_read_token_path.clone(),
+            );
+        }
     }
 
     if let Some(stg) = &toml.storage {
@@ -1310,6 +1338,121 @@ root_dir = "runtime#dir\nSHARDLINE_INJECTED_VALUE=unexpected"
         ));
         remove_env_var("SHARDLINE_METRICS_TOKEN");
         remove_env_var("SHARDLINE_METRICS_TOKEN_FILE");
+        remove_env_var("SHARDLINE_ROOT_DIR");
+        remove_env_var("SHARDLINE_PUBLIC_BASE_URL");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn load_server_config_admin_read_token_from_file() {
+        use std::io::Write;
+        let mut token_file = tempfile::NamedTempFile::new().unwrap();
+        token_file.write_all(b"admin-read-token").unwrap();
+        token_file.flush().unwrap();
+
+        set_env_var(
+            "SHARDLINE_ADMIN_READ_TOKEN_FILE",
+            token_file.path().to_str().unwrap(),
+        );
+        remove_env_var("SHARDLINE_ADMIN_READ_TOKEN");
+        set_env_var("SHARDLINE_ROOT_DIR", "/tmp/shardline_admin_read_test");
+        set_env_var("SHARDLINE_PUBLIC_BASE_URL", "http://localhost:8080");
+
+        let config = super::load_server_config_from_env().unwrap();
+        assert_eq!(
+            config.admin_read_token(),
+            Some(b"admin-read-token".as_slice())
+        );
+
+        remove_env_var("SHARDLINE_ADMIN_READ_TOKEN_FILE");
+        remove_env_var("SHARDLINE_ROOT_DIR");
+        remove_env_var("SHARDLINE_PUBLIC_BASE_URL");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn load_server_config_admin_read_token_from_direct_env() {
+        set_env_var("SHARDLINE_ADMIN_READ_TOKEN", "direct-admin-read-token");
+        remove_env_var("SHARDLINE_ADMIN_READ_TOKEN_FILE");
+        set_env_var("SHARDLINE_ROOT_DIR", "/tmp/shardline_admin_read_test");
+        set_env_var("SHARDLINE_PUBLIC_BASE_URL", "http://localhost:8080");
+
+        let config = super::load_server_config_from_env().unwrap();
+        assert_eq!(
+            config.admin_read_token(),
+            Some(b"direct-admin-read-token".as_slice())
+        );
+
+        remove_env_var("SHARDLINE_ADMIN_READ_TOKEN");
+        remove_env_var("SHARDLINE_ROOT_DIR");
+        remove_env_var("SHARDLINE_PUBLIC_BASE_URL");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn load_server_config_admin_read_token_rejects_conflicting_sources() {
+        set_env_var("SHARDLINE_ADMIN_READ_TOKEN", "direct-token");
+        set_env_var("SHARDLINE_ADMIN_READ_TOKEN_FILE", "/tmp/admin-read-token");
+        set_env_var("SHARDLINE_ROOT_DIR", "/tmp/shardline_admin_read_test");
+        set_env_var("SHARDLINE_PUBLIC_BASE_URL", "http://localhost:8080");
+
+        let result = super::load_server_config_from_env();
+        assert!(matches!(
+            result,
+            Err(super::ServerConfigError::SecretSourceConflict { .. })
+        ));
+
+        remove_env_var("SHARDLINE_ADMIN_READ_TOKEN");
+        remove_env_var("SHARDLINE_ADMIN_READ_TOKEN_FILE");
+        remove_env_var("SHARDLINE_ROOT_DIR");
+        remove_env_var("SHARDLINE_PUBLIC_BASE_URL");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn load_server_config_admin_read_token_from_toml() {
+        use std::io::Write;
+        let mut token_file = tempfile::NamedTempFile::new().unwrap();
+        token_file.write_all(b"toml-admin-read-token").unwrap();
+        token_file.flush().unwrap();
+        let toml: super::ShardlineTomlConfig = toml::from_str(&format!(
+            "[server]\nadmin_read_token_path = {:?}\n",
+            token_file.path().to_str().unwrap()
+        ))
+        .unwrap();
+
+        remove_env_var("SHARDLINE_ADMIN_READ_TOKEN");
+        remove_env_var("SHARDLINE_ADMIN_READ_TOKEN_FILE");
+        set_env_var("SHARDLINE_ROOT_DIR", "/tmp/shardline_admin_read_toml_test");
+        set_env_var("SHARDLINE_PUBLIC_BASE_URL", "http://localhost:8080");
+        let config = load_server_config_from_env_with_toml(&toml).unwrap();
+        assert_eq!(
+            config.admin_read_token(),
+            Some(b"toml-admin-read-token".as_slice())
+        );
+
+        remove_env_var("SHARDLINE_ADMIN_READ_TOKEN_FILE");
+        remove_env_var("SHARDLINE_ROOT_DIR");
+        remove_env_var("SHARDLINE_PUBLIC_BASE_URL");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn direct_admin_read_token_overrides_toml_file_path() {
+        let toml: super::ShardlineTomlConfig =
+            toml::from_str("[server]\nadmin_read_token_path = \"/does/not/exist\"\n").unwrap();
+
+        set_env_var("SHARDLINE_ADMIN_READ_TOKEN", "environment-token");
+        remove_env_var("SHARDLINE_ADMIN_READ_TOKEN_FILE");
+        set_env_var("SHARDLINE_ROOT_DIR", "/tmp/shardline_admin_read_toml_test");
+        set_env_var("SHARDLINE_PUBLIC_BASE_URL", "http://localhost:8080");
+        let config = load_server_config_from_env_with_toml(&toml).unwrap();
+        assert_eq!(
+            config.admin_read_token(),
+            Some(b"environment-token".as_slice())
+        );
+
+        remove_env_var("SHARDLINE_ADMIN_READ_TOKEN");
         remove_env_var("SHARDLINE_ROOT_DIR");
         remove_env_var("SHARDLINE_PUBLIC_BASE_URL");
     }

--- a/crates/shardline-server/src/config/file.rs
+++ b/crates/shardline-server/src/config/file.rs
@@ -34,6 +34,9 @@ pub struct ServerSection {
     pub chunk_size_bytes: Option<u64>,
     pub upload_max_in_flight_chunks: Option<u64>,
     pub transfer_max_in_flight_chunks: Option<u64>,
+    /// Path to the dedicated read-only administration API bearer token.
+    /// Secret values are intentionally not accepted inline in TOML.
+    pub admin_read_token_path: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -179,12 +182,37 @@ pub fn load_toml_config(config_path: Option<&Path>) -> Result<Option<ShardlineTo
     Ok(Some(config))
 }
 
+/// Parses the server TOML schema without touching the filesystem.
+///
+/// This narrow hook keeps the production parser under continuous fuzzing
+/// without exposing its internal representation as public API.
+///
+/// # Errors
+///
+/// Returns the TOML parser error when the document does not satisfy the strict
+/// server configuration schema.
+#[cfg(feature = "fuzzing")]
+pub fn parse_toml_config_for_fuzzing(input: &str) -> Result<(), String> {
+    toml::from_str::<ShardlineTomlConfig>(input)
+        .map(|_config| ())
+        .map_err(|error| error.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
     use std::io::Write;
     use tempfile::NamedTempFile;
 
+    proptest! {
+        #[test]
+        fn arbitrary_toml_parsing_is_deterministic_and_never_panics(input in any::<String>()) {
+            let first = toml::from_str::<ShardlineTomlConfig>(&input);
+            let second = toml::from_str::<ShardlineTomlConfig>(&input);
+            prop_assert_eq!(format!("{first:?}"), format!("{second:?}"));
+        }
+    }
     #[test]
     fn test_expand_tilde_no_tilde() {
         let result = expand_tilde("/etc/shardline/shardline.toml");

--- a/crates/shardline-server/src/config/tests.rs
+++ b/crates/shardline-server/src/config/tests.rs
@@ -98,6 +98,7 @@ fn server_config_keeps_bind_address_and_public_url() {
     assert_eq!(config.index_postgres_url(), None);
     assert_eq!(config.token_signing_key(), None);
     assert_eq!(config.metrics_token(), None);
+    assert_eq!(config.admin_read_token(), None);
     assert_eq!(config.provider_config_path(), None);
 }
 
@@ -136,6 +137,63 @@ fn server_config_rejects_empty_metrics_token() {
         config,
         Err(super::ServerConfigError::EmptyMetricsToken)
     ));
+}
+
+#[test]
+fn server_config_accepts_and_redacts_admin_read_token() {
+    let config = ServerConfig::new(
+        "127.0.0.1:8080".parse().unwrap(),
+        "https://assets.example.test".to_owned(),
+        PathBuf::from("/tmp/shardline"),
+        NonZeroUsize::MIN,
+    )
+    .with_admin_read_token(b"admin-read-token".to_vec())
+    .unwrap();
+
+    assert_eq!(
+        config.admin_read_token(),
+        Some(b"admin-read-token".as_slice())
+    );
+    let debug = format!("{config:?}");
+    assert!(debug.contains("admin_read_token"));
+    assert!(!debug.contains("admin-read-token"));
+}
+
+#[test]
+fn server_config_rejects_empty_admin_read_token() {
+    let result = ServerConfig::new(
+        "127.0.0.1:8080".parse().unwrap(),
+        "https://assets.example.test".to_owned(),
+        PathBuf::from("/tmp/shardline"),
+        NonZeroUsize::MIN,
+    )
+    .with_admin_read_token(Vec::new());
+
+    assert!(matches!(
+        result,
+        Err(super::ServerConfigError::EmptyAdminReadToken)
+    ));
+}
+
+#[test]
+fn server_config_rejects_unusable_admin_read_tokens() {
+    for token in [
+        b"contains space".as_slice(),
+        b"contains\nnewline".as_slice(),
+        &[0xff],
+    ] {
+        let result = ServerConfig::new(
+            "127.0.0.1:8080".parse().unwrap(),
+            "http://localhost:8080".to_owned(),
+            PathBuf::from("/tmp/shardline"),
+            NonZeroUsize::new(65_536).unwrap(),
+        )
+        .with_admin_read_token(token.to_vec());
+        assert!(matches!(
+            result,
+            Err(super::ServerConfigError::InvalidAdminReadToken)
+        ));
+    }
 }
 
 #[test]

--- a/crates/shardline-server/src/config/types/config.rs
+++ b/crates/shardline-server/src/config/types/config.rs
@@ -23,11 +23,11 @@ use super::defaults::{
     DEFAULT_S3_MAX_PART_BYTES, DEFAULT_S3_MIN_PART_BYTES, DEFAULT_S3_UPLOAD_MAX_ACTIVE_PART_FILES,
     DEFAULT_S3_UPLOAD_MAX_ACTIVE_SESSIONS, DEFAULT_S3_UPLOAD_SESSION_MAX_BYTES,
     DEFAULT_S3_UPLOAD_SESSION_TTL_SECONDS, DEFAULT_S3_UPLOAD_TOTAL_MAX_BYTES,
-    HUB_WEBHOOK_SECRET_KEY_BYTES, MAX_DEFAULT_TRANSFER_MAX_IN_FLIGHT_CHUNKS,
-    MAX_DEFAULT_UPLOAD_MAX_IN_FLIGHT_CHUNKS, MAX_ED25519_KEY_BYTES, MAX_METRICS_TOKEN_BYTES,
-    MAX_PROVIDER_API_KEY_BYTES, MAX_TOKEN_SIGNING_KEY_BYTES,
-    MIN_DEFAULT_TRANSFER_MAX_IN_FLIGHT_CHUNKS, MIN_DEFAULT_UPLOAD_MAX_IN_FLIGHT_CHUNKS,
-    MIN_S3_MAX_PART_BYTES,
+    HUB_WEBHOOK_SECRET_KEY_BYTES, MAX_ADMIN_READ_TOKEN_BYTES,
+    MAX_DEFAULT_TRANSFER_MAX_IN_FLIGHT_CHUNKS, MAX_DEFAULT_UPLOAD_MAX_IN_FLIGHT_CHUNKS,
+    MAX_ED25519_KEY_BYTES, MAX_METRICS_TOKEN_BYTES, MAX_PROVIDER_API_KEY_BYTES,
+    MAX_TOKEN_SIGNING_KEY_BYTES, MIN_DEFAULT_TRANSFER_MAX_IN_FLIGHT_CHUNKS,
+    MIN_DEFAULT_UPLOAD_MAX_IN_FLIGHT_CHUNKS, MIN_S3_MAX_PART_BYTES,
 };
 use super::enums::{
     AuthConfig, AuthProviderKind, CacheConfig, DeploymentMode, ObjectStorageAdapter, OciConfig,
@@ -49,6 +49,34 @@ pub use shardline_server_core::DEFAULT_SHARD_METADATA_LIMITS;
 /// Bounded-parser limits for native Xet shard metadata.
 pub use shardline_server_core::ShardMetadataLimits;
 
+/// Validated bearer token for the read-only administration boundary.
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct AdminReadToken(SecretBytes);
+
+impl AdminReadToken {
+    fn new(value: SecretBytes) -> Result<Self, ServerConfigError> {
+        if value.expose_secret().is_empty() {
+            return Err(ServerConfigError::EmptyAdminReadToken);
+        }
+        ensure_secret_size_within_limit(
+            u64::try_from(value.len()).unwrap_or(u64::MAX),
+            MAX_ADMIN_READ_TOKEN_BYTES,
+            |observed_bytes, maximum_bytes| ServerConfigError::AdminReadTokenTooLarge {
+                observed_bytes,
+                maximum_bytes,
+            },
+        )?;
+        if !value.expose_secret().iter().all(u8::is_ascii_graphic) {
+            return Err(ServerConfigError::InvalidAdminReadToken);
+        }
+        Ok(Self(value))
+    }
+
+    fn expose_secret(&self) -> &[u8] {
+        self.0.expose_secret()
+    }
+}
+
 /// Public server configuration.
 #[derive(Clone, PartialEq, Eq)]
 pub struct ServerConfig {
@@ -66,6 +94,7 @@ pub struct ServerConfig {
     pub(crate) transfer_max_in_flight_chunks: NonZeroUsize,
     pub(crate) index_postgres_url: Option<SecretString>,
     pub(crate) metrics_token: Option<SecretBytes>,
+    pub(crate) admin_read_token: Option<AdminReadToken>,
     pub(crate) deployment_mode: DeploymentMode,
     /// Whether the deployment mode was explicitly selected (e.g. via
     /// `SHARDLINE_DEPLOYMENT_MODE`), as opposed to the built-in insecure
@@ -141,6 +170,7 @@ impl ServerConfig {
             transfer_max_in_flight_chunks: default_transfer_max_in_flight_chunks(),
             index_postgres_url: None,
             metrics_token: None,
+            admin_read_token: None,
             deployment_mode: DeploymentMode::default(),
             deployment_mode_explicitly_set: false,
             allow_plaintext_secrets_in_production: false,
@@ -614,6 +644,14 @@ impl ServerConfig {
     #[must_use]
     pub fn metrics_token(&self) -> Option<&[u8]> {
         self.metrics_token.as_ref().map(SecretBytes::expose_secret)
+    }
+
+    /// Returns the optional bearer token protecting the read-only admin API.
+    #[must_use]
+    pub fn admin_read_token(&self) -> Option<&[u8]> {
+        self.admin_read_token
+            .as_ref()
+            .map(AdminReadToken::expose_secret)
     }
 
     /// Returns the deployment security mode.
@@ -1218,6 +1256,19 @@ impl ServerConfig {
         )?;
 
         self.metrics_token = Some(metrics_token);
+        Ok(self)
+    }
+
+    /// Enables the read-only administrative API with a dedicated bearer token.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ServerConfigError::EmptyAdminReadToken`] when the token is empty.
+    pub fn with_admin_read_token(
+        mut self,
+        admin_read_token: impl Into<SecretBytes>,
+    ) -> Result<Self, ServerConfigError> {
+        self.admin_read_token = Some(AdminReadToken::new(admin_read_token.into())?);
         Ok(self)
     }
 

--- a/crates/shardline-server/src/config/types/debug.rs
+++ b/crates/shardline-server/src/config/types/debug.rs
@@ -33,6 +33,10 @@ impl fmt::Debug for ServerConfig {
                 "metrics_token",
                 &self.metrics_token.as_ref().map(|_token| "***"),
             )
+            .field(
+                "admin_read_token",
+                &self.admin_read_token.as_ref().map(|_token| "***"),
+            )
             .field("auth", &self.auth)
             .field("oci", &self.oci)
             .field("cache", &self.cache)

--- a/crates/shardline-server/src/config/types/defaults.rs
+++ b/crates/shardline-server/src/config/types/defaults.rs
@@ -86,6 +86,7 @@ pub(crate) const HUB_WEBHOOK_SECRET_KEY_BYTES: u64 = 32;
 pub(crate) const CONFIG_SECRET_KEY_BYTES: u64 = 32;
 pub(crate) const MAX_PROVIDER_API_KEY_BYTES: u64 = 4096;
 pub(crate) const MAX_METRICS_TOKEN_BYTES: u64 = 4096;
+pub(crate) const MAX_ADMIN_READ_TOKEN_BYTES: u64 = 4096;
 pub(crate) const MAX_REDIS_TLS_MATERIAL_BYTES: u64 = 1_048_576;
 pub(crate) const MAX_S3_CREDENTIAL_BYTES: u64 = 4096;
 

--- a/crates/shardline-server/src/config/types/error.rs
+++ b/crates/shardline-server/src/config/types/error.rs
@@ -333,6 +333,31 @@ pub enum ServerConfigError {
         "strict deployment mode requires a metrics token (set SHARDLINE_METRICS_TOKEN or SHARDLINE_METRICS_TOKEN_FILE)"
     )]
     MissingMetricsToken,
+    /// The read-only admin API token file could not be read.
+    #[error("admin read token could not be read")]
+    AdminReadToken(#[source] IoError),
+    /// The read-only admin API bearer token was empty.
+    #[error("admin read token must not be empty")]
+    EmptyAdminReadToken,
+    /// The read-only admin API token cannot be represented in an HTTP bearer header.
+    #[error("admin read token must contain only visible ASCII bytes without whitespace")]
+    InvalidAdminReadToken,
+    /// The read-only admin API bearer token exceeded the parser ceiling.
+    #[error("admin read token exceeded the bounded parser ceiling")]
+    AdminReadTokenTooLarge {
+        /// Observed secret file length in bytes.
+        observed_bytes: u64,
+        /// Maximum accepted secret file length in bytes.
+        maximum_bytes: u64,
+    },
+    /// The read-only admin API token changed after validation.
+    #[error("admin read token changed during bounded read")]
+    AdminReadTokenLengthMismatch {
+        /// Validated secret file length in bytes.
+        expected_bytes: u64,
+        /// Observed secret file length in bytes after bounded read.
+        observed_bytes: u64,
+    },
     /// The selected role uses the local HMAC provider and would expose CAS routes
     /// without bearer-token verification.
     #[error("served shardline routes require shardline token signing key configuration")]

--- a/crates/shardline-server/src/config/types/tests.rs
+++ b/crates/shardline-server/src/config/types/tests.rs
@@ -1806,6 +1806,40 @@ fn server_config_error_display_metrics_token_length_mismatch() {
 }
 
 #[test]
+fn server_config_error_display_admin_read_token_variants() {
+    let io_err = std::io::Error::other("file error");
+    assert_eq!(
+        ServerConfigError::AdminReadToken(io_err).to_string(),
+        "admin read token could not be read"
+    );
+    assert_eq!(
+        ServerConfigError::EmptyAdminReadToken.to_string(),
+        "admin read token must not be empty"
+    );
+    assert!(
+        ServerConfigError::InvalidAdminReadToken
+            .to_string()
+            .contains("visible ASCII")
+    );
+    assert!(
+        ServerConfigError::AdminReadTokenTooLarge {
+            observed_bytes: 5000,
+            maximum_bytes: 4096,
+        }
+        .to_string()
+        .contains("exceeded")
+    );
+    assert!(
+        ServerConfigError::AdminReadTokenLengthMismatch {
+            expected_bytes: 100,
+            observed_bytes: 200,
+        }
+        .to_string()
+        .contains("changed during bounded read")
+    );
+}
+
+#[test]
 fn server_config_error_display_provider_api_key() {
     let io_err = std::io::Error::other("file error");
     let err = ServerConfigError::ProviderApiKey(io_err);
@@ -2040,6 +2074,21 @@ fn server_config_builder_with_metrics_token_rejects_too_large() {
     assert!(matches!(
         result,
         Err(ServerConfigError::MetricsTokenTooLarge { .. })
+    ));
+}
+
+#[test]
+fn server_config_builder_with_admin_read_token_rejects_too_large() {
+    let config = ServerConfig::new(
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080),
+        "http://localhost:8080".to_owned(),
+        PathBuf::from("/tmp/test"),
+        NonZeroUsize::new(4096).unwrap(),
+    );
+    let result = config.with_admin_read_token(vec![0_u8; 5000]);
+    assert!(matches!(
+        result,
+        Err(ServerConfigError::AdminReadTokenTooLarge { .. })
     ));
 }
 

--- a/crates/shardline-server/src/error/server.rs
+++ b/crates/shardline-server/src/error/server.rs
@@ -71,6 +71,9 @@ pub enum ServerError {
     /// Request query exceeded the bounded metadata parser budget.
     #[error("request query exceeded the bounded metadata parser budget")]
     RequestQueryTooLarge,
+    /// A read-only administration API query was malformed or unsupported.
+    #[error("administration API query was invalid")]
+    InvalidAdminQuery,
     /// Request body frame slicing exceeded checked bounds.
     #[error("request body frame exceeded checked bounds")]
     RequestBodyFrameOutOfBounds,
@@ -307,6 +310,7 @@ impl ServerError {
             | Self::Json(_)
             | Self::RequestBodyRead(_)
             | Self::RequestQueryTooLarge
+            | Self::InvalidAdminQuery
             | Self::RequestBodyFrameOutOfBounds
             | Self::NumericConversion(_)
             | Self::HashParse(_)
@@ -382,6 +386,7 @@ impl ServerError {
             | Self::TooManyBatchReconstructionFileIds
             | Self::RequestBodyTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
             Self::RequestQueryTooLarge => StatusCode::URI_TOO_LONG,
+            Self::InvalidAdminQuery => StatusCode::BAD_REQUEST,
             Self::RequestBodyRead(_) | Self::RequestBodyFrameOutOfBounds => StatusCode::BAD_REQUEST,
             Self::ExpectedBodyHashMismatch => StatusCode::BAD_REQUEST,
             Self::NotFound | Self::UnknownProvider | Self::ProviderTokensDisabled => {
@@ -758,6 +763,7 @@ impl shardline_s3_adapter::S3ErrorClassify for ServerError {
             | Self::RequestBodyRead(_)
             | Self::RequestBodyTooLarge
             | Self::RequestQueryTooLarge
+            | Self::InvalidAdminQuery
             | Self::RequestBodyFrameOutOfBounds
             | Self::NumericConversion(_)
             | Self::HashParse(_)

--- a/crates/shardline-server/src/fuzz.rs
+++ b/crates/shardline-server/src/fuzz.rs
@@ -6,7 +6,10 @@ use shardline_server_core::AuthorizedRepository;
 
 use crate::{
     BazelCacheKind, InvalidReconstructionResponseError, InvalidSerializedShardError, ServerError,
-    app::{parse_oci_path, parse_upload_content_range},
+    app::{
+        parse_admin_cursor_for_fuzzing, parse_admin_query_for_fuzzing, parse_oci_path,
+        parse_upload_content_range,
+    },
     bazel_cache_object_key,
     config::ShardMetadataLimits,
     lfs_object_key,
@@ -25,6 +28,24 @@ use crate::{
         reconstruction_v2_from_v1, retained_shard_chunk_hashes, validate_serialized_xorb,
     },
 };
+
+/// Exercise the bounded administration query and cursor parser.
+///
+/// # Errors
+///
+/// Returns the parser's bounded validation error for malformed input.
+pub fn fuzz_admin_api_query(input: &str) -> Result<(), ServerError> {
+    parse_admin_query_for_fuzzing(input)
+}
+
+/// Exercise deserialization and validation of the versioned cursor DTO and its newtypes.
+///
+/// # Errors
+///
+/// Returns the parser's bounded validation error for malformed input.
+pub fn fuzz_admin_api_cursor(input: &[u8]) -> Result<(), ServerError> {
+    parse_admin_cursor_for_fuzzing(input)
+}
 
 /// Summary of Git LFS frontend validation used by fuzz targets.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/shardline-server/src/lib.rs
+++ b/crates/shardline-server/src/lib.rs
@@ -180,6 +180,8 @@ pub(crate) mod xet_adapter {
 
 pub use app::{serve, serve_with_listener};
 pub use backup::{BackupManifestReport, write_backup_manifest};
+#[cfg(feature = "fuzzing")]
+pub use config::file::parse_toml_config_for_fuzzing;
 pub use config::{
     AuthProviderKind, DeploymentMode, ObjectStorageAdapter, ServerConfig, ServerConfigError,
     ShardMetadataLimits, file::load_toml_config, load_server_config_from_env_with_toml,

--- a/crates/shardline-server/src/lib.rs
+++ b/crates/shardline-server/src/lib.rs
@@ -206,10 +206,10 @@ pub use fuzz::{
     FuzzBazelHttpFrontendSummary, FuzzLfsFrontendSummary, FuzzLifecycleRepairSummary,
     FuzzOciFrontendSummary, FuzzProtocolFrontendSummary, FuzzQuarantineAction,
     FuzzReconstructionResponseSummary, FuzzRetainedShardSummary, FuzzRetentionAction,
-    FuzzValidatedXorbSummary, FuzzWebhookAction, fuzz_bazel_http_frontend_summary,
-    fuzz_classify_quarantine, fuzz_classify_retention, fuzz_classify_webhook,
-    fuzz_lfs_frontend_summary, fuzz_lifecycle_repair_summary, fuzz_normalize_and_validate_xorb,
-    fuzz_oci_frontend_summary, fuzz_protocol_frontend_summary,
+    FuzzValidatedXorbSummary, FuzzWebhookAction, fuzz_admin_api_cursor, fuzz_admin_api_query,
+    fuzz_bazel_http_frontend_summary, fuzz_classify_quarantine, fuzz_classify_retention,
+    fuzz_classify_webhook, fuzz_lfs_frontend_summary, fuzz_lifecycle_repair_summary,
+    fuzz_normalize_and_validate_xorb, fuzz_oci_frontend_summary, fuzz_protocol_frontend_summary,
     fuzz_reconstruction_response_summary, fuzz_retained_shard_chunk_hashes,
 };
 pub use gc::{

--- a/crates/shardline-server/src/local_backend/backend.rs
+++ b/crates/shardline-server/src/local_backend/backend.rs
@@ -172,9 +172,13 @@ impl LocalBackend {
     pub async fn stats(&self) -> Result<ServerStatsResponse, ServerError> {
         let object_store = self.object_store();
         let prefix = ObjectPrefix::parse("").map_err(|_error| ServerError::InvalidContentHash)?;
+        let mut objects = 0_u64;
+        let mut object_bytes = 0_u64;
         let mut chunks = 0_u64;
         let mut chunk_bytes = 0_u64;
         visit_object_prefix(&object_store, &prefix, |metadata| {
+            objects = checked_increment(objects)?;
+            object_bytes = checked_add(object_bytes, metadata.length())?;
             let is_chunk = chunk_hash_from_chunk_object_key_if_present(metadata.key())?.is_some();
             if is_chunk {
                 chunks = checked_increment(chunks)?;
@@ -190,6 +194,8 @@ impl LocalBackend {
         )?;
 
         Ok(ServerStatsResponse {
+            objects,
+            object_bytes,
             chunks,
             chunk_bytes,
             files,
@@ -1017,6 +1023,8 @@ mod tests {
         .await
         .unwrap();
         let stats = backend.stats().await.unwrap();
+        assert_eq!(stats.objects, 0);
+        assert_eq!(stats.object_bytes, 0);
         assert_eq!(stats.chunks, 0);
         assert_eq!(stats.chunk_bytes, 0);
         assert_eq!(stats.files, 0);

--- a/crates/shardline-server/src/local_backend/tests.rs
+++ b/crates/shardline-server/src/local_backend/tests.rs
@@ -91,6 +91,8 @@ async fn local_backend_reuses_unchanged_chunks() {
         stats.chunks,
         first.inserted_chunks
     );
+    assert!(stats.objects >= stats.chunks);
+    assert!(stats.object_bytes >= stats.chunk_bytes);
 }
 
 #[cfg(unix)]

--- a/crates/shardline-server/src/model.rs
+++ b/crates/shardline-server/src/model.rs
@@ -65,6 +65,10 @@ pub struct UploadFileResponse {
 /// Storage stats response.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ServerStatsResponse {
+    /// Number of objects stored across the configured object namespace.
+    pub objects: u64,
+    /// Total physical bytes stored across the configured object namespace.
+    pub object_bytes: u64,
     /// Number of chunk objects stored.
     pub chunks: u64,
     /// Total bytes stored across chunk objects.
@@ -303,6 +307,8 @@ mod tests {
     #[test]
     fn server_stats_response_serde_round_trip() {
         let original = ServerStatsResponse {
+            objects: 20,
+            object_bytes: 81_920,
             chunks: 10,
             chunk_bytes: 40960,
             files: 5,

--- a/crates/shardline-server/src/postgres_backend/stats.rs
+++ b/crates/shardline-server/src/postgres_backend/stats.rs
@@ -18,9 +18,13 @@ impl super::PostgresBackend {
     pub async fn stats(&self) -> Result<ServerStatsResponse, ServerError> {
         let object_store = self.object_store();
         let prefix = ObjectPrefix::parse("").map_err(|_error| ServerError::InvalidContentHash)?;
+        let mut objects = 0_u64;
+        let mut object_bytes = 0_u64;
         let mut chunks = 0_u64;
         let mut chunk_bytes = 0_u64;
         visit_object_prefix(&object_store, &prefix, |metadata| {
+            objects = checked_increment(objects)?;
+            object_bytes = checked_add(object_bytes, metadata.length())?;
             let is_chunk = chunk_hash_from_chunk_object_key_if_present(metadata.key())?.is_some();
             if is_chunk {
                 chunks = checked_increment(chunks)?;
@@ -37,6 +41,8 @@ impl super::PostgresBackend {
         .await?;
 
         Ok(ServerStatsResponse {
+            objects,
+            object_bytes,
             chunks,
             chunk_bytes,
             files,
@@ -82,11 +88,15 @@ mod tests {
     #[test]
     fn server_stats_response_default_fields() {
         let response = ServerStatsResponse {
+            objects: 0,
+            object_bytes: 0,
             chunks: 0,
             chunk_bytes: 0,
             files: 0,
         };
         assert_eq!(response.chunks, 0);
+        assert_eq!(response.objects, 0);
+        assert_eq!(response.object_bytes, 0);
         assert_eq!(response.chunk_bytes, 0);
         assert_eq!(response.files, 0);
     }
@@ -94,11 +104,15 @@ mod tests {
     #[test]
     fn server_stats_response_arbitrary_values() {
         let response = ServerStatsResponse {
+            objects: 84,
+            object_bytes: 2_000_000,
             chunks: 42,
             chunk_bytes: 1_000_000,
             files: 7,
         };
         assert_eq!(response.chunks, 42);
+        assert_eq!(response.objects, 84);
+        assert_eq!(response.object_bytes, 2_000_000);
         assert_eq!(response.chunk_bytes, 1_000_000);
         assert_eq!(response.files, 7);
     }

--- a/crates/shardline-server/src/route_policy.rs
+++ b/crates/shardline-server/src/route_policy.rs
@@ -82,6 +82,21 @@ pub(crate) fn register_route_policies(registry: &mut RoutePolicyRegistry) {
     // Metrics — separately protected (token file)
     registry.register("GET", "/metrics", RouteAuthPolicy::SeparatelyProtected);
 
+    // Read-only administrative API — separately protected by its own token.
+    for path in [
+        "/api/v1/status",
+        "/api/v1/storage",
+        "/api/v1/gc",
+        "/api/v1/integrity",
+        "/api/v1/nodes",
+        "/api/v1/tasks",
+        "/api/v1/metrics",
+        "/api/v1/plugins",
+        "/api/v1/replication",
+    ] {
+        registry.register("GET", path, RouteAuthPolicy::SeparatelyProtected);
+    }
+
     // Stats — authenticated
     registry.register("GET", "/v1/stats", RouteAuthPolicy::Authenticated);
 

--- a/crates/shardline-server/tests/deployment_chaos.rs
+++ b/crates/shardline-server/tests/deployment_chaos.rs
@@ -812,13 +812,17 @@ async fn s3_get(base: &str, token: &str, key: &str) -> reqwest::Response {
 }
 
 async fn admin_status(base: &str, token: &str) -> reqwest::Response {
+    admin_get(base, "/api/v1/status", token).await
+}
+
+async fn admin_get(base: &str, path: &str, token: &str) -> reqwest::Response {
     reqwest::Client::new()
-        .get(format!("{base}/api/v1/status"))
+        .get(format!("{base}{path}"))
         .header("Authorization", format!("Bearer {token}"))
         .timeout(Duration::from_secs(20))
         .send()
         .await
-        .expect("admin status request completed within its bound")
+        .expect("admin request completed within its bound")
 }
 
 async fn assert_admin_state(base: &str, expected: &str) {
@@ -1121,6 +1125,24 @@ async fn drill_deploy_a_postgres_kill_mid_upload_no_lost_commits() {
         401,
         "dependency failure must not weaken the admin authorization boundary"
     );
+    let malformed = admin_get(&base, "/api/v1/nodes?limit=1&limit=2", ADMIN_READ_TOKEN).await;
+    assert_eq!(
+        malformed.status().as_u16(),
+        400,
+        "query validation must remain fail-closed during dependency failure"
+    );
+    let failed_storage = admin_get(&base, "/api/v1/storage", ADMIN_READ_TOKEN).await;
+    assert!(
+        failed_storage.status().is_server_error(),
+        "authoritative inventory must fail instead of returning fabricated data"
+    );
+    let failed_storage_body = failed_storage.text().await.expect("admin error body");
+    for secret in [ADMIN_READ_TOKEN, "shardline-dev-password", PG_URL] {
+        assert!(
+            !failed_storage_body.contains(secret),
+            "admin dependency error must not disclose {secret}"
+        );
+    }
 
     // Restore Postgres; verify no committed data was lost.
     restart_and_wait(

--- a/crates/shardline-server/tests/deployment_chaos.rs
+++ b/crates/shardline-server/tests/deployment_chaos.rs
@@ -72,6 +72,7 @@ const CONTAINER_REDIS: &str = "chaos-redis";
 const NETEM_IMAGE: &str = "nicolaka/netshoot:v0.13";
 
 const TEST_SIGNING_KEY: &[u8] = b"0123456789abcdef0123456789abcdef";
+const ADMIN_READ_TOKEN: &str = "deployment-chaos-admin-read-token";
 const CHUNK_SIZE: usize = 65536;
 
 // ---------------------------------------------------------------------------
@@ -810,6 +811,33 @@ async fn s3_get(base: &str, token: &str, key: &str) -> reqwest::Response {
         .expect("s3 GET request")
 }
 
+async fn admin_status(base: &str, token: &str) -> reqwest::Response {
+    reqwest::Client::new()
+        .get(format!("{base}/api/v1/status"))
+        .header("Authorization", format!("Bearer {token}"))
+        .timeout(Duration::from_secs(20))
+        .send()
+        .await
+        .expect("admin status request completed within its bound")
+}
+
+async fn assert_admin_state(base: &str, expected: &str) {
+    let response = admin_status(base, ADMIN_READ_TOKEN).await;
+    assert_eq!(response.status().as_u16(), 200, "admin status response");
+    assert_eq!(
+        response
+            .headers()
+            .get("cache-control")
+            .and_then(|value| value.to_str().ok()),
+        Some("no-store")
+    );
+    let body: serde_json::Value = response.json().await.expect("admin status JSON");
+    assert_eq!(body["api_version"], "v1");
+    assert_eq!(body["state"], expected);
+    assert_eq!(body["durable_storage_state"], expected);
+    assert!(!body.to_string().contains(ADMIN_READ_TOKEN));
+}
+
 async fn assert_s3_bytes(base: &str, token: &str, key: &str, expected: &[u8], context: &str) {
     let response = s3_get(base, token, key).await;
     assert_eq!(response.status().as_u16(), 200, "{context}: GET {key}");
@@ -1035,6 +1063,7 @@ async fn drill_deploy_a_postgres_kill_mid_upload_no_lost_commits() {
         &[
             ("SHARDLINE_SERVER_FRONTENDS", "s3"),
             ("SHARDLINE_S3_ENDPOINT", &stack.s3_endpoint),
+            ("SHARDLINE_ADMIN_READ_TOKEN", ADMIN_READ_TOKEN),
         ],
         tmp.path(),
     );
@@ -1042,6 +1071,7 @@ async fn drill_deploy_a_postgres_kill_mid_upload_no_lost_commits() {
 
     let token = mint_token("drill", "drill", TokenScope::Write);
     let base = server.base_url();
+    assert_admin_state(&base, "ready").await;
 
     // Seed two acked objects (durable commits before the outage).
     let k1 = "a-k1";
@@ -1082,6 +1112,15 @@ async fn drill_deploy_a_postgres_kill_mid_upload_no_lost_commits() {
         matches!(health, Ok(r) if r.status().as_u16() == 200),
         "healthz must stay 200 after postgres kill"
     );
+    assert_admin_state(&base, "degraded").await;
+    assert_eq!(
+        admin_status(&base, "wrong-admin-token")
+            .await
+            .status()
+            .as_u16(),
+        401,
+        "dependency failure must not weaken the admin authorization boundary"
+    );
 
     // Restore Postgres; verify no committed data was lost.
     restart_and_wait(
@@ -1092,6 +1131,22 @@ async fn drill_deploy_a_postgres_kill_mid_upload_no_lost_commits() {
     .await;
     migrate_chaos_postgres(&stack.pg_url).await;
     guard.recovered(CONTAINER_POSTGRES);
+    assert!(
+        ready_within(
+            || async {
+                let response = admin_status(&base, ADMIN_READ_TOKEN).await;
+                response.status().as_u16() == 200
+                    && response
+                        .json::<serde_json::Value>()
+                        .await
+                        .map(|body| body["state"] == "ready")
+                        .unwrap_or(false)
+            },
+            Duration::from_secs(30),
+        )
+        .await,
+        "admin status must recover to ready after Postgres recovery"
+    );
 
     for (key, expected) in [(&k1, &v1), (&k2a, &v2a)] {
         let resp = s3_get(&base, &token, key).await;

--- a/crates/shardline-server/tests/postgres_integration.rs
+++ b/crates/shardline-server/tests/postgres_integration.rs
@@ -697,11 +697,15 @@ async fn test_complete_workflow() {
 #[test]
 fn test_server_stats_response_default() {
     let stats = ServerStatsResponse {
+        objects: 0,
+        object_bytes: 0,
         chunks: 0,
         chunk_bytes: 0,
         files: 0,
     };
     assert_eq!(stats.chunks, 0);
+    assert_eq!(stats.objects, 0);
+    assert_eq!(stats.object_bytes, 0);
     assert_eq!(stats.chunk_bytes, 0);
     assert_eq!(stats.files, 0);
 }
@@ -709,11 +713,15 @@ fn test_server_stats_response_default() {
 #[test]
 fn test_server_stats_response_arbitrary() {
     let stats = ServerStatsResponse {
+        objects: 12,
+        object_bytes: 4096,
         chunks: 10,
         chunk_bytes: 2048,
         files: 3,
     };
     assert_eq!(stats.chunks, 10);
+    assert_eq!(stats.objects, 12);
+    assert_eq!(stats.object_bytes, 4096);
     assert_eq!(stats.chunk_bytes, 2048);
     assert_eq!(stats.files, 3);
 }

--- a/crates/shardline-server/tests/server_config_e2e.rs
+++ b/crates/shardline-server/tests/server_config_e2e.rs
@@ -314,6 +314,7 @@ fn test_load_toml_config_found() {
 bind_addr = "127.0.0.1:9090"
 server_role = "api"
 frontends = ["xet", "oci"]
+admin_read_token_path = "/run/secrets/shardline-admin-read-token"
 "#,
     );
     let config_path = dir.path().join("shardline.toml");
@@ -328,6 +329,10 @@ frontends = ["xet", "oci"]
     assert_eq!(srv.bind_addr.unwrap(), "127.0.0.1:9090");
     assert_eq!(srv.server_role.unwrap(), "api");
     assert_eq!(srv.frontends.unwrap(), vec!["xet", "oci"]);
+    assert_eq!(
+        srv.admin_read_token_path.as_deref(),
+        Some("/run/secrets/shardline-admin-read-token")
+    );
 }
 
 #[test]

--- a/crates/shardline/tests/k8s_manifest_security_e2e.rs
+++ b/crates/shardline/tests/k8s_manifest_security_e2e.rs
@@ -135,6 +135,18 @@ fn production_and_kind_configs_use_a_supported_auth_provider() {
     }
 }
 
+#[test]
+fn kind_runtime_secret_provides_every_new_projected_admin_key() {
+    let dependencies = read_manifest("tests/k8s/kind/dependencies.yaml");
+    assert!(dependencies.contains("name: shardline-runtime"));
+    assert!(dependencies.contains("admin-read-token: kind-smoke-admin-read-token"));
+
+    for deployment in ["api-deployment.yaml", "transfer-deployment.yaml"] {
+        let manifest = read_manifest(&format!("docs/k8s/production-scaled/{deployment}"));
+        assert!(manifest.contains("- key: admin-read-token\n                path: admin-read-token"));
+    }
+}
+
 fn read_manifest(path: &str) -> String {
     let result = read_to_string(
         Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/shardline/tests/k8s_manifest_security_e2e.rs
+++ b/crates/shardline/tests/k8s_manifest_security_e2e.rs
@@ -143,7 +143,9 @@ fn kind_runtime_secret_provides_every_new_projected_admin_key() {
 
     for deployment in ["api-deployment.yaml", "transfer-deployment.yaml"] {
         let manifest = read_manifest(&format!("docs/k8s/production-scaled/{deployment}"));
-        assert!(manifest.contains("- key: admin-read-token\n                path: admin-read-token"));
+        assert!(
+            manifest.contains("- key: admin-read-token\n                path: admin-read-token")
+        );
     }
 }
 

--- a/crates/shardline/tests/k8s_manifest_security_e2e.rs
+++ b/crates/shardline/tests/k8s_manifest_security_e2e.rs
@@ -11,8 +11,12 @@ fn production_api_manifest_pins_secret_volume_permissions() {
     assert!(manifest.contains("secretName: shardline-provider-catalog"));
     assert!(manifest.contains("SHARDLINE_S3_ACCESS_KEY_ID_FILE"));
     assert!(manifest.contains("SHARDLINE_S3_SECRET_ACCESS_KEY_FILE"));
+    assert!(manifest.contains("SHARDLINE_ADMIN_READ_TOKEN_FILE"));
+    assert!(manifest.contains("value: /run/secrets/shardline/admin-read-token"));
+    assert!(manifest.contains("- key: admin-read-token\n                path: admin-read-token"));
     assert!(!manifest.contains("SHARDLINE_S3_ACCESS_KEY_ID\n"));
     assert!(!manifest.contains("SHARDLINE_S3_SECRET_ACCESS_KEY\n"));
+    assert!(!manifest.contains("SHARDLINE_ADMIN_READ_TOKEN\n"));
     assert!(manifest.contains("- name: root\n          emptyDir: {}"));
     assert!(!manifest.contains("persistentVolumeClaim:"));
 }
@@ -27,8 +31,12 @@ fn production_transfer_manifest_pins_secret_volume_permissions() {
     assert!(manifest.contains("defaultMode: 0440"));
     assert!(manifest.contains("SHARDLINE_S3_ACCESS_KEY_ID_FILE"));
     assert!(manifest.contains("SHARDLINE_S3_SECRET_ACCESS_KEY_FILE"));
+    assert!(manifest.contains("SHARDLINE_ADMIN_READ_TOKEN_FILE"));
+    assert!(manifest.contains("value: /run/secrets/shardline/admin-read-token"));
+    assert!(manifest.contains("- key: admin-read-token\n                path: admin-read-token"));
     assert!(!manifest.contains("SHARDLINE_S3_ACCESS_KEY_ID\n"));
     assert!(!manifest.contains("SHARDLINE_S3_SECRET_ACCESS_KEY\n"));
+    assert!(!manifest.contains("SHARDLINE_ADMIN_READ_TOKEN\n"));
 }
 
 #[test]

--- a/docs/ADMIN_READ_API.md
+++ b/docs/ADMIN_READ_API.md
@@ -1,0 +1,139 @@
+# Read-Only Administration API
+
+Shardline exposes a versioned, read-only operations API for dashboards,
+monitoring systems, and Kubernetes operators. It is deliberately separate from
+the repository-scoped data API and does not expose mutation methods.
+
+## Enable and authenticate
+
+The API is disabled by default. Configure exactly one of:
+
+```text
+SHARDLINE_ADMIN_READ_TOKEN=<token>
+SHARDLINE_ADMIN_READ_TOKEN_FILE=/run/secrets/shardline-admin-read-token
+```
+
+The file form is recommended in production. Tokens must contain only visible
+ASCII without whitespace, be non-empty, and be at most 4096 bytes. Supplying
+both forms is a configuration error. The configured secret is redacted from
+debug output.
+
+The equivalent `shardline.toml` setting references the secret file without
+placing the secret itself in configuration:
+
+```toml
+[server]
+admin_read_token_path = "/run/secrets/shardline-admin-read-token"
+```
+
+An explicitly set environment variable takes precedence over TOML, consistently
+with the rest of Shardline's configuration.
+
+Every request uses the dedicated token:
+
+```bash
+curl -H "Authorization: Bearer $SHARDLINE_ADMIN_READ_TOKEN" \
+  https://cas.example.com/api/v1/status
+```
+
+The comparison is constant-time. Repository tokens and the independently
+configured `/metrics` token do not grant access. When no administration token
+is configured, these paths return `404`; when configured but authentication is
+missing or invalid, they return `401`.
+
+Do not expose these routes through a public ingress. They reveal aggregate
+capacity, topology, and process activity even though they do not reveal object
+keys, repositories, users, credentials, or presigned URLs.
+
+## Endpoints
+
+| Endpoint | Scope |
+| --- | --- |
+| `GET /api/v1/status` | Current process durable/cache readiness, role, enabled frontends, and backend kinds |
+| `GET /api/v1/storage` | Authoritative CAS counts plus explicitly process-lifetime write counters |
+| `GET /api/v1/gc` | GC counters observed by this process and execution ownership |
+| `GET /api/v1/integrity` | Fsck counters observed by this process and execution ownership |
+| `GET /api/v1/nodes` | Current process health; cluster discovery capability |
+| `GET /api/v1/tasks` | Background scheduler capability and known tasks |
+| `GET /api/v1/replication` | Replication-controller capability and known replicas |
+| `GET /api/v1/metrics` | A bounded JSON snapshot of high-level process metrics |
+| `GET /api/v1/plugins` | Reserved typed plugin registry/health surface |
+
+All successful responses contain `api_version: "v1"` and
+`observed_at_unix_seconds`. They return `Cache-Control: no-store`. `GET` and
+the normal body-free `HEAD` behavior are read-only; mutation methods return
+`405 Method Not Allowed`.
+
+The routes are mounted on `all`, `api`, and `transfer` roles. A dashboard must
+poll each process or place an explicitly configured aggregation layer in front
+of them when it needs per-process visibility.
+
+## State and consistency semantics
+
+The API distinguishes facts Shardline can authoritatively report from facts it
+does not own:
+
+- `ready` means the current process completed its backend readiness check.
+- `degraded` means that check failed. Internal backend errors are not returned.
+- `external` means execution or coordination is owned outside the server
+  process, such as CLI/CronJob GC and fsck or storage-provider replication.
+- `unsupported` means this version has no registry or discovery mechanism for
+  that field.
+
+`storage.authoritative` comes from an admission-controlled inventory of the durable backend
+and includes total object count/physical bytes plus CAS chunk and file counts.
+Fields under `process_lifetime` are Prometheus counters for only the serving
+process and can reset on restart. Shardline does not yet retain authoritative
+logical input bytes across every replica, so `deduplication_ratio_state` is
+`unsupported` and `deduplication_ratio` is `null` rather than a misleading
+value derived from process-local counters.
+
+GC and fsck are currently operator-run commands, not server-owned background
+workers. Their endpoints therefore report `state: "external"`,
+`execution: "external"`, and expose only counters observed in the current process.
+Likewise, Shardline coordinates
+multiple writers over shared Postgres/object storage but does not own the
+storage provider's replication controller; `/api/v1/replication` reports that
+boundary explicitly.
+
+The plugin endpoint is part of the stable shape anticipated by the plugin
+architecture. Until a plugin registry exists, it returns `registry:
+"unsupported"` and an empty list. Future plugin entries will expose bounded
+IDs, versions, health, lifecycle state, and declared capabilities without
+granting plugins raw access to the administration API or durable stores.
+
+## Compatibility contract
+
+Within `/api/v1`, existing field meanings and enum values are not changed or
+removed in a patch or minor release. New fields and endpoints may be added, so
+clients must ignore unknown object fields. A semantic break requires a new API
+version. Numeric counters are JSON integers and may increase between polls or
+reset when explicitly documented as process-lifetime values.
+
+Responses are bounded: there are no caller-selected page sizes, unbounded
+queries, raw labels, or arbitrary object identifiers. `/api/v1/storage` uses
+the same weighted admission control as the authenticated stats route, so
+monitoring pressure cannot bypass normal request limits.
+
+## Failure behavior
+
+- A dependency outage changes readiness-bearing responses to `degraded`; it
+  does not weaken authentication.
+- A saturated storage-stat request returns `503` rather than waiting without a
+  bound.
+- A failed authoritative storage query returns a sanitized server error rather
+  than stale or fabricated data.
+- Process counters and unsupported/external capability responses remain
+  available when they do not require the failed dependency.
+- Every response is a snapshot. No endpoint triggers GC, repair, fsck,
+  replication, plugin lifecycle, or another state transition.
+
+The deterministic deployment-chaos gate polls this API before, during, and
+after a Postgres kill. It requires `ready -> degraded -> ready`, bounded HTTP
+completion, secret-free responses, `no-store` cache policy, and continued
+rejection of an invalid token throughout the outage.
+
+For Prometheus/OpenMetrics scraping, continue to use `GET /metrics` and its
+separate `SHARDLINE_METRICS_TOKEN[_FILE]` secret. The JSON metrics endpoint is
+intended for dashboard summaries, not as a replacement for time-series
+collection.

--- a/docs/ADMIN_READ_API.md
+++ b/docs/ADMIN_READ_API.md
@@ -1,8 +1,9 @@
 # Read-Only Administration API
 
 Shardline exposes a versioned, read-only operations API for dashboards,
-monitoring systems, and Kubernetes operators. It is deliberately separate from
-the repository-scoped data API and does not expose mutation methods.
+monitoring systems, and Kubernetes operators. It is separate from the
+repository-scoped data API, accepts only a dedicated administration token, and
+has no mutation handlers.
 
 ## Enable and authenticate
 
@@ -13,13 +14,8 @@ SHARDLINE_ADMIN_READ_TOKEN=<token>
 SHARDLINE_ADMIN_READ_TOKEN_FILE=/run/secrets/shardline-admin-read-token
 ```
 
-The file form is recommended in production. Tokens must contain only visible
-ASCII without whitespace, be non-empty, and be at most 4096 bytes. Supplying
-both forms is a configuration error. The configured secret is redacted from
-debug output.
-
-The equivalent `shardline.toml` setting references the secret file without
-placing the secret itself in configuration:
+The file form is recommended in production. The equivalent `shardline.toml`
+setting references the file without placing the secret in TOML:
 
 ```toml
 [server]
@@ -27,113 +23,311 @@ admin_read_token_path = "/run/secrets/shardline-admin-read-token"
 ```
 
 An explicitly set environment variable takes precedence over TOML, consistently
-with the rest of Shardline's configuration.
+with the rest of Shardline's configuration. Supplying both token environment
+forms is a configuration error. Tokens must be non-empty visible ASCII without
+whitespace and at most 4096 bytes. Secret values are redacted from debug output.
 
-Every request uses the dedicated token:
+Every request uses the dedicated bearer token:
 
 ```bash
 curl -H "Authorization: Bearer $SHARDLINE_ADMIN_READ_TOKEN" \
   https://cas.example.com/api/v1/status
 ```
 
-The comparison is constant-time. Repository tokens and the independently
-configured `/metrics` token do not grant access. When no administration token
-is configured, these paths return `404`; when configured but authentication is
-missing or invalid, they return `401`.
+The comparison is constant-time. Duplicate or malformed `Authorization`
+headers are rejected. Repository tokens and the separately configured
+`/metrics` token do not grant access. Disabled routes return `404`; enabled
+routes with missing or invalid authentication return `401`. Query parsing
+happens only after this concealment/authentication decision.
 
-Do not expose these routes through a public ingress. They reveal aggregate
-capacity, topology, and process activity even though they do not reveal object
-keys, repositories, users, credentials, or presigned URLs.
+Keep these routes on an internal ingress. They reveal aggregate capacity,
+topology, backend kinds, and process activity, but never object keys,
+repositories, users, credentials, connection strings, or presigned URLs.
 
-## Endpoints
+## Common response contract
 
-| Endpoint | Scope |
+The server models these payloads as dedicated DTOs in an explicit `v1` module;
+they are not aliases of internal backend, database, or metrics structures. The
+`api_version` discriminator and the Rust module boundary therefore advance
+together. Pagination inputs are also distinct validated newtypes for page
+limits, prefixes, capabilities, cursor tokens, and cursor item keys. Cursor
+state uses the `OperationalState` enum rather than string comparison.
+
+Every successful response is JSON and contains:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `api_version` | string | API schema version. It is `"v1"` for these routes. |
+| `observed_at_unix_seconds` | unsigned integer | Wall-clock Unix second at which this process produced the snapshot. It is not a transaction or cluster timestamp. |
+
+Responses include `Cache-Control: no-store`, `X-Content-Type-Options: nosniff`,
+and a restrictive Content Security Policy. `GET` and the normal body-free
+`HEAD` behavior are read-only. `POST`, `PUT`, `PATCH`, `DELETE`, `CONNECT`, and
+`TRACE` do not reach mutation code and return `405`. Browser preflight may
+return `200`, but credentialed CORS is not enabled.
+
+Operational-state fields use exactly these values:
+
+| Value | Meaning |
 | --- | --- |
-| `GET /api/v1/status` | Current process durable/cache readiness, role, enabled frontends, and backend kinds |
-| `GET /api/v1/storage` | Authoritative CAS counts plus explicitly process-lifetime write counters |
-| `GET /api/v1/gc` | GC counters observed by this process and execution ownership |
-| `GET /api/v1/integrity` | Fsck counters observed by this process and execution ownership |
-| `GET /api/v1/nodes` | Current process health; cluster discovery capability |
-| `GET /api/v1/tasks` | Background scheduler capability and known tasks |
-| `GET /api/v1/replication` | Replication-controller capability and known replicas |
-| `GET /api/v1/metrics` | A bounded JSON snapshot of high-level process metrics |
-| `GET /api/v1/plugins` | Reserved typed plugin registry/health surface |
+| `ready` | The current process successfully checked the named dependency or capability. |
+| `degraded` | The current process checked it and the check failed. Internal failure details are withheld. |
+| `external` | Execution or coordination belongs to an operator or external system, not this server process. |
+| `unsupported` | This API version has no authoritative registry or discovery mechanism for it. |
 
-All successful responses contain `api_version: "v1"` and
-`observed_at_unix_seconds`. They return `Cache-Control: no-store`. `GET` and
-the normal body-free `HEAD` behavior are read-only; mutation methods return
-`405 Method Not Allowed`.
+The routes are mounted on `all`, `api`, and `transfer` runtime roles. Poll each
+process, or deploy an explicit aggregation layer, when a dashboard needs
+per-process or cluster-wide visibility.
 
-The routes are mounted on `all`, `api`, and `transfer` roles. A dashboard must
-poll each process or place an explicitly configured aggregation layer in front
-of them when it needs per-process visibility.
+## Endpoints and fields
 
-## State and consistency semantics
+### `GET /api/v1/status`
 
-The API distinguishes facts Shardline can authoritatively report from facts it
-does not own:
+| Field | Type | Scope and meaning |
+| --- | --- | --- |
+| `api_version` | string | Common field. |
+| `shardline_version` | string | Package version of this running binary. |
+| `observed_at_unix_seconds` | unsigned integer | Common field. |
+| `state` | operational state | Overall durable-backend readiness of this process. |
+| `durable_storage_state` | operational state | Readiness of the configured metadata and object backend combination. |
+| `cache_state` | operational state | Reconstruction-cache readiness when this role uses it; otherwise ready because it is outside this role's dependency set. |
+| `server_role` | string | Runtime role: `all`, `api`, or `transfer`. |
+| `server_frontends` | array of strings | Frontends enabled in this process, such as `xet`, `oci`, `s3`, `lfs`, `bazel`, or `hub`. |
+| `metadata_backend` | string | Configured metadata implementation name. No address or credentials are included. |
+| `object_backend` | string | Configured object-storage implementation name. No bucket, endpoint, or credentials are included. |
+| `cache_backend` | string | Configured reconstruction-cache implementation name. |
+| `plugin_registry` | operational state | `unsupported` until a server plugin registry exists. |
 
-- `ready` means the current process completed its backend readiness check.
-- `degraded` means that check failed. Internal backend errors are not returned.
-- `external` means execution or coordination is owned outside the server
-  process, such as CLI/CronJob GC and fsck or storage-provider replication.
-- `unsupported` means this version has no registry or discovery mechanism for
-  that field.
+### `GET /api/v1/storage`
 
-`storage.authoritative` comes from an admission-controlled inventory of the durable backend
-and includes total object count/physical bytes plus CAS chunk and file counts.
-Fields under `process_lifetime` are Prometheus counters for only the serving
-process and can reset on restart. Shardline does not yet retain authoritative
-logical input bytes across every replica, so `deduplication_ratio_state` is
-`unsupported` and `deduplication_ratio` is `null` rather than a misleading
-value derived from process-local counters.
+The authoritative inventory is admission-controlled with the same weighted
+limit as the authenticated statistics route.
 
-GC and fsck are currently operator-run commands, not server-owned background
-workers. Their endpoints therefore report `state: "external"`,
-`execution: "external"`, and expose only counters observed in the current process.
-Likewise, Shardline coordinates
-multiple writers over shared Postgres/object storage but does not own the
-storage provider's replication controller; `/api/v1/replication` reports that
-boundary explicitly.
+| Field | Type | Scope and meaning |
+| --- | --- | --- |
+| `api_version` | string | Common field. |
+| `observed_at_unix_seconds` | unsigned integer | Common field. |
+| `authoritative.objects` | unsigned integer | Objects in the configured durable object namespace. |
+| `authoritative.object_bytes` | unsigned integer | Physical bytes occupied by those objects. |
+| `authoritative.chunks` | unsigned integer | Stored CAS chunk objects. |
+| `authoritative.chunk_bytes` | unsigned integer | Physical bytes occupied by CAS chunks. |
+| `authoritative.files` | unsigned integer | Durable file records. |
+| `process_lifetime.objects_written` | unsigned integer | Successful object writes observed by this process since start. |
+| `process_lifetime.object_bytes_written` | unsigned integer | Object bytes written by this process since start. |
+| `process_lifetime.xorbs_written` | unsigned integer | Xorbs written by this process since start. |
+| `process_lifetime.xorb_bytes_written` | unsigned integer | Xorb bytes written by this process since start. |
+| `process_lifetime.shards_written` | signed integer | Shards written as reported by the process metric. |
+| `process_lifetime.deduplicated_bytes` | unsigned integer | Bytes avoided through deduplication by this process since start. |
+| `process_lifetime.compression_saved_bytes` | unsigned integer | Bytes avoided through compression by this process since start. |
+| `deduplication_ratio_state` | operational state | `unsupported` until logical input bytes are retained authoritatively across replicas. |
+| `deduplication_ratio` | object or null | Null while unsupported. A future object has `numerator_bytes`, `denominator_bytes`, and integer `basis_points`; clients must not synthesize it from process counters. |
 
-The plugin endpoint is part of the stable shape anticipated by the plugin
-architecture. Until a plugin registry exists, it returns `registry:
-"unsupported"` and an empty list. Future plugin entries will expose bounded
-IDs, versions, health, lifecycle state, and declared capabilities without
-granting plugins raw access to the administration API or durable stores.
+Authoritative fields describe current durable state. `process_lifetime` fields
+reset on restart and are not cluster totals.
+
+### `GET /api/v1/gc`
+
+| Field | Type | Scope and meaning |
+| --- | --- | --- |
+| `api_version`, `observed_at_unix_seconds` | common | Common fields. |
+| `state` | operational state | `external`: GC is currently operator-run. |
+| `execution` | operational state | `external`: this endpoint never starts or owns a GC run. |
+| `runs_observed_by_process` | unsigned integer | GC runs recorded in this process's lifetime metrics. |
+| `objects_collected_by_process` | unsigned integer | Objects reclaimed by those observed runs. |
+| `bytes_collected_by_process` | unsigned integer | Bytes reclaimed by those observed runs. |
+
+### `GET /api/v1/integrity`
+
+| Field | Type | Scope and meaning |
+| --- | --- | --- |
+| `api_version`, `observed_at_unix_seconds` | common | Common fields. |
+| `state` | operational state | `external`: integrity checking is operator-run. |
+| `execution` | operational state | `external`: this endpoint never starts or owns fsck. |
+| `fsck_runs_observed_by_process` | unsigned integer | Fsck runs recorded in this process's lifetime metrics. |
+| `errors_observed_by_process` | unsigned integer | Integrity errors recorded by those observed runs; it is not an unbounded error listing. |
+
+### `GET /api/v1/nodes`
+
+| Field | Type | Scope and meaning |
+| --- | --- | --- |
+| `api_version`, `observed_at_unix_seconds` | common | Common fields. |
+| `discovery` | operational state | `unsupported`: Shardline does not currently maintain a cluster member registry. |
+| `nodes` | array | The current process entry after filtering. |
+| `nodes[].scope` | string | Stable pagination key; currently `current_process`. It is not a hostname or secret-bearing pod identity. |
+| `nodes[].state` | operational state | Current process durable-backend readiness. |
+| `nodes[].server_role` | string | This entry's runtime role. |
+| `nodes[].server_frontends` | array of strings | Frontends enabled on this entry. |
+| `page` | page object | Cursor metadata described below. |
+
+### `GET /api/v1/tasks`
+
+| Field | Type | Scope and meaning |
+| --- | --- | --- |
+| `api_version`, `observed_at_unix_seconds` | common | Common fields. |
+| `scheduler` | operational state | `external`: scheduled maintenance belongs to an operator/CronJob. |
+| `tasks` | array | Empty until an authoritative bounded task registry exists. |
+| `tasks[].id` | string | Stable opaque task identifier and pagination key. |
+| `tasks[].state` | operational state | Task lifecycle/health state. |
+| `page` | page object | Cursor metadata described below. |
+
+### `GET /api/v1/metrics`
+
+| Field | Type | Scope and meaning |
+| --- | --- | --- |
+| `api_version`, `observed_at_unix_seconds` | common | Common fields. |
+| `prometheus_path` | string | Always `/metrics`; use it for full time-series scraping. |
+| `active_connections` | signed integer | Connections active in this process at observation time. |
+| `admitted_requests` | unsigned integer | Requests admitted during this process lifetime. |
+| `queued_requests` | unsigned integer | Requests queued during this process lifetime. |
+| `rejected_requests` | unsigned integer | Requests rejected by admission control during this process lifetime. |
+| `upload_requests` | unsigned integer | Upload requests observed during this process lifetime. |
+| `upload_bytes` | unsigned integer | Upload bytes observed during this process lifetime. |
+| `download_requests` | unsigned integer | Download requests observed during this process lifetime. |
+| `download_bytes` | unsigned integer | Download bytes observed during this process lifetime. |
+| `range_requests` | unsigned integer | Range requests observed during this process lifetime. |
+
+### `GET /api/v1/plugins`
+
+| Field | Type | Scope and meaning |
+| --- | --- | --- |
+| `api_version`, `observed_at_unix_seconds` | common | Common fields. |
+| `registry` | operational state | `unsupported` until the plugin registry exists. |
+| `plugins` | array | Empty while the registry is unsupported. |
+| `plugins[].id` | string | Stable bounded plugin identifier and pagination key. |
+| `plugins[].version` | string | Plugin implementation version. |
+| `plugins[].state` | operational state | Plugin lifecycle/health state. |
+| `plugins[].capabilities` | array of strings | Declared bounded capabilities, used by the `capability` exact-match filter. |
+| `page` | page object | Cursor metadata described below. |
+
+### `GET /api/v1/replication`
+
+| Field | Type | Scope and meaning |
+| --- | --- | --- |
+| `api_version`, `observed_at_unix_seconds` | common | Common fields. |
+| `state` | operational state | `external`: replication belongs to the configured storage provider. |
+| `coordinator` | operational state | `external`: Shardline has no asynchronous replication controller to report. |
+| `replicas` | array | Empty until an authoritative replication registry exists. |
+| `replicas[].id` | string | Stable opaque replica identifier and pagination key. |
+| `replicas[].state` | operational state | Replica health/lifecycle state. |
+| `page` | page object | Cursor metadata described below. |
+
+## Cursor pagination and filtering
+
+`nodes`, `tasks`, `plugins`, and `replication` are keyset-paginated. Other
+endpoints reject all query parameters.
+
+| Parameter | Applicable endpoints | Contract |
+| --- | --- | --- |
+| `limit` | all collections | Optional integer `1..=1000`; default `100`. |
+| `cursor` | all collections | Optional opaque URL-safe base64 cursor returned as `next_cursor`; maximum 1024 bytes. |
+| `state` | all collections | Exact operational-state match. |
+| `prefix` | all collections | Case-sensitive prefix of the stable item key; maximum 128 decoded bytes. |
+| `capability` | `plugins` only | Exact declared-capability match; non-empty and at most 128 decoded bytes. |
+
+Every collection contains:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `page.limit` | unsigned integer | Effective requested/default page size. |
+| `page.returned` | unsigned integer | Number of entries in this response. |
+| `page.next_cursor` | string or null | Pointer after the final returned key, or null when no later matching entry exists. |
+
+Pass the cursor back with the same filters:
+
+```bash
+curl -H "Authorization: Bearer $SHARDLINE_ADMIN_READ_TOKEN" \
+  'https://cas.example.com/api/v1/plugins?limit=100&state=ready&capability=storage.read'
+
+curl -H "Authorization: Bearer $SHARDLINE_ADMIN_READ_TOKEN" \
+  'https://cas.example.com/api/v1/plugins?limit=100&state=ready&capability=storage.read&cursor=...'
+```
+
+Cursors are versioned, integrity-checked structurally, and bound to `state`,
+`prefix`, and `capability`. Changing a bound filter, corrupting a cursor,
+repeating a parameter, using an unknown parameter, using invalid percent
+encoding/control characters, or exceeding the 4096-byte raw-query bound fails
+closed. Treat cursors as opaque, short-lived pointers, not durable bookmarks.
+
+Ordering is ascending by stable item key. Each request is a fresh snapshot;
+there is no transaction spanning pages. If a collection changes between page
+requests, deleted entries disappear and newly inserted entries whose keys sort
+at or before the cursor are not revisited. The current node collection is a
+single process entry, and the other registries are presently empty, but this
+contract applies when they gain entries.
+
+## Status and failure behavior
+
+| Status | Meaning |
+| --- | --- |
+| `200` | Authorized snapshot or browser preflight. |
+| `400` | Authorized request has an invalid, duplicate, unknown, polluted, or filter-incompatible query/cursor. |
+| `401` | API is enabled but bearer authentication is missing, malformed, duplicated, or wrong. |
+| `404` | API is disabled; route availability is concealed. |
+| `405` | The route does not support that method. |
+| `414` | Authorized raw query exceeds 4096 bytes. |
+| `503` | Weighted admission is saturated or a dependency is temporarily unavailable through a mapped retryable error. |
+| `500` | Sanitized unexpected backend failure; internal errors and secrets are not serialized. |
+
+A dependency outage changes readiness-bearing fields to `degraded`; it never
+weakens authentication. Authoritative storage inventory fails rather than
+returning stale or fabricated data. Process counters and external/unsupported
+capability responses remain available when they do not need the failed
+dependency. No endpoint triggers GC, repair, fsck, replication, plugin
+lifecycle, publication, or another durable transition.
+
+## Security threat model and verification
+
+The claim is coverage of vulnerability classes applicable to this API, with
+non-applicable classes stated explicitly—not a claim that testing can prove the
+absence of every future vulnerability.
+
+| Class | Control and test evidence |
+| --- | --- |
+| Broken authentication / authorization | Dedicated token, constant-time comparison, duplicate-header rejection, token-domain separation, disabled-route concealment, every endpoint and runtime role tested. |
+| Broken object/property authorization | No repository/object/user identifiers or caller-selected fields exist. Responses are one fixed operator-level projection behind one operator boundary. |
+| Injection (SQL/command/template/header) | Filters operate only on typed in-memory values; no query text reaches SQL, shells, templates, or response headers. SQL/XSS/CRLF payload regressions and arbitrary-string property/fuzz tests are included. |
+| XSS/content sniffing | JSON serialization, no reflection of filters, `nosniff`, and `default-src 'none'` CSP are tested on success and error paths. |
+| CSRF | Authentication is an explicit bearer header, not an ambient cookie, and no mutation method exists. Credentialed CORS is disabled. |
+| CORS abuse | Preflight is body-free and does not grant credentials. Operators must still restrict ingress and origins because a bearer explicitly supplied by application code remains a bearer. |
+| SSRF | No endpoint accepts URLs, hosts, callbacks, paths, or other outbound-request targets. |
+| Path traversal / file disclosure | No endpoint accepts filesystem or object paths, and backend names are fixed implementation identifiers. |
+| Request smuggling / method confusion | Duplicate authorization fails; ambiguous duplicate query fields fail; mutation and uncommon methods cannot reach handlers. HTTP framing remains the responsibility of the HTTP stack and ingress. |
+| Resource exhaustion | Query/filter/cursor/page bounds, bounded fixed projections, weighted storage admission, and request timeouts are exercised. No endpoint returns raw labels or unbounded identifiers. |
+| Sensitive-data exposure / caching | Fixed response DTOs omit keys, tenants, credentials, URLs, and backend errors. `no-store` and sanitized-outage regressions cover success and failure. |
+| Replay | Reads are idempotent snapshots; replay cannot mutate state. Bearer replay remains possible until token rotation, so protect transport and token files. |
+| Unsafe API consumption | The API consumes no third-party response or attacker-selected remote data. Backend failures are converted to bounded states or sanitized errors. |
+| Security misconfiguration / inventory | Disabled by default, explicit internal-ingress guidance, versioned `/api/v1`, strict TOML schema, Kubernetes secret projection, and manifest regression tests. |
+
+Use TLS at the ingress or service mesh. Token rotation is an operator action;
+the API intentionally does not expose a token-minting or rotation endpoint.
+
+## Durability, chaos, and fault evidence
+
+| Scenario | Required invariant |
+| --- | --- |
+| Concurrent polling and request cancellation | Bounded completion; no panic; durable inventory unchanged. |
+| Router/process restart after polling | Authoritative inventory is identical because reads create no durable API state. Process-lifetime counters may reset as documented. |
+| Postgres killed during an active upload | Status transitions `ready -> degraded -> ready`; invalid tokens remain rejected; malformed queries remain rejected; storage errors reveal no token, password, or connection string; acknowledged object bytes survive recovery. |
+| Dependency failure during storage inventory | Return a sanitized error, never fabricated or partial authoritative counts. |
+| Arbitrary query bytes | Deterministic parser/newtype result, no panic, bounded decode; covered by proptest and the `shardline_admin_api_query` libFuzzer target. |
+| Arbitrary versioned cursor DTO bytes | Deterministic deserialization and validation of typed state, prefix, capability, and item-key fields; covered by the `shardline_admin_api_v1_cursor` libFuzzer target. |
+| Authentication and query failure ordering | Disabled malformed requests remain `404`; unauthorized malformed requests remain `401`; only an authorized malformed request receives `400`. |
+| Security headers across failure states | `no-store`, `nosniff`, and restrictive CSP remain present on success, authentication failure, and disabled-route responses. |
+
+The deployment-chaos test is deterministic and part of the project's permanent
+chaos gate. Every discovered failure should be reduced to a replayable
+regression. Chaos and fuzzing provide strong evidence; they do not
+mathematically prove correctness.
 
 ## Compatibility contract
 
 Within `/api/v1`, existing field meanings and enum values are not changed or
 removed in a patch or minor release. New fields and endpoints may be added, so
 clients must ignore unknown object fields. A semantic break requires a new API
-version. Numeric counters are JSON integers and may increase between polls or
-reset when explicitly documented as process-lifetime values.
-
-Responses are bounded: there are no caller-selected page sizes, unbounded
-queries, raw labels, or arbitrary object identifiers. `/api/v1/storage` uses
-the same weighted admission control as the authenticated stats route, so
-monitoring pressure cannot bypass normal request limits.
-
-## Failure behavior
-
-- A dependency outage changes readiness-bearing responses to `degraded`; it
-  does not weaken authentication.
-- A saturated storage-stat request returns `503` rather than waiting without a
-  bound.
-- A failed authoritative storage query returns a sanitized server error rather
-  than stale or fabricated data.
-- Process counters and unsupported/external capability responses remain
-  available when they do not require the failed dependency.
-- Every response is a snapshot. No endpoint triggers GC, repair, fsck,
-  replication, plugin lifecycle, or another state transition.
-
-The deterministic deployment-chaos gate polls this API before, during, and
-after a Postgres kill. It requires `ready -> degraded -> ready`, bounded HTTP
-completion, secret-free responses, `no-store` cache policy, and continued
-rejection of an invalid token throughout the outage.
+version and a new DTO module rather than reinterpreting the v1 types. Numeric
+counters are JSON integers and can increase between polls or reset only where
+documented as process-lifetime values.
 
 For Prometheus/OpenMetrics scraping, continue to use `GET /metrics` and its
-separate `SHARDLINE_METRICS_TOKEN[_FILE]` secret. The JSON metrics endpoint is
-intended for dashboard summaries, not as a replacement for time-series
-collection.
+separate `SHARDLINE_METRICS_TOKEN[_FILE]` secret. The JSON endpoint is a bounded
+dashboard summary, not a replacement for time-series collection.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -462,6 +462,12 @@ Shardline uses `tracing` for structured logging and `prometheus` for metrics.
 
 Token-gated in production via `SHARDLINE_METRICS_TOKEN_FILE`.
 
+The core server also owns a separately authenticated, versioned read-only
+administration contract under `/api/v1/*`. It exposes bounded operational
+snapshots to external dashboards without granting mutation authority or direct
+database/object-store access. See
+[Read-Only Administration API](ADMIN_READ_API.md).
+
 ## Database Migrations
 
 Shardline ships 18 bundled migrations applied via `shardline db migrate up`:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -235,6 +235,12 @@ Set `SHARDLINE_METRICS_TOKEN_FILE` in production so the route requires
 `Authorization: Bearer <metrics-token>`. `/readyz` is for Kubernetes probes and
 service-local diagnostics, not public ingress.
 
+The versioned read-only administration routes under `/api/v1/*` are disabled
+unless `SHARDLINE_ADMIN_READ_TOKEN` or `SHARDLINE_ADMIN_READ_TOKEN_FILE` is set.
+Keep them on an internal operator endpoint. See
+[Read-Only Administration API](ADMIN_READ_API.md) for their security and
+consistency contract.
+
 ## Container Requirements
 
 The container image:
@@ -296,6 +302,7 @@ server_role = "all"
 frontends = ["xet", "oci", "hub"]
 root_dir = "/var/lib/shardline"
 chunk_size_bytes = 65536
+admin_read_token_path = "/run/secrets/shardline-admin-read-token"
 
 [storage]
 adapter = "s3"
@@ -357,6 +364,7 @@ SHARDLINE_MAX_SHARD_RECONSTRUCTION_TERMS=65536
 SHARDLINE_MAX_SHARD_XORB_CHUNKS=65536
 SHARDLINE_TOKEN_SIGNING_KEY_FILE=/run/secrets/shardline-token-key
 SHARDLINE_METRICS_TOKEN_FILE=/run/secrets/shardline-metrics-token
+SHARDLINE_ADMIN_READ_TOKEN_FILE=/run/secrets/shardline-admin-read-token
 SHARDLINE_PROVIDER_CONFIG_FILE=/etc/shardline/providers.json
 SHARDLINE_PROVIDER_API_KEY_FILE=/run/secrets/shardline-provider-key
 SHARDLINE_PROVIDER_TOKEN_ISSUER=shardline-provider
@@ -922,6 +930,11 @@ full procedure, recommended order, and rollback steps.
 `GET /metrics` emits Prometheus text format.
 When `SHARDLINE_METRICS_TOKEN_FILE` is set, the endpoint rejects unauthenticated scrape
 requests and requires `Authorization: Bearer <metrics-token>`.
+
+For bounded JSON snapshots suitable for dashboards, configure the separate
+`SHARDLINE_ADMIN_READ_TOKEN_FILE` secret and use the
+[read-only administration API](ADMIN_READ_API.md). The two tokens are not
+interchangeable.
 
 50+ metrics across 9 categories:
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -39,6 +39,16 @@ The production Kubernetes package already follows that model:
 - topology spread across nodes
 - externalized S3, Postgres, and Redis-cache dependencies
 
+## Read-only operational API
+
+External dashboards and operators can consume versioned JSON snapshots without
+embedding a management UI in Shardline. Configure the dedicated admin-read
+token and keep `/api/v1/*` on an internal endpoint. These routes report storage,
+GC, integrity, node, task, replication, metrics, and future plugin state; they
+never start or mutate an operation. See
+[Read-Only Administration API](ADMIN_READ_API.md) for endpoint schemas,
+authentication, and cluster/process consistency semantics.
+
 ## Scaling Model
 
 Shardline scales by separating control-plane traffic from transfer traffic.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ docs that match your use case.
 - [Compatibility Status](COMPATIBILITY_STATUS.md)
 - [Stability Graduation Policy](STABILITY_GRADUATION.md)
 - [CLI](CLI.md)
+- [Read-Only Administration API](ADMIN_READ_API.md)
 
 ## Setup And Rollout
 

--- a/docs/SYSTEMD.md
+++ b/docs/SYSTEMD.md
@@ -123,6 +123,7 @@ SHARDLINE_RECONSTRUCTION_CACHE_ADAPTER=redis
 SHARDLINE_RECONSTRUCTION_CACHE_REDIS_URL=redis://default:replace-me@garnet.example.com:6379
 SHARDLINE_TOKEN_SIGNING_KEY_FILE=/etc/shardline/token-signing-key
 SHARDLINE_METRICS_TOKEN_FILE=/etc/shardline/metrics-token
+SHARDLINE_ADMIN_READ_TOKEN_FILE=/etc/shardline/admin-read-token
 SHARDLINE_PROVIDER_CONFIG_FILE=/etc/shardline/providers.json
 SHARDLINE_PROVIDER_API_KEY_FILE=/etc/shardline/provider-api-key
 ```

--- a/docs/k8s/README.md
+++ b/docs/k8s/README.md
@@ -184,6 +184,10 @@ The example does not expose `/metrics` on the public ingress.
 Scrape it through the API Service or an internal monitoring ingress.
 The production manifests configure `SHARDLINE_METRICS_TOKEN_FILE`, so scrapers must send
 `Authorization: Bearer <metrics-token>` when reading `/metrics`.
+They also configure `SHARDLINE_ADMIN_READ_TOKEN_FILE` on both runtime roles for
+the versioned `/api/v1/*` operational snapshots. Keep these routes internal and
+use the distinct admin-read token; see
+[Read-Only Administration API](../ADMIN_READ_API.md).
 
 ## Scaling
 

--- a/docs/k8s/production-scaled/api-deployment.yaml
+++ b/docs/k8s/production-scaled/api-deployment.yaml
@@ -66,6 +66,8 @@ spec:
               value: /run/secrets/shardline/token-signing-key
             - name: SHARDLINE_METRICS_TOKEN_FILE
               value: /run/secrets/shardline/metrics-token
+            - name: SHARDLINE_ADMIN_READ_TOKEN_FILE
+              value: /run/secrets/shardline/admin-read-token
             - name: SHARDLINE_PROVIDER_API_KEY_FILE
               value: /run/secrets/shardline/provider-api-key
             - name: SHARDLINE_PROVIDER_CONFIG_FILE
@@ -118,6 +120,8 @@ spec:
               value: /run/secrets/shardline/token-signing-key
             - name: SHARDLINE_METRICS_TOKEN_FILE
               value: /run/secrets/shardline/metrics-token
+            - name: SHARDLINE_ADMIN_READ_TOKEN_FILE
+              value: /run/secrets/shardline/admin-read-token
             - name: SHARDLINE_PROVIDER_API_KEY_FILE
               value: /run/secrets/shardline/provider-api-key
             - name: SHARDLINE_PROVIDER_CONFIG_FILE
@@ -185,6 +189,8 @@ spec:
                 path: token-signing-key
               - key: metrics-token
                 path: metrics-token
+              - key: admin-read-token
+                path: admin-read-token
               - key: provider-api-key
                 path: provider-api-key
               - key: config-secret-key

--- a/docs/k8s/production-scaled/runtime-secret.template.yaml
+++ b/docs/k8s/production-scaled/runtime-secret.template.yaml
@@ -11,6 +11,7 @@ stringData:
   s3-secret-access-key: replace-me
   token-signing-key: replace-me
   metrics-token: replace-me
+  admin-read-token: replace-me
   provider-api-key: replace-me
   # 32-byte AES-256 at-rest encryption key for provider-config webhook secrets
   # (SHARDLINE_CONFIG_SECRET_KEY). Generate one with, e.g.:

--- a/docs/k8s/production-scaled/transfer-deployment.yaml
+++ b/docs/k8s/production-scaled/transfer-deployment.yaml
@@ -68,6 +68,8 @@ spec:
               value: /run/secrets/shardline/token-signing-key
             - name: SHARDLINE_METRICS_TOKEN_FILE
               value: /run/secrets/shardline/metrics-token
+            - name: SHARDLINE_ADMIN_READ_TOKEN_FILE
+              value: /run/secrets/shardline/admin-read-token
           volumeMounts:
             - name: config
               mountPath: /etc/shardline
@@ -118,6 +120,8 @@ spec:
               value: /run/secrets/shardline/token-signing-key
             - name: SHARDLINE_METRICS_TOKEN_FILE
               value: /run/secrets/shardline/metrics-token
+            - name: SHARDLINE_ADMIN_READ_TOKEN_FILE
+              value: /run/secrets/shardline/admin-read-token
           volumeMounts:
             - name: config
               mountPath: /etc/shardline
@@ -176,6 +180,8 @@ spec:
                 path: token-signing-key
               - key: metrics-token
                 path: metrics-token
+              - key: admin-read-token
+                path: admin-read-token
               - key: s3-access-key-id
                 path: s3-access-key-id
               - key: s3-secret-access-key

--- a/tests/k8s/kind/dependencies.yaml
+++ b/tests/k8s/kind/dependencies.yaml
@@ -16,6 +16,7 @@ stringData:
   s3-secret-access-key: kind-smoke-minio-secret
   token-signing-key: kind-smoke-token-signing-key-at-least-32-bytes
   metrics-token: kind-smoke-metrics-token
+  admin-read-token: kind-smoke-admin-read-token
   provider-api-key: kind-smoke-provider-key
   config-secret-key: 0123456789abcdef0123456789abcdef
 ---


### PR DESCRIPTION
## Description

Adds a separately authenticated, versioned, read-only administration API for dashboards and operator tooling. It exposes bounded JSON snapshots for runtime health, authoritative physical storage inventory, GC and integrity observations, node-local status, external task/replication ownership, process metrics, and the future plugin-registry shape.

The API is disabled by default and available on every runtime role at `/api/v1/*`. Response DTOs live in an explicit `admin_api::v1` module, and unavailable cluster-wide facts remain honestly represented as `unsupported` or `external`.

## Changes

Detailed list of what changed:

- Adds GET/HEAD-only `/api/v1/status`, `storage`, `gc`, `integrity`, `nodes`, `tasks`, `metrics`, `plugins`, and `replication` handlers.
- Adds dedicated v1 response DTOs, typed `OperationalState`, and validated newtypes for page limits, prefixes, capabilities, cursor tokens, and cursor item keys.
- Adds keyset/cursor pagination to `nodes`, `tasks`, `plugins`, and `replication`; supports bounded `limit`, typed `state`, key `prefix`, and plugin `capability` filters where applicable.
- Binds opaque cursors to their filters, rejects duplicate/unknown/polluted parameters, invalid percent/UTF-8 encoding, invalid state, forged DTO shape, and over-limit query/cursor/filter values.
- Adds the redacted `AdminReadToken` newtype, constant-time bearer authorization, duplicate-header rejection, strict token validation, token-domain separation, and concealed `404` behavior while disabled.
- Extends authoritative backend inventory with total object count and bytes for local and Postgres/S3 deployments.
- Supports `SHARDLINE_ADMIN_READ_TOKEN`, `SHARDLINE_ADMIN_READ_TOKEN_FILE`, and `[server].admin_read_token_path` in `shardline.toml`; inline TOML secrets remain intentionally unsupported.
- Adds `no-store`, `nosniff`, restrictive CSP, method-confusion tests, fixed JSON projections, sanitized failures, and an explicit applicable/non-applicable vulnerability matrix.
- Adds cancellation/restart durability tests, concurrent polling, arbitrary-input property tests, and separate query and v1 cursor DTO libFuzzer targets.
- Strengthens the real Postgres-kill drill with malformed-query rejection, sanitized authoritative-inventory failure, fail-closed authentication, and `ready -> degraded -> ready` recovery.
- Projects the dedicated admin token into both scaled Kubernetes roles and verifies the manifest/secret contract.
- Documents every response field, state, pagination/filter rule, error status, consistency boundary, compatibility rule, security control, and chaos invariant.

For cross-crate or runtime changes, include:

- Affected crates: `shardline-server`, `shardline` integration tests, and `fuzz`.
- Cross-crate interaction changes: `ServerStatsResponse` gains additive `objects` and `object_bytes` fields populated by both backend implementations.
- Migration or rollout requirements: no database migration. The API remains disabled until a dedicated token source is configured. Scaled deployments should create the `admin-read-token` runtime-secret key before rolling out the updated manifests.

## Motivation

Business or operator motivation:

Users need a stable, non-destructive API for dashboards and operational integrations without granting mutation access, shell access, repository credentials, or the raw Prometheus token.

Technical motivation:

Shardline already owns authoritative backend health and inventory data, but it was spread across health routes, metrics, and maintenance commands. A versioned DTO boundary makes those observations consumable without coupling clients to internal database/backend structures. Bounded cursor pagination and typed filtering keep future registries scalable without creating an unbounded query surface.

Alternative approaches considered:

- Reusing the metrics token was rejected because administration and scraping credentials need independent least-privilege and rotation boundaries.
- Accepting an inline TOML secret was rejected to avoid storing bearer material in ordinary configuration.
- Offset pagination was rejected because keyset pointers behave more predictably as registries grow and change.
- Raw string matching for cursor state and filters was replaced with enums/newtypes so validation invariants are explicit and fuzzable.
- Inferring cluster-wide state from one process was rejected because it would become incorrect after restarts or with multiple replicas.
- Mutation endpoints were rejected because issue #45 calls for a read-only operator surface.

## Scope and impact

- Affected crates: `shardline-server`, `shardline` integration tests, `fuzz`.
- Protocol or API changes: additive versioned JSON endpoints under `/api/v1/*`; existing data protocol routes are unchanged.
- Backward compatibility: additive and disabled by default. Existing deployments behave as before. Existing stats JSON receives two additive fields. Within v1, clients must ignore additive unknown fields; semantic breaks require a new URL and DTO version.
- Performance impact: lightweight responses are fixed and bounded. `/api/v1/storage` performs an authoritative inventory and is protected by weighted admission control. Collection pages default to 100 and cap at 1000.
- Security impact: dedicated constant-time bearer boundary, redacted token, bounded parsing, duplicate credential/query rejection, no mutation methods, cache/security headers on success and error paths, sanitized backend failures, and explicit threat-model coverage.
- Operational impact: optional new secret file. Kubernetes examples wire it to both scaled roles. GC/fsck/task/replication ownership remains external and is reported as such.

## Testing

- [x] Unit tests
- [x] Integration tests
- [x] Manual verification
- [ ] Performance checks (not a data-path change; response/page bounds and storage admission are regression-tested)
- [x] Security checks

Commands/results:

```bash
cargo make ci
# passed: formatting, clippy -D warnings, dependency policy, workspace library tests,
# release-binary verification, and migration synchronization

cargo make test-e2e
# 492 passed, 4 skipped

cargo make coverage-check
# 92.8989% line coverage; 92.8000% ratchet passed
# includes 13/13 deployment-chaos drills, deterministic chaos, fault drills,
# multi-node/Postgres/security matrices, and integration suites

cargo test -p shardline-server admin_api --all-features
# 21 passed

cargo check --manifest-path crates/fuzz/Cargo.toml \
  --bin shardline_admin_api_query --bin shardline_admin_api_v1_cursor
# passed

cargo +nightly fuzz run shardline_admin_api_query --fuzz-dir crates/fuzz \
  -- -max_total_time=10 -timeout=5
# 1,662,276 executions; no crash

cargo +nightly fuzz run shardline_admin_api_v1_cursor --fuzz-dir crates/fuzz \
  -- -max_total_time=10 -timeout=5
# 1,043,081 executions; no crash
```

## Related issues and documentation

- Fixes: #45
- Related: the future plugin architecture is represented by an explicitly unsupported empty registry until an authoritative registry exists.
- Architecture docs: `docs/ARCHITECTURE.md`
- Protocol docs: no data-protocol semantics changed.
- Security/invariants docs: `docs/ADMIN_READ_API.md` contains the field-level API, pagination, threat, durability, and compatibility contract.
- Operations/runbook updates: `docs/OPERATIONS.md`, `docs/DEPLOYMENT.md`, `docs/SYSTEMD.md`, and `docs/k8s/README.md`.

## Reviewer checklist

- [ ] Code follows project standards and crate-boundary constraints
- [ ] Tests added or updated and passing
- [ ] Documentation updated where behavior or config changed
- [ ] No undocumented breaking change
- [ ] Performance trade-offs documented where relevant
- [ ] Security considerations addressed where relevant

## Additional notes

The API is evidence-conservative. `unsupported` means Shardline has no authoritative source for that datum; `external` means an operator, CronJob, or storage provider owns it. It does not invent cluster discovery, replication lag, task history, or a cluster-wide deduplication ratio from process-local metrics.

The security claim is scoped to vulnerability classes applicable to this read-only API, with non-applicable classes documented explicitly. Fuzzing and chaos provide strong evidence, not a mathematical proof of absence of vulnerabilities.
