### PR TITLE
chore(release): prepare v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-09-07
+
+Comprehensive security-hardening release that also ships the new read-only
+administration API. An adversarial audit cycle closed findings across
+authentication, the Git/Hub/LFS protocol surfaces, storage, configuration, and
+the reference Kubernetes deployment — constant-time credential checks,
+checked-arithmetic overflow fixes, symlink/TOCTOU hardening, disclosure
+reduction on `/readyz` and error paths, and stronger deployment defaults
+(mandatory OIDC audience, enforced 16-byte provider bootstrap keys,
+CORS-restricted admin surface, per-endpoint `Cache-Control`). The administration
+API is disabled by default and additive; operator-visible behavioral changes are
+listed under *Changed* — notably `/readyz` is now health-only by design.
+
 ### Added
 
 - Add a disabled-by-default, versioned read-only administration API for storage,
@@ -24,8 +37,91 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   polling cannot mutate inventory, and dedicated property and fuzz targets cover
   both the strict TOML secret-file setting and administration query parser plus
   versioned cursor DTO/newtype deserialization.
+- The authenticated admin status endpoint (`/api/v1/status`) exposes runtime
+  topology (server role, enabled frontends, and metadata/object/cache backend
+  identities) that the unauthenticated `/readyz` previously disclosed.
 - Extend storage statistics with authoritative total object count and physical
   object bytes while preserving the existing CAS chunk/file counters.
+- Hub repository search implements an `author` filter (`{author}/` repo-id
+  prefix match) instead of rejecting the query parameter.
+
+### Changed
+
+- `/readyz` is now health-only and returns `{"status": "ok"}`. Runtime topology
+  is no longer served without authentication; it is available on the
+  authenticated admin `/api/v1/status` endpoint. Integration and e2e assertions
+  were re-routed accordingly.
+- CORS: the admin surface (`/api/v1/*`) no longer emits
+  `Access-Control-Allow-Origin`, making it same-origin only. Non-admin routes
+  reflect the requesting origin and restore the full method set
+  (`GET/HEAD/POST/PUT/PATCH/DELETE`, needed for LFS/OCI uploads).
+- HSTS now includes the `includeSubDomains` directive.
+- All authenticated endpoints send `Cache-Control: private, no-store`, preventing
+  CDN/proxy caching of sensitive responses.
+- OIDC `audience` is now mandatory at startup (fail closed); tokens minted for
+  unrelated services at the same issuer are refused.
+- Provider bootstrap API keys shorter than 16 bytes are rejected at startup
+  (previously only a warning).
+- The passthrough provider is rejected unless `deployment_mode` is `insecure`;
+  `Passthrough + Authenticated` remains the documented trusted-proxy carve-out,
+  while `Passthrough + Strict` is refused by config validation.
+- The reference Kubernetes manifests no longer mount the token-signing-key into
+  the GC CronJob (reduced blast radius), and the egress NetworkPolicy template
+  requirement is documented.
+- Secret-file mode policy permits owner/group-readable modes
+  (`0600`/`0640`/`0440`) and rejects only world-readable files — matching the
+  `defaultMode: 0440` + `fsGroup` Kubernetes deployment model. Config-file
+  loading accepts Kubernetes `..data` symlink projections that resolve inside
+  the config directory; symlinks escaping the directory are still refused, with
+  `O_NOFOLLOW` on the resolved path closing the TOCTOU window.
+- Hub repository search enforces a 200-character query limit, and the Hub Host
+  header is sanitized when building repository URLs.
+
+### Fixed
+
+- Git LFS batch responses return the real token expiration from the issued
+  claims instead of a hard-coded `TOKEN_EXPIRATION = 0`.
+- Resumable-session state machine corrections: completion failures transition
+  to Aborted/Expired (the invalid Completing → Active edge was removed), and
+  Aborted/Expired sessions can be retried after operator intervention.
+- `collect_digest_refs` regression test updated for the corrected
+  non-early-return behavior.
+
+### Security
+
+- **Constant-time credential comparison**: provider API-key validation no longer
+  leaks key length through a timing side channel.
+- **Checked-arithmetic overflow fixes**: Git pack `ofs_delta` offset parsing and
+  `xet-core` bounds checks use checked arithmetic with a varint byte cap,
+  closing crafted-input integer overflows; a duplicate bitwise OR in
+  `ofs_delta_offset` was removed.
+- **Decompression-bomb fix**: the LZ4 size prefix is read in full (8 bytes)
+  before allocation, closing the u32-truncation bypass of the size guard.
+- **Content-hash verification** for `FixedChunkV1` downloads prevents silent
+  delivery of corrupted storage objects.
+- **Path traversal**: git tree entries containing `..`, `.`, NUL, or control
+  characters are rejected; symlinked backup outputs are refused; secret and
+  config files must resolve within their parent directory.
+- **TOCTOU/race hardening**: config reads open the resolved path with
+  `O_NOFOLLOW`; copy and upload-shard metadata commits are wrapped in
+  `metadata_write_lock`; the delete-file reference race is documented with its
+  hash-check mitigation.
+- **Retention safety**: lifecycle repair never removes permanent
+  (`release_after = None`) retention holds, even when an object is temporarily
+  missing.
+- **Webhook signing**: all VCS adapters warn loudly when the webhook secret is
+  unconfigured (signature verification would be skipped); the at-rest cipher
+  strips a legacy `sse1:` prefix from the plaintext fallback so HMACs are
+  computed over the correct bytes.
+- **Disclosure reduction**: `/readyz` no longer leaks topology; signing-key and
+  provider errors return a generic message to clients (JWKS `kid`, OIDC issuer
+  URLs, and key paths are logged at warn level only).
+- **Hardening defaults**: `deny_unknown_fields` on the OIDC config section, Hub
+  LFS upload bodies capped at 64 MiB, commit messages capped at 4096 bytes
+  (NDJSON and git protocol), Hub webhook LIKE filters escape `%` and `_`
+  (Postgres + SQLite), S3 startup warns when `allow_http = true`, JWKS
+  cache-lock waits no longer block Tokio workers, and the admin read token
+  SHA-256 digest is precomputed once at config load.
 
 ## [1.8.0] - 2026-08-25
 
