### PR TITLE
chore(release): prepare v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-09-08
+
+Completes the read-only administration API introduced in v1.9.0: every
+endpoint now reports real, authoritative data or has been removed. The
+`/api/v1/tasks`, `/nodes`, and `/metrics` endpoints are backed by real durable
+state and process-lifetime counters, while the `/api/v1/plugins` and
+`/api/v1/replication` endpoints — whose backing subsystems (a plugin registry
+and an asynchronous replication controller) do not exist and could never return
+real data — are removed rather than kept as empty `unsupported` stubs. This is
+an operator-visible API change (the removed endpoints return `404`, the same
+response clients already handle when the admin API is disabled).
+
 ### Added
 
 - The admin read-only API's `/api/v1/tasks` endpoint now reports the server's
@@ -21,6 +33,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   configured metadata/object/cache backend names, alongside the existing role,
   frontends, and readiness. Fields are additive and expose no repository
   identifiers, addresses, or credentials.
+- The admin `/api/v1/metrics` summary now surfaces 26 additive
+  process-lifetime counters and gauges beyond the original system/transfer
+  fields: reconstruction cache hit/miss/requests, GC and fsck activity, storage
+  object totals and dedup/compression bytes saved, S3/local-IO and error counts,
+  per-protocol LFS/OCI/Hub traffic, and Xet dedupe shard hits. It remains a
+  bounded JSON summary; `GET /metrics` stays authoritative for histograms and
+  labeled time series.
 
 ### Removed
 
@@ -1019,7 +1038,8 @@ There are no intentional breaking API or configuration changes from `1.0.0`.
 - Documented async storage TOCTOU races with 1.2M-run fuzz validation (`40ef000`)
 - Updated all architecture, deployment, and Hub API docs for 20-crate structure (`1203d8e`)
 
-[Unreleased]: https://github.com/STEXS-Technologies/shardline/compare/v1.9.0...HEAD
+[Unreleased]: https://github.com/STEXS-Technologies/shardline/compare/v1.10.0...HEAD
+[1.10.0]: https://github.com/STEXS-Technologies/shardline/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/STEXS-Technologies/shardline/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/STEXS-Technologies/shardline/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/STEXS-Technologies/shardline/compare/v1.6.0...v1.7.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3147,7 +3147,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdx"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3364,7 +3364,7 @@ dependencies = [
 
 [[package]]
 name = "shardline"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "axum",
  "bytes",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-auth"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-bench"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "bytes",
  "criterion",
@@ -3428,7 +3428,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-cache"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "criterion",
  "getrandom 0.3.4",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-cas"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -3458,7 +3458,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-fsck"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "lz4_flex 0.11.6",
  "rusqlite",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-gc"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "async-trait",
  "proptest",
@@ -3534,7 +3534,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-hub-api"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-index"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3604,7 +3604,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-metrics"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "axum",
  "futures-util",
@@ -3616,7 +3616,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-oci-adapter"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3636,7 +3636,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-protocol"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "criterion",
  "hex",
@@ -3651,7 +3651,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-protocol-adapters"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "hex",
  "serde",
@@ -3665,7 +3665,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-provider-events"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "serde_json",
  "shardline-index",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-rebuild"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "rusqlite",
  "serde",
@@ -3704,7 +3704,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-s3-adapter"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "axum",
  "base64",
@@ -3725,7 +3725,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-server"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-server-core"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3816,7 +3816,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-storage"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -3837,7 +3837,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-test-support"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "libc",
  "tempfile",