@@ -894,7 +990,12 @@ There are no intentional breaking API or configuration changes from `1.0.0`.
 - Documented async storage TOCTOU races with 1.2M-run fuzz validation (`40ef000`)
 - Updated all architecture, deployment, and Hub API docs for 20-crate structure (`1203d8e`)
 
-[Unreleased]: https://github.com/STEXS-Technologies/shardline/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/STEXS-Technologies/shardline/compare/v1.9.0...HEAD
+[1.9.0]: https://github.com/STEXS-Technologies/shardline/compare/v1.8.0...v1.9.0
+[1.8.0]: https://github.com/STEXS-Technologies/shardline/compare/v1.7.0...v1.8.0
+[1.7.0]: https://github.com/STEXS-Technologies/shardline/compare/v1.6.0...v1.7.0
+[1.6.0]: https://github.com/STEXS-Technologies/shardline/compare/v1.5.0...v1.6.0
+[1.5.0]: https://github.com/STEXS-Technologies/shardline/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/STEXS-Technologies/shardline/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/STEXS-Technologies/shardline/compare/v1.2.2...v1.3.0
 [1.2.2]: https://github.com/STEXS-Technologies/shardline/compare/v1.2.1...v1.2.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3147,7 +3147,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdx"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3364,7 +3364,7 @@ dependencies = [
 
 [[package]]
 name = "shardline"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "axum",
  "bytes",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-auth"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-bench"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "bytes",
  "criterion",
@@ -3428,7 +3428,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-cache"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "criterion",
  "getrandom 0.3.4",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-cas"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -3458,7 +3458,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-fsck"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "lz4_flex 0.11.6",
  "rusqlite",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-gc"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "async-trait",
  "proptest",
@@ -3534,7 +3534,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-hub-api"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-index"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3603,7 +3603,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-metrics"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "axum",
  "futures-util",
@@ -3615,7 +3615,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-oci-adapter"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3635,7 +3635,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-protocol"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "criterion",
  "hex",
@@ -3650,7 +3650,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-protocol-adapters"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "hex",
  "serde",
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-provider-events"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "serde_json",
  "shardline-index",
@@ -3683,7 +3683,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-rebuild"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "rusqlite",
  "serde",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-s3-adapter"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "axum",
  "base64",
@@ -3724,7 +3724,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-server"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3791,7 +3791,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-server-core"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3815,7 +3815,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-storage"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -3836,7 +3836,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-test-support"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "libc",
  "tempfile",