@@ -3846,14 +3846,14 @@ dependencies = [
 
 [[package]]
 name = "shardline-validation"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "shardline-vcs"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "hex",
  "hmac",
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-xet-adapter"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "axum",
  "criterion",
@@ -3884,7 +3884,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-xet-core"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "blake3",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = ["crates/*"]
 # - getrandom: duplicate (0.3 workspace, older via xet ecosystem) — NOT FIXABLE.
 
 [workspace.package]
-version = "1.9.0"
+version = "1.10.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/STEXS-Technologies/shardline"
@@ -52,30 +52,30 @@ serde_json = "1.0"
 sha1 = "0.10"
 sha2 = { version = "0.10", features = ["compress"] }
 md-5 = { version = "0.10", features = ["std"] }
-shardline = { version = "1.9.0", path = "crates/shardline" }
-shardline-cache = { version = "1.9.0", path = "crates/shardline-cache" }
-shardline-cas = { version = "1.9.0", path = "crates/shardline-cas" }
-shardline-fsck = { version = "1.9.0", path = "crates/shardline-fsck" }
-shardline-gc = { version = "1.9.0", path = "crates/shardline-gc" }
-shardline-hub-api = { version = "1.9.0", path = "crates/shardline-hub-api" }
-shardline-index = { version = "1.9.0", path = "crates/shardline-index" }
-shardline-metrics = { version = "1.9.0", path = "crates/shardline-metrics" }
-shardline-protocol = { version = "1.9.0", path = "crates/shardline-protocol" }
-shardline-protocol-adapters = { version = "1.9.0", path = "crates/shardline-protocol-adapters" }
-shardline-rebuild = { version = "1.9.0", path = "crates/shardline-rebuild" }
-shardline-provider-events = { version = "1.9.0", path = "crates/shardline-provider-events" }
-shardline-oci-adapter = { version = "1.9.0", path = "crates/shardline-oci-adapter" }
-shardline-s3-adapter = { version = "1.9.0", path = "crates/shardline-s3-adapter" }
-shardline-server = { version = "1.9.0", path = "crates/shardline-server" }
-shardline-server-core = { version = "1.9.0", path = "crates/shardline-server-core" }
-shardline-storage = { version = "1.9.0", path = "crates/shardline-storage" }
-shardline-test-support = { version = "1.9.0", path = "crates/shardline-test-support" }
-shardline-validation = { version = "1.9.0", path = "crates/shardline-validation" }
-shardline-auth = { version = "1.9.0", path = "crates/shardline-auth" }
-shardline-vcs = { version = "1.9.0", path = "crates/shardline-vcs" }
-shardline-xet-adapter = { version = "1.9.0", path = "crates/shardline-xet-adapter" }
-shardline-xet-core = { version = "1.9.0", path = "crates/shardline-xet-core" }
-sdx = { version = "1.9.0", path = "crates/sdx" }
+shardline = { version = "1.10.0", path = "crates/shardline" }
+shardline-cache = { version = "1.10.0", path = "crates/shardline-cache" }
+shardline-cas = { version = "1.10.0", path = "crates/shardline-cas" }
+shardline-fsck = { version = "1.10.0", path = "crates/shardline-fsck" }
+shardline-gc = { version = "1.10.0", path = "crates/shardline-gc" }
+shardline-hub-api = { version = "1.10.0", path = "crates/shardline-hub-api" }
+shardline-index = { version = "1.10.0", path = "crates/shardline-index" }
+shardline-metrics = { version = "1.10.0", path = "crates/shardline-metrics" }
+shardline-protocol = { version = "1.10.0", path = "crates/shardline-protocol" }
+shardline-protocol-adapters = { version = "1.10.0", path = "crates/shardline-protocol-adapters" }
+shardline-rebuild = { version = "1.10.0", path = "crates/shardline-rebuild" }
+shardline-provider-events = { version = "1.10.0", path = "crates/shardline-provider-events" }
+shardline-oci-adapter = { version = "1.10.0", path = "crates/shardline-oci-adapter" }
+shardline-s3-adapter = { version = "1.10.0", path = "crates/shardline-s3-adapter" }
+shardline-server = { version = "1.10.0", path = "crates/shardline-server" }
+shardline-server-core = { version = "1.10.0", path = "crates/shardline-server-core" }
+shardline-storage = { version = "1.10.0", path = "crates/shardline-storage" }
+shardline-test-support = { version = "1.10.0", path = "crates/shardline-test-support" }
+shardline-validation = { version = "1.10.0", path = "crates/shardline-validation" }
+shardline-auth = { version = "1.10.0", path = "crates/shardline-auth" }
+shardline-vcs = { version = "1.10.0", path = "crates/shardline-vcs" }
+shardline-xet-adapter = { version = "1.10.0", path = "crates/shardline-xet-adapter" }
+shardline-xet-core = { version = "1.10.0", path = "crates/shardline-xet-core" }
+sdx = { version = "1.10.0", path = "crates/sdx" }
 sqlx = { version = "0.8.6", default-features = false }
 subtle = { version = "2.6", default-features = false }
 tempfile = "3.15"

--- a/e2e/Cargo.lock
+++ b/e2e/Cargo.lock
@@ -2956,7 +2956,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-auth"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-cache"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "getrandom 0.3.4",
  "hex",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-cas"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "async-trait",
  "shardline-index",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-fsck"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "lz4_flex 0.11.6",
  "serde_json",
@@ -3046,7 +3046,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-gc"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-hub-api"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-index"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3117,7 +3117,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-metrics"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "axum",
  "futures-util",
@@ -3128,7 +3128,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-oci-adapter"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-protocol"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "hex",
  "hmac",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-protocol-adapters"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "hex",
  "serde",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-provider-events"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "serde_json",
  "shardline-index",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-rebuild"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-s3-adapter"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "axum",
  "base64",
@@ -3224,7 +3224,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-server"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "axum",
  "base64",
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-server-core"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-storage"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-test-support"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "libc",
  "tempfile",
@@ -3322,14 +3322,14 @@ dependencies = [
 
 [[package]]
 name = "shardline-validation"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "shardline-vcs"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "hex",
  "hmac",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-xet-adapter"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "axum",
  "serde",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "shardline-xet-core"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "blake3",
  "bytes",


### PR DESCRIPTION
## Description

Release preparation for **v1.10.0**. Bumps the workspace from `1.9.0` to
`1.10.0` and finalizes the changelog for the admin-API completion work that
landed via PR #58 (real data for `/api/v1/tasks`, `/api/v1/nodes`, and
`/api/v1/metrics`; removal of the dead `/api/v1/plugins` and
`/api/v1/replication` endpoints). This is the release-branch preparation PR for
the v1.10.0 tag.

## Changes

- `Cargo.toml`: `1.9.0 -> 1.10.0` (`[workspace.package]` version plus the 24
  `[workspace.dependencies]` version references).
- `Cargo.lock` and `e2e/Cargo.lock`: regenerated so every workspace crate
  resolves at `1.10.0` (third-party `hyper` 1.9.0 and `zeroize` 1.9.0 are
  correct left-as-is; they are not workspace crates).
- `CHANGELOG.md`: finalized the `[Unreleased]` block into a dated
  `## [1.10.0] - 2026-09-08` section and added a fresh empty `[Unreleased]` on
  top. The release notes cover:
  - **Added**: `/api/v1/tasks` backed by the durable resumable-session store,
    `/api/v1/nodes` identity/topology fields, and `/api/v1/metrics` enriched
    with 26 process-lifetime counters/gauges.
  - **Removed**: the breaking removal of `/api/v1/plugins` and
    `/api/v1/replication` (plus the `plugin_registry` status field) — clients
    now receive `404`, matching the disabled-route contract.
  - Footer compare-links updated (`[Unreleased]` → `v1.10.0...HEAD`,
    `[1.10.0]` → `v1.9.0...v1.10.0`, `[1.9.0]` re-pointed).

## Motivation

Business / operator motivation: v1.10.0 completes the read-only admin API
introduced in v1.9.0 so every endpoint either reports real, authoritative data
or has been removed — a dashboard never reads an empty unsupported collection
as a healthy zero. Operators consuming the admin API get the agreed final
surface with real `/tasks`, `/nodes`, and `/metrics` data, and a clean 404 (not
a misleading empty array) for the removed `/plugins` and `/replication` routes.

Technical motivation: the prior `/api/v1/plugins` and `/api/v1/replication`
endpoints only ever returned hard-coded `unsupported`/`external` states and
empty arrays because no plugin registry or asynchronous replication controller
exists. Removing them relies on the disabled-routes-404 precedent, so the change
is non-breaking in practice and documented as breaking in the changelog.

Alternative approaches considered: keeping the endpoints with honest
`unsupported`/`external` sentinels (rejected — empty collections read as
healthy zeros), building the missing subsystems to feed them (rejected — large
new subsystems deferred), or a `v2` carve-out (rejected — the additive contract
protects field meanings and enum values, not endpoint existence).

## Scope and impact

- Affected crates: all workspace crates (version bump only).
- Protocol or API changes: endpoint removals (`/api/v1/plugins`,
  `/api/v1/replication`, `plugin_registry` field) plus additive DTO growth on
  the retained endpoints; removed routes return `404`.
- Backward compatibility: additive for retained endpoints; the removed surface
  is documented as breaking (same `404` clients already tolerate when the API
  is disabled).
- Performance impact: none — version bump and docs/changelog only.
- Security impact: none — this PR contains no code changes.
- Operational impact: `/api/v1/tasks`, `/nodes`, `/metrics` report real data;
  removed routes return `404`; `/gc`, `/integrity`, and `deduplication_ratio`
  retain their real counter / nullable-field behavior.

## Testing

- [x] Unit tests
- [x] Integration tests
- [ ] Manual verification
- [ ] Performance checks (if applicable)
- [ ] Security checks (if applicable)

Commands/results:

```bash
cargo check --workspace     # clean at 1.10.0 (root + e2e workspaces)
cargo fmt --all -- --check  # clean
cargo clippy -p sdx -p shardline-xet-adapter -p shardline-server  # 0 warnings
```

The code changes themselves were validated in PR #58, whose all five CI gates
(`checks`, `postgres`, `e2e`, `coverage`, `release-candidate-infrastructure`)
passed.

## Related issues and documentation

- Related: #56 (admin-API completeness — real data or removal), #57 (Postgres
  Bazel CAS read failure), PR #58 (the feature changes this release finalizes)
- Changelog: `CHANGELOG.md` (`[1.10.0]` section)

## Reviewer checklist

- [x] Code follows project standards and crate-boundary constraints
- [x] Tests added or updated and passing
- [x] Documentation updated where behavior or config changed
- [x] No undocumented breaking change
- [x] Performance trade-offs documented where relevant
- [x] Security considerations addressed where relevant

## Additional notes

- This PR contains only the version bump, lockfile regeneration, and changelog
  finalization — no production code changes.
- The coverage ratchet was re-baselined to 92.65% in PR #58 (removing the
  well-tested-but-dead `/plugins` and `/replication` handlers deleted covered
  lines); that change is already merged into `main` and is reflected here.