@@ -3845,14 +3845,14 @@ dependencies = [
 
 [[package]]
 name = "shardline-validation"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "shardline-vcs"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "hex",
  "hmac",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-xet-adapter"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "axum",
  "criterion",
@@ -3883,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-xet-core"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "blake3",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = ["crates/*"]
 # - getrandom: duplicate (0.3 workspace, older via xet ecosystem) — NOT FIXABLE.
 
 [workspace.package]
-version = "1.8.0"
+version = "1.9.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/STEXS-Technologies/shardline"
@@ -52,30 +52,30 @@ serde_json = "1.0"
 sha1 = "0.10"
 sha2 = { version = "0.10", features = ["compress"] }
 md-5 = { version = "0.10", features = ["std"] }
-shardline = { version = "1.8.0", path = "crates/shardline" }
-shardline-cache = { version = "1.8.0", path = "crates/shardline-cache" }
-shardline-cas = { version = "1.8.0", path = "crates/shardline-cas" }
-shardline-fsck = { version = "1.8.0", path = "crates/shardline-fsck" }
-shardline-gc = { version = "1.8.0", path = "crates/shardline-gc" }
-shardline-hub-api = { version = "1.8.0", path = "crates/shardline-hub-api" }
-shardline-index = { version = "1.8.0", path = "crates/shardline-index" }
-shardline-metrics = { version = "1.8.0", path = "crates/shardline-metrics" }
-shardline-protocol = { version = "1.8.0", path = "crates/shardline-protocol" }
-shardline-protocol-adapters = { version = "1.8.0", path = "crates/shardline-protocol-adapters" }
-shardline-rebuild = { version = "1.8.0", path = "crates/shardline-rebuild" }
-shardline-provider-events = { version = "1.8.0", path = "crates/shardline-provider-events" }
-shardline-oci-adapter = { version = "1.8.0", path = "crates/shardline-oci-adapter" }
-shardline-s3-adapter = { version = "1.8.0", path = "crates/shardline-s3-adapter" }
-shardline-server = { version = "1.8.0", path = "crates/shardline-server" }
-shardline-server-core = { version = "1.8.0", path = "crates/shardline-server-core" }
-shardline-storage = { version = "1.8.0", path = "crates/shardline-storage" }
-shardline-test-support = { version = "1.8.0", path = "crates/shardline-test-support" }
-shardline-validation = { version = "1.8.0", path = "crates/shardline-validation" }
-shardline-auth = { version = "1.8.0", path = "crates/shardline-auth" }
-shardline-vcs = { version = "1.8.0", path = "crates/shardline-vcs" }
-shardline-xet-adapter = { version = "1.8.0", path = "crates/shardline-xet-adapter" }
-shardline-xet-core = { version = "1.8.0", path = "crates/shardline-xet-core" }
-sdx = { version = "1.8.0", path = "crates/sdx" }
+shardline = { version = "1.9.0", path = "crates/shardline" }
+shardline-cache = { version = "1.9.0", path = "crates/shardline-cache" }
+shardline-cas = { version = "1.9.0", path = "crates/shardline-cas" }
+shardline-fsck = { version = "1.9.0", path = "crates/shardline-fsck" }
+shardline-gc = { version = "1.9.0", path = "crates/shardline-gc" }
+shardline-hub-api = { version = "1.9.0", path = "crates/shardline-hub-api" }
+shardline-index = { version = "1.9.0", path = "crates/shardline-index" }
+shardline-metrics = { version = "1.9.0", path = "crates/shardline-metrics" }
+shardline-protocol = { version = "1.9.0", path = "crates/shardline-protocol" }
+shardline-protocol-adapters = { version = "1.9.0", path = "crates/shardline-protocol-adapters" }
+shardline-rebuild = { version = "1.9.0", path = "crates/shardline-rebuild" }
+shardline-provider-events = { version = "1.9.0", path = "crates/shardline-provider-events" }
+shardline-oci-adapter = { version = "1.9.0", path = "crates/shardline-oci-adapter" }
+shardline-s3-adapter = { version = "1.9.0", path = "crates/shardline-s3-adapter" }
+shardline-server = { version = "1.9.0", path = "crates/shardline-server" }
+shardline-server-core = { version = "1.9.0", path = "crates/shardline-server-core" }
+shardline-storage = { version = "1.9.0", path = "crates/shardline-storage" }
+shardline-test-support = { version = "1.9.0", path = "crates/shardline-test-support" }
+shardline-validation = { version = "1.9.0", path = "crates/shardline-validation" }
+shardline-auth = { version = "1.9.0", path = "crates/shardline-auth" }
+shardline-vcs = { version = "1.9.0", path = "crates/shardline-vcs" }
+shardline-xet-adapter = { version = "1.9.0", path = "crates/shardline-xet-adapter" }
+shardline-xet-core = { version = "1.9.0", path = "crates/shardline-xet-core" }
+sdx = { version = "1.9.0", path = "crates/sdx" }
 sqlx = { version = "0.8.6", default-features = false }
 subtle = { version = "2.6", default-features = false }
 tempfile = "3.15"

--- a/e2e/Cargo.lock
+++ b/e2e/Cargo.lock
@@ -2956,7 +2956,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-auth"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-cache"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "getrandom 0.3.4",
  "hex",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-cas"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "async-trait",
  "shardline-index",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-fsck"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "lz4_flex 0.11.6",
  "serde_json",
@@ -3046,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-gc"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-hub-api"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-index"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3117,7 +3117,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-metrics"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "axum",
  "futures-util",
@@ -3128,7 +3128,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-oci-adapter"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-protocol"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "hex",
  "hmac",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-protocol-adapters"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "hex",
  "serde",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-provider-events"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "serde_json",
  "shardline-index",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-rebuild"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-s3-adapter"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "axum",
  "base64",
@@ -3224,7 +3224,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-server"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "axum",
  "base64",
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-server-core"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-storage"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-test-support"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "libc",
  "tempfile",
@@ -3322,14 +3322,14 @@ dependencies = [
 
 [[package]]
 name = "shardline-validation"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "shardline-vcs"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "hex",
  "hmac",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-xet-adapter"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "axum",
  "serde",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-xet-core"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "blake3",
  "bytes",


### PR DESCRIPTION
## Description

Security-hardening release (v1.9.0). Ships the new read-only administration API and closes an adversarial audit cycle across authentication, the Git/Hub/LFS protocol surfaces, storage, configuration, and the reference Kubernetes deployment. Bumps the workspace to v1.9.0.

## Changes

### Version bump
- `Cargo.toml`: 1.8.0 -> 1.9.0 (workspace + 24 dependency refs)
- `Cargo.lock`, `e2e/Cargo.lock`: updated all workspace crate versions

### Changelog
- Finalized `[Unreleased]` to `[1.9.0] - 2026-09-07` with release description
- New `Added`/`Changed`/`Fixed`/`Security` sections covering the admin API, `/readyz` health-only change, CORS/OIDC/API-key hardening, and the audit-cycle fixes
- Added the missing 1.5.0-1.8.0 footer compare-links and repointed `[Unreleased]` at `v1.9.0...HEAD`

## Motivation

This is the v1.9.0 release preparation. The code changes were merged in prior PRs (#52 admin read-only API, #54 comprehensive security hardening). The changelog captures the operator-visible behavioral changes:
- `/readyz` is now health-only (`{"status": "ok"}`); runtime topology moved behind the authenticated admin `/api/v1/status`
- OIDC `audience` is mandatory at startup; provider bootstrap keys < 16 bytes rejected
- CORS-restricted admin surface, per-endpoint `Cache-Control`, HSTS `includeSubDomains`
- Secret/config-file policy aligned with the Kubernetes `defaultMode: 0440` + `fsGroup` / `..data` projection model

## Scope and impact

- Affected crates: all workspace crates (version bump)
- Backward compatible: yes - version bump only, no API changes in this PR
- Operator note: `/readyz` no longer returns topology fields; dashboards should use the authenticated admin status endpoint

## Testing

- [x] `cargo check --workspace` (root and e2e workspaces resolve at 1.9.0)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p sdx -p shardline-xet-adapter -p shardline-server`
- [x] CI gates previously green on the constituent PRs (#52, #54): checks, postgres, e2e, coverage, release-candidate-infrastructure

## Related issues and documentation

- Related: PR #52 (feat(server): add read-only administration API)
- Related: PR #54 (security(server): comprehensive security hardening)
- Administration API docs: `docs/ADMIN_READ_API.md`

## Reviewer checklist

- [x] Code follows project standards and crate-boundary constraints
- [ ] Tests added or updated and passing
- [x] Documentation updated where behavior or config changed
- [x] No undocumented breaking change
- [ ] Performance trade-offs documented where relevant
- [x] Security considerations addressed where relevant